### PR TITLE
fix: Deprecate Bot Kit Pro in documentations

### DIFF
--- a/docs/pages/get-started/examples.mdx
+++ b/docs/pages/get-started/examples.mdx
@@ -22,8 +22,9 @@ description: "SDKs, dev tools, and example apps to help you start building apps 
 
 [xmtp-node-js-tools](https://github.com/xmtp/xmtp-node-js-tools/tree/main/packages) is a repo of tools for building with XMTP, including:
 
-- Bot Kit Pro  
+- Bot Kit Pro (Deprecated)
   A framework for running bots on the XMTP network designed for complex workflows that require high reliability.
+  Note Bot Kit Pro is deprecated in favor of [MessageKit](https://message-kit.vercel.app/).
 - Bot examples  
   Provides examples of bots built using Bot Kit Pro.
 - Broadcast SDK  


### PR DESCRIPTION
As Bot Kit Pro is deprecated and https://github.com/xmtp/botkit in favour of [MessageKit](https://message-kit.vercel.app/)

