### PR TITLE
Move XMTP V3 concepts up to top level

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -291,42 +291,36 @@ export default defineConfig({
       collapsed: true,
       items: [
         {
-          text: "XMTP versions",
-          link: "/protocol/xmtp-versions",
+          text: "Account signatures",
+          link: "/protocol/signatures",
+        },
+        {
+          text: "Group chat",
+          link: "/protocol/v3/group-chat",
+        },
+        {
+          text: "Multi-wallet identity",
+          link: "/protocol/v3/identity",
+        },
+        {
+          text: "Message history",
+          link: "/protocol/v3/message-history",
+        },
+        {
+          text: "Smart wallet support",
+          link: "/protocol/v3/smart-wallet",
         },
         {
           text: "Portable inbox",
           link: "/protocol/portable-inbox",
         },
         {
-          text: "Account signatures",
-          link: "/protocol/signatures",
-        },
-        {
           text: "XIPs",
           link: "/protocol/xips",
         },
         {
-          text: "XMTP V3",
-          collapsed: true,
-          items: [
-            {
-              text: "Group chat",
-              link: "/protocol/v3/group-chat",
-            },
-            {
-              text: "Multi-wallet identity",
-              link: "/protocol/v3/identity",
-            },
-            {
-              text: "Message history",
-              link: "/protocol/v3/message-history",
-            },
-            {
-              text: "Smart wallet support",
-              link: "/protocol/v3/smart-wallet",
-            },
-          ],
+          text: "XMTP versions",
+          link: "/protocol/xmtp-versions",
         },
         {
           text: "XMTP V2",


### PR DESCRIPTION
The concepts in the XMTP V3 section are CURRENT functionality and do not need to be called out explicitly as V3. This is a first of a few adjustments to be made.