### PR TITLE
fix: code errors  in messaging component

### DIFF
--- a/docs/pages/dms/messages.mdx
+++ b/docs/pages/dms/messages.mdx
@@ -30,7 +30,7 @@ You might want to consider [optimistically sending messages](/perf-ux/optimistic
 const preparedTextMessage = await conversation.prepareMessage(messageText);
 //After preparing an optimistic message, use its `send` method to send it.
 try {
-  preparedMessage.send();
+  preparedTextMessage.send();
 } catch (e) {
   // handle error, enable canceling and retries (see below)
 }
@@ -70,9 +70,9 @@ export const SendMessage: React.FC<{ conversation: CachedConversation }> = ({
     async (e: React.FormEvent) => {
       e.preventDefault();
       if (peerAddress && isValidAddress(peerAddress) && message) {
-        setIsLoading(true);
+        setIsSending(true);
         await sendMessage(conversation, message);
-        setIsLoading(false);
+        setIsSending(false);
       }
     },
     [message, peerAddress, sendMessage],
@@ -275,7 +275,7 @@ const conversation = await xmtp.conversations.newConversation(
   '0x3F11b27F323b62B159D2642964fa27C46C841897'
 )
 
-for await (const page of conversation.messages(limit: 25)) {
+for await (const page of conversation.messages({limit: 25})) {
   for (const msg of page) {
     // Breaking from the outer loop will stop the client from requesting any further pages
     if (msg?.content() === 'gm') {


### PR DESCRIPTION
Fixes #52 

Change: `preparedMessage.send();` → `preparedTextMessage.send();`. In the original code, the variable `preparedMessage`, is used, which was not declared. Instead `preparedTextMessage` was declared. This will lead to a `ReferenceError: preparedMessage is not defined` when attempting to call the send() method. This fix eliminates the obvious error, allowing the prepared message to be sent correctly.
 
Change: `setIsLoading(true);` and `setIsLoading(false);` → `setIsSending(true);` and `setIsSending(false);` .The component declares the state `isSending` with the update function `setIsSending`, but inside `handleSendMessage`, `setIsLoading` is used, which is not declared. This leads to a `ReferenceError: setIsLoading is not defined` and disrupts the state management logic. This fix resolves the mismatch between the declared state and the updater function, preventing execution errors and ensuring correct state management.

Change: `for await (const page of conversation.messages(limit: 25))` → `for await (const page of conversation.messages({ limit: 25 }))`. The `messages` method expects an object with options, not just a numerical value. Passing the parameters as an object `({ limit: 25 })` ensures the method correctly interprets the arguments. In the original code, passing `limit: 25` as a separate argument is incorrect and will cause an error. This fix ensures the correct use of the `messages` API method, preventing execution errors and ensuring proper pagination functionality.

