### PR TITLE
docs: Corrected grammar errors and typos

### DIFF
--- a/docs/pages/consent/build-engagement.mdx
+++ b/docs/pages/consent/build-engagement.mdx
@@ -79,7 +79,7 @@ With these use cases for subscriptions, user consent, and broadcasts in mind, it
 - To learn more about how user consent works, see [Understand user consent preferences](/consent/user-consent).
 - To learn how to send broadcast messages, see [Broadcast messages](/consent/broadcast).
 
-Want to explore code in consent, subscribe, and broadcast uickstart repos? See [Quickstart repos for building audience engagement](/consent/consent-quickstarts)
+Want to explore code in consent, subscribe, and broadcast quickstart repos? See [Quickstart repos for building audience engagement](/consent/consent-quickstarts)
 
 Prefer to use a ready-made solution? Consider using a third-party service, such as:
 

--- a/docs/pages/dms/conversations.mdx
+++ b/docs/pages/dms/conversations.mdx
@@ -28,7 +28,7 @@ const areOnNetwork = await client.canMessage([
   "address1",
   "address2",
   "...",
-  "adress1000",
+  "address1000",
 ]);
 ```
 </div>

--- a/docs/pages/perf-ux/get-featured.md
+++ b/docs/pages/perf-ux/get-featured.md
@@ -9,7 +9,7 @@ Before launching, ensure your app meets the following criteria:
 ### Meet performance benchmarks
 
 - [ ] Implement a [Local-first cache](/perf-ux/local-first).
-- [ ] Cache conversation list `conversations.list()` to boost performance by 90%.
+- [ ] Cache conversation list `conversations.list ()` to boost performance by 90%.
 - [ ] Serialize securely stored `DecodedMessage` histories to reduce redundant downloads and decryptions.
 - [ ] Implement message [pagination](/dms/messages#list-messages-in-a-conversation-with-pagination).
 - [ ] Compress message content with a suitable compression algorithm.

--- a/docs/pages/protocol/signatures.mdx
+++ b/docs/pages/protocol/signatures.mdx
@@ -41,7 +41,7 @@ Sign the **XMTP : Authenticate to inbox** message with your wallet address to co
 
 You can add another wallet address to your inbox at any time. For example, you might have started using an app with one wallet address and now want to use the app with an additional wallet address.
 
-If you decide to add another wallet address to your inbox, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign a **Link address to inbox** message. for exasmple:
+If you decide to add another wallet address to your inbox, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign a **Link address to inbox** message. for example:
 
 ```text
 - Link address to inbox


### PR DESCRIPTION
While studying the documentation I found several grammatical errors and typos in the text and corrected them, please review the improvements.