### PR TITLE
fix: syntax error in JavaScript

### DIFF
--- a/docs/pages/content-types/transaction-ref.mdx
+++ b/docs/pages/content-types/transaction-ref.mdx
@@ -67,7 +67,7 @@ const transactionReference: TransactionReference = {
   /**
    * Optional namespace for the networkId
    */
-  namespace: "eip155";
+  namespace: "eip155",
   /**
    * The networkId for the transaction, in decimal or hexadecimal format
    */


### PR DESCRIPTION
Closes #60 

Fixed syntax error in JavaScript, and it needs to be fixed from 
namespace: 'eip155'; to namespace: 'eip155', because the semicolon (;) is not a valid separator for key-value pairs in objects. 
In JavaScript, objects require properties to be separated by commas, and using a semicolon will cause a syntax error, leading to an immediate failure when the code is interpreted or executed. Unlike a trailing comma, which modern interpreters can ignore, this mistake directly violates JavaScript’s object syntax rules. 

This is a critical error because, without correcting it, the program will not run correctly. 





