### PR TITLE
Add link to preview of latest docs

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -10,8 +10,8 @@ import "../styles.css";
   <CustomHomePage.TileGrid>
     <CustomHomePage.Tile
       href="/preview"
-      title="Preview latest docs"
-      description="Preview the latest XMTP docs and start building today."
+      title="Preview latest V3 docs"
+      description="Preview the latest XMTP V3 docs and start building today."
       icon="⚡️"
     />
     <CustomHomePage.Tile

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -12,7 +12,7 @@ import "../styles.css";
       href="/preview"
       title="Preview latest V3 docs"
       description="Preview the latest XMTP V3 docs and start building today."
-      icon="🚀"
+      icon="⚡️"
     />
     <CustomHomePage.Tile
       href="/get-started/intro"

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -12,7 +12,7 @@ import "../styles.css";
       href="/preview"
       title="Preview latest V3 docs"
       description="Preview the latest XMTP V3 docs and start building today."
-      icon="⚡️"
+      icon="🚀"
     />
     <CustomHomePage.Tile
       href="/get-started/intro"

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -9,6 +9,12 @@ import "../styles.css";
   </CustomHomePage.Subhead>
   <CustomHomePage.TileGrid>
     <CustomHomePage.Tile
+      href="/preview"
+      title="Preview latest docs"
+      description="Preview the latest XMTP docs and start building today."
+      icon="⚡️"
+    />
+    <CustomHomePage.Tile
       href="/get-started/intro"
       title="Introduction to XMTP"
       description="Get a quick intro to XMTP, including FAQ and how try an XMTP app"

--- a/docs/pages/preview.md
+++ b/docs/pages/preview.md
@@ -1,0 +1,9 @@
+# Preview the latest XMTP documentation
+
+We’re excited to share a [preview](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) of the latest XMTP documentation. Soon, these preview docs will replace the content on this site, becoming the new standard reference. 
+
+Until then, we strongly recommend using the [preview docs](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) to start building with XMTP today.
+
+The XMTP SDKs will continue to evolve as we add features, rename functions, and iterate based on community feedback.
+
+Onward builders! 🫡

--- a/docs/pages/preview.md
+++ b/docs/pages/preview.md
@@ -1,8 +1,8 @@
 # Preview the latest XMTP V3 documentation
 
-We’re excited to share a [preview](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) of the latest XMTP V3 documentation. Soon, these preview docs will replace the content on this site, becoming the new standard reference.
+We’re excited to share a [preview](https://docs-xmtp-org-git-v3-preview-ephemerahq.vercel.app/) of the latest XMTP V3 documentation. Soon, these preview docs will replace the content on this site, becoming the new standard reference.
 
-Until then, we strongly recommend using the [preview docs](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) to start building with XMTP V3 today.
+Until then, we strongly recommend using the [preview docs](https://docs-xmtp-org-git-v3-preview-ephemerahq.vercel.app/) to start building with XMTP V3 today.
 
 The XMTP V3 SDKs will continue to evolve as we add features, rename functions, and iterate based on community feedback.
 

--- a/docs/pages/preview.md
+++ b/docs/pages/preview.md
@@ -1,9 +1,9 @@
-# Preview the latest XMTP documentation
+# Preview the latest XMTP V3 documentation
 
-We’re excited to share a [preview](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) of the latest XMTP documentation. Soon, these preview docs will replace the content on this site, becoming the new standard reference. 
+We’re excited to share a [preview](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) of the latest XMTP V3 documentation. Soon, these preview docs will replace the content on this site, becoming the new standard reference.
 
-Until then, we strongly recommend using the [preview docs](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) to start building with XMTP today.
+Until then, we strongly recommend using the [preview docs](https://docs-xmtp-org-git-inbox-protocol-docs-ephemerahq.vercel.app/) to start building with XMTP V3 today.
 
-The XMTP SDKs will continue to evolve as we add features, rename functions, and iterate based on community feedback.
+The XMTP V3 SDKs will continue to evolve as we add features, rename functions, and iterate based on community feedback.
 
 Onward builders! 🫡

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -47,7 +47,7 @@ export default defineConfig({
   ],
   sidebar: [
     {
-      text: "⚡️Preview XMTP V3 docs⚡️",
+      text: "🚀 Preview XMTP V3 docs 🚀",
       link: "/preview",
       items: [], // Add this line
     },

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -47,7 +47,7 @@ export default defineConfig({
   ],
   sidebar: [
     {
-      text: "🚀 Preview XMTP V3 docs 🚀",
+      text: "⚡️ Preview XMTP V3 docs ⚡️",
       link: "/preview",
       items: [], // Add this line
     },

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -47,6 +47,11 @@ export default defineConfig({
   ],
   sidebar: [
     {
+      text: "⚡️Preview latest docs⚡️",
+      link: "/preview",
+      items: [], // Add this line
+    },
+    {
       text: "Overview",
       collapsed: true,
       items: [

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -47,7 +47,7 @@ export default defineConfig({
   ],
   sidebar: [
     {
-      text: "⚡️Preview latest docs⚡️",
+      text: "⚡️Preview XMTP V3 docs⚡️",
       link: "/preview",
       items: [], // Add this line
     },


### PR DESCRIPTION
- Adds a "Preview latest docs" link to top of left nav and to landing page
- "Preview latest docs" links to a [page that shares the link](https://docs-xmtp-org-git-preview-docs-link-ephemerahq.vercel.app/preview) to the preview docs, while also sharing a bit more context