### PR TITLE
Grammatical and typo corrections

### DIFF
--- a/docs/pages/dms/conversations.mdx
+++ b/docs/pages/dms/conversations.mdx
@@ -4,7 +4,7 @@ description: Learn how to start, list, and cache conversations with XMTP
 
 # Start, list, and cache conversations with XMTP
 
-Most of the time, when interacting with the network, you'll want to do it through conversations. Conversations are between two wallets addresses.
+Most of the time, when interacting with the network, you'll want to do it through conversations. Conversations are between two wallet addresses.
 
 ## Check if an address is on the network
 

--- a/docs/pages/dms/messages.mdx
+++ b/docs/pages/dms/messages.mdx
@@ -28,7 +28,7 @@ You might want to consider [optimistically sending messages](/perf-ux/optimistic
 ```tsx [TypeScript]
 // standard (string) message
 const preparedTextMessage = await conversation.prepareMessage(messageText);
-//After preparing an optimistic message, use its `send` method to send it.
+// After preparing an optimistic message, use its `send` method to send it.
 try {
   preparedTextMessage.send();
 } catch (e) {

--- a/docs/pages/dms/troubleshoot.md
+++ b/docs/pages/dms/troubleshoot.md
@@ -29,7 +29,7 @@ window.Buffer = window.Buffer ?? Buffer;
 - NuxtJS: `app.vue`
 
 ```tsx [TypeScript]
-//has to be on the first line of the file for it to work
+// It has to be on the first line of the file for it to work
 import "./polyfills";
 ```
 


### PR DESCRIPTION
Added typo corrections to documentation.

`docs-xmtp-org/blob/main/docs/pages/dms/conversations.mdx`

Typo in the description "Conversations are between two wallets addresses":
The phrase "Conversations are between two wallets addresses" contains an extra word "wallets".
The correct version is: "Conversations are between two wallet addresses."

Corrected.

`docs-xmtp-org/blob/main/docs/pages/dms/messages.mdx`

Typo in the section "standard (string) message" (missing space after the comment).

Corrected.

`docs-xmtp-org/blob/main/docs/pages/dms/troubleshoot.md`

The issue here is the missing capital letter at the beginning of the sentence, and it would also sound more natural with the addition of "It" at the start of the comment.

Corrected.

`docs-xmtp-org/blob/main/docs/pages/dms/troubleshoot.md`

The issue here is the missing capital letter at the beginning of the sentence, and it would also sound more natural with the addition of "It" at the start of the comment.

### Goal

Correct grammatical errors and improve readability of the documentation.