### PR TITLE
Prepare to put preview docs on main branch

### DIFF
--- a/docs/pages/doc-status.md
+++ b/docs/pages/doc-status.md
@@ -1,0 +1,11 @@
+# XMTP documentation status
+
+We’re excited to share documentation for the latest version of XMTP.
+
+We'll be continuously releasing new and updated documentation. To follow along, see this [tracking issue](https://github.com/xmtp/docs-xmtp-org/issues/74).
+
+Not seeing the specific documentation you need? [Open an issue](https://github.com/xmtp/docs-xmtp-org/issues/new/choose). We ❤️ doc requests.
+
+The XMTP SDKs will continue to evolve as we add features, rename functions, and iterate based on community feedback.
+
+Onward builders! 🫡

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -4,7 +4,7 @@ import "../styles.css";
 <CustomHomePage.Root>
   <CustomHomePage.Headline>Build with XMTP</CustomHomePage.Headline>
   <CustomHomePage.Subhead>
-    XMTP is an open, secure, and resilient messaging protocol—for the next phase of the internet
+    XMTP is a secure and decentralized protocol for building communication platforms for the next phase of the internet.
   </CustomHomePage.Subhead>
   <CustomHomePage.TileGrid>
     <CustomHomePage.Tile
@@ -16,7 +16,7 @@ import "../styles.css";
     <CustomHomePage.Tile
       href="/inboxes/get-started"
       title="Build chat inboxes"
-      description="Build standalone inbox apps with DMs and group chats built with MLS"
+      description="Build standalone inbox apps with 1:1 and group chats built with MLS"
       icon="📥"
     />
     <CustomHomePage.Tile

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   title: "Build with XMTP",
   description:
-    "XMTP is an open, secure, and resilient messaging protocol—for the next phase of the internet",
+    "XMTP is a secure and decentralized protocol for building communication platforms for the next phase of the internet.",
   logoUrl: {
     light: "/logomark-light-purple.png",
     dark: "/logomark-dark-purple.png",
@@ -43,8 +43,8 @@ export default defineConfig({
   ],
   sidebar: [
     {
-      text: "⚡️ Documentation preview ⚡️",
-      link: "", // Add this line,
+      text: "📋 Documentation status",
+      link: "/doc-status",
       items: [ ]
     },
     {


### PR DESCRIPTION
- Changed `doc-preview` page to `doc-status` page: [Preview here](https://docs-xmtp-org-git-prep-main-ephemerahq.vercel.app/doc-status)

  - The page provides a link to [this GitHub tracking issue](https://github.com/xmtp/docs-xmtp-org/issues/74) that people can follow to understand which docs are still to come.

  - The page also prompts people to open an issue if they need a specific doc.

- Once this PR is approved, I'll merge it to the `v3-preview` branch and then merge the `v3-preview` branch to `main`, which will publish these docs to docs.xmtp.org.

- I've created an `xmtp-legacy` docs branch here: https://docs-xmtp-org-git-xmtp-legacy-ephemerahq.vercel.app/ where the docs currently on docs.xmtp.org will still be referenceable. 
  - The site is clearly marked as legacy with multiple pointers to the latest docs on docs.xmtp.org. 
  - I'll ensure that these legacy docs are not indexed by search engines. 
  - I have Plausible running on this branch just to be sure the visitor count is very low to zero. 
  - Once V2 is deprecated, we can take down the doc branch. WDYT? Should we do it sooner?

# JHA CREATE REDIRECTS!!!
https://docs.google.com/spreadsheets/d/1HxoN6nSpISoBiFLOg4-MF7L-UFnbDkm5JfEYZSL9NeA/edit?usp=sharing