### PR TITLE
Typo Update broadcast.md

### DIFF
--- a/docs/pages/consent/broadcast.md
+++ b/docs/pages/consent/broadcast.md
@@ -89,7 +89,7 @@ If you prefer to handle rate-limiting manually, here are some tips:
 - Spread your requests over 5 minutes
 - Use multiple IPs to make requests
 - Implement error handling that can manage rate-limiting responses from the network, including adjusting send rates and retrying failed messages.
-- Bulk `canMessage` makes API calls in 50-address batches.
+- Bulk `canMessage` make API calls in 50-address batches.
 
 ## Broadcast best practices
 


### PR DESCRIPTION
**Fixes subject-verb agreement error in "Broadcast best practices" section**

In the "Broadcast best practices" section, the sentence:

**"Bulk `canMessage` makes API calls in 50-address batches."**

was identified as incorrect due to a subject-verb agreement issue. The phrase "Bulk `canMessage`" refers to multiple API calls, so the verb "makes" should be changed to "make" to maintain proper grammar.

The corrected sentence is:

**"Bulk `canMessage` make API calls in 50-address batches."**

This change ensures grammatical accuracy and improves readability.

