### PR TITLE
Update syncAll documentation and deleting local databases

### DIFF
--- a/docs/pages/inboxes/build-inbox.md
+++ b/docs/pages/inboxes/build-inbox.md
@@ -541,24 +541,26 @@ await client.conversations.sync();
 ```
 
 ```tsx [React Native]
-await alix.conversations.sync();
-
-// Does not refetch existing conversations
+await client.conversations.sync();
 ```
 
 ```kotlin [Kotlin]
-alix.conversations.sync()
+client.conversations.sync()
 ```
 
 ```swift [Swift]
-try await alix.conversations.sync()
+try await client.conversations.sync()
 ```
 
 :::
 
 ### List new messages
 
-Get new messages from the network for all existing group chats and DMs in the local database:
+Get all new messages and conversations from the network:
+
+:::tip[Note]
+Syncing does not refetch existing messages and conversations or messages for group chats you are no longer a part of.
+:::
 
 :::code-group
 
@@ -571,17 +573,15 @@ await client.conversations.syncAll();
 ```
 
 ```tsx [React Native]
-await alix.conversations.syncAllConversations();
-
-// Does not refetch existing messages or messages for inactive group chat conversations
+await client.conversations.syncAllConversations();
 ```
 
 ```kotlin [Kotlin]
-alix.conversations.syncAllConversations()
+client.conversations.syncAllConversations()
 ```
 
 ```swift [Swift]
-try await alix.conversations.syncAllConversations()
+try await client.conversations.syncAllConversations()
 ```
 
 :::

--- a/docs/pages/inboxes/build-inbox.md
+++ b/docs/pages/inboxes/build-inbox.md
@@ -359,6 +359,28 @@ let client = try await Client.build(
 
 :::
 
+### Log a client out
+When you log a user out of your app you can give the user the option to delete their local database or not.
+
+:::tip
+If you delete the users local database they will have to make a new installation the next time they log in and will loose all their messages.
+:::
+
+```tsx [React Native]
+  await client.deleteLocalDatabase()
+  await Client.dropClient(client.installationId)
+```
+
+```kotlin [Kotlin]
+  client.deleteLocalDatabase()
+```
+
+```swift [Swift]
+  try await client.deleteLocalDatabase()
+```
+
+
+
 ## Check if an address is reachable
 
 The first step to creating a conversation is to verify that participants’ addresses are reachable on XMTP. The `canMessage` method checks each address’ compatibility, returning a response indicating whether each address can receive messages.

--- a/docs/pages/inboxes/build-inbox.md
+++ b/docs/pages/inboxes/build-inbox.md
@@ -359,12 +359,15 @@ let client = try await Client.build(
 
 :::
 
-### Log a client out
-When you log a user out of your app you can give the user the option to delete their local database or not.
+### Log out a client
 
-:::tip
-If you delete the users local database they will have to make a new installation the next time they log in and will loose all their messages.
+When you log a user out of your app, you can give them the option to delete their local database.
+
+:::tip[Important]
+If the user chooses to delete their local database, they will have to create a new installation the next time they log in and will lose all of their messages.
 :::
+
+:::code-group
 
 ```tsx [React Native]
   await client.deleteLocalDatabase()
@@ -379,7 +382,7 @@ If you delete the users local database they will have to make a new installation
   try await client.deleteLocalDatabase()
 ```
 
-
+:::
 
 ## Check if an address is reachable
 
@@ -581,7 +584,7 @@ try await client.conversations.sync()
 Get all new messages and conversations from the network:
 
 :::tip[Note]
-Syncing does not refetch existing messages and conversations or messages for group chats you are no longer a part of.
+Syncing does not refetch existing messages and conversations. It also does not fetch messages for group chats you are no longer a part of.
 :::
 
 :::code-group


### PR DESCRIPTION
Update sync all to reflect the new changes to the sync all function

Also adds guidance for logging clients out and deleting the local database.