### PR TITLE
Provide more V2 context in upgrade doc

### DIFF
--- a/docs/pages/upgrade-to-v3.md
+++ b/docs/pages/upgrade-to-v3.md
@@ -25,7 +25,7 @@ To learn more, see [Build a chat inbox](/inboxes/build-inbox).
 ## Local databases mean no need to export/import topic data
 
 - In V2, we needed to manually create and manage a local database for performance. Additionally, when moving across different SDKs, you could export a topic and then import it into the other SDK to shorten the performance loop. This was particularly useful when handling push notifications in React Native apps to increase the speed of exporting and importing a conversation across SDKs.
-- In V3, a client automatically creates and manages a local database per installation so performance issues are no longer a problem. When moving across installations it is advised to use message history to easily move data between installations. In the case of React Native push notifications the database is accessible from both the native layer and react native.
+- In V3, a client automatically creates and manages a local database per installation, so performance issues are no longer an issue. When moving across installations, use message history to move data between installations. In the case of React Native push notifications, the database is accessible from both the native layer and React Native.
 
 ## Loading messages
 

--- a/docs/pages/upgrade-to-v3.md
+++ b/docs/pages/upgrade-to-v3.md
@@ -25,7 +25,7 @@ To learn more, see [Build a chat inbox](/inboxes/build-inbox).
 ## Local databases mean no need to export/import topic data
 
 - In V2, we needed to manually create and manage a local database for performance. Additionally, when moving across different SDKS to increase performance you could export a topic and then import the topic into the other SDK shortening the performance loop. This was particularly present when handling push notifications in RN applications allowing the speed of exporting and importing a conversation across sdks.
-- In V3, a client automatically creates and manages a local database. And all of the data (keys, welcomes, and conversations) the client needs to present messages to the user are either stored locally or automatically synchronized from the network. To learn more, see [XMTP MLS protocol specification](https://docs.xmtp.org/protocol/specs).
+- In V3, a client automatically creates and manages a local database per installation so performance issues are no longer a problem. When moving across installations it is advised to use message history to easily move data between installations. In the case of React Native push notifications the database is accessible from both the native layer and react native.
 
 ## Loading messages
 

--- a/docs/pages/upgrade-to-v3.md
+++ b/docs/pages/upgrade-to-v3.md
@@ -24,7 +24,7 @@ To learn more, see [Build a chat inbox](/inboxes/build-inbox).
 
 ## Local databases mean no need to export/import topic data
 
-- In V2, we needed to manually create and manage a local database. Additionally, the contact, invite, and conversation topic data required to present messages to the user were dependent on the export/import of topic data to and from the network.
+- In V2, we needed to manually create and manage a local database for performance. Additionally, when moving across different SDKS to increase performance you could export a topic and then import the topic into the other SDK shortening the performance loop. This was particularly present when handling push notifications in RN applications allowing the speed of exporting and importing a conversation across sdks.
 - In V3, a client automatically creates and manages a local database. And all of the data (keys, welcomes, and conversations) the client needs to present messages to the user are either stored locally or automatically synchronized from the network. To learn more, see [XMTP MLS protocol specification](https://docs.xmtp.org/protocol/specs).
 
 ## Loading messages

--- a/docs/pages/upgrade-to-v3.md
+++ b/docs/pages/upgrade-to-v3.md
@@ -24,7 +24,8 @@ To learn more, see [Build a chat inbox](/inboxes/build-inbox).
 
 ## Local databases mean no need to export/import topic data
 
-In V3, a client creates and manages a local database. For this reason, we no longer need to export or import topic data.
+- In V2, we needed to manually create and manage a local database. Additionally, the contact, invite, and conversation topic data required to present messages to the user were dependent on the export/import of topic data to and from the network.
+- In V3, a client automatically creates and manages a local database. And all of the data (keys, welcomes, and conversations) the client needs to present messages to the user are either stored locally or automatically synchronized from the network. To learn more, see [XMTP MLS protocol specification](https://docs.xmtp.org/protocol/specs).
 
 ## Loading messages
 

--- a/docs/pages/upgrade-to-v3.md
+++ b/docs/pages/upgrade-to-v3.md
@@ -24,7 +24,7 @@ To learn more, see [Build a chat inbox](/inboxes/build-inbox).
 
 ## Local databases mean no need to export/import topic data
 
-- In V2, we needed to manually create and manage a local database for performance. Additionally, when moving across different SDKS to increase performance you could export a topic and then import the topic into the other SDK shortening the performance loop. This was particularly present when handling push notifications in RN applications allowing the speed of exporting and importing a conversation across sdks.
+- In V2, we needed to manually create and manage a local database for performance. Additionally, when moving across different SDKs, you could export a topic and then import it into the other SDK to shorten the performance loop. This was particularly useful when handling push notifications in React Native apps to increase the speed of exporting and importing a conversation across SDKs.
 - In V3, a client automatically creates and manages a local database per installation so performance issues are no longer a problem. When moving across installations it is advised to use message history to easily move data between installations. In the case of React Native push notifications the database is accessible from both the native layer and react native.
 
 ## Loading messages


### PR DESCRIPTION
Re [Local databases mean no need to export/import topic data](https://docs.xmtp.org/upgrade-to-v3#local-databases-mean-no-need-to-exportimport-topic-data) in the Update to V3 doc - Michael suggested that we provide a bit more info about why we needed to import and export topic data, what topic data was, and why the fact that the client has a database implies that we don’t need to do this anymore.