### PR TITLE
Add links to xmtp.chat

### DIFF
--- a/docs/pages/inboxes/build-inbox.md
+++ b/docs/pages/inboxes/build-inbox.md
@@ -1,5 +1,13 @@
 # Build a chat inbox
 
+This guide walks you through the steps to build a chat inbox using the XMTP SDK. 
+
+:::tip[Learn to build with XMTP.chat]
+
+Learn to build a chat inbox with the help of [XMTP.chat](https://xmtp.chat/), an interactive developer tool and chat app.
+
+:::
+
 ## Create or build a client
 
 ### Create an account signer

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -27,6 +27,13 @@ import "../styles.css";
       icon="📥"
     />
     <CustomHomePage.Tile
+      href="https://xmtp.chat/"
+      title="Build with XMTP.chat"
+      description="Build an inbox app with the help of this interactive developer tool and chat app"
+      icon="🧑🏽‍💻"
+      isExternal={true}
+    />
+    <CustomHomePage.Tile
       href="https://messagekit.ephemerahq.com/"
       title="Build chat agents"
       description="Use MessageKit to build agents that send messages in XMTP apps"

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -24,6 +24,7 @@ export default defineConfig({
   },
   iconUrl: "/x-mark-blue.png",
   topNav: [
+    { text: "XMTP.chat", link: "https://xmtp.chat/" },
     { text: "Dev support", link: "https://github.com/xmtp" },
     { text: "XMTP.org", link: "https://xmtp.org/" },
   ],


### PR DESCRIPTION
- Added to [top nav and to home page tiles](https://docs-xmtp-org-git-xmtp-chat-ephemerahq.vercel.app/)
- Added to top of [Build a chat inbox](https://docs-xmtp-org-git-xmtp-chat-ephemerahq.vercel.app/inboxes/build-inbox)