### PR TITLE
fix: typo in documentation files

### DIFF
--- a/llms/llms-full.txt
+++ b/llms/llms-full.txt
@@ -2471,7 +2471,7 @@ func sendMessageWithOptimisticUI(conversation: Conversation, messageText: String
 ### Key UX considerations for optimistically sent messages
 
 - After optimistically sending a message, show the user an indicator that the message is still being processed. After successfully sending the message, show the user a success indicator.
-  - An optimistically sent message initially has an `unpublished` status. Once published to the network, it has a `published` status. You can use this status to determine which indicator to dipslay in the UI.
+  - An optimistically sent message initially has an `unpublished` status. Once published to the network, it has a `published` status. You can use this status to determine which indicator to display in the UI.
 - If an optimistically sent message fails to send it will have a `failed` status. In this case, be sure to give the user an option to retry sending the message or cancel sending. Use a try/catch block to intercept errors and allow the user to retry or cancel.
 
 ## Handle unsupported content types


### PR DESCRIPTION
Corrected "dipslay" → "display"