### PR TITLE
Ability to sync a sync group independent of syncAll

### DIFF
--- a/docs/pages/inboxes/history-sync.mdx
+++ b/docs/pages/inboxes/history-sync.mdx
@@ -54,6 +54,8 @@ History syncs are accomplished using these components:
 
 A sync group is a special [Messaging Layer Security](/protocol/security) group that includes all of the user’s devices. The sync group is used to send serialized sync messages across the user's devices. The sync group is filtered out of most queries by default so they don’t appear in the user’s inbox.
 
+You can sync a device sync group independent of the history sync process. To learn more, see [Sync a sync group](/inboxes/sync-and-syncall#sync-a-sync-group).
+
 ### Sync worker
 
 A sync worker is a spawned background worker that listens for sync events, and processes them accordingly. This worker:
@@ -76,7 +78,7 @@ Once [this issue](https://github.com/xmtp/libxmtp/issues/1309) is resolved, conv
 
 ### A user logged into a new app installation and sees their conversations, but no messages. What's going on?
 
-Ensure that you've initiated a call to [sync messages](#sync-messages) and that the pre-existing app installation is online to receive the sync request, process and encrypt the payload, upload it to the history server, and send a sync reply message to the new app installation.
+Ensure that you've initiated a call to [sync messages](#sync-all-new-conversations-messages-and-updates) and that the pre-existing app installation is online to receive the sync request, process and encrypt the payload, upload it to the history server, and send a sync reply message to the new app installation.
 
 ### I called a sync method (messages, consent state, or conversations), but nothing is happening. What's going on?
 

--- a/docs/pages/inboxes/sync-and-syncall.mdx
+++ b/docs/pages/inboxes/sync-and-syncall.mdx
@@ -1,7 +1,7 @@
-# Sync conversations and messages
+# Sync conversations, messages, and sync groups
 
 :::tip[Note]
-Syncing does not refetch existing conversations and messages. It also does not fetch messages for group chats you are no longer a part of.
+Syncing can't refetch existing conversations, messages, or sync group updates. It also can't fetch messages for group chats a user is no longer a member of.
 :::
 
 ## 🎥 walkthrough: Syncing
@@ -68,7 +68,7 @@ try await client.conversations.sync()
 
 ## Sync all new conversations, messages, and updates
 
-Sync all new group chat and DM conversations, messages, and installation-related updates (consent states, HMAC keys, etc.) from the network. We recommend that you run this sync in the background and call it more frequently than not.
+Sync all new group chat and DM conversations, messages, and installation-related sync group updates (consent states, HMAC keys, etc.) from the network. We recommend that you run this sync in the background and call it more frequently than not.
 
 :::code-group
 
@@ -90,6 +90,34 @@ client.conversations.syncAllConversations()
 
 ```swift [Swift]
 try await client.conversations.syncAllConversations()
+```
+
+:::
+
+## Sync a sync group
+
+A [sync group](/inboxes/history-sync#sync-group) is a special Messaging Layer Security group that includes all of a user's devices. Its primary role is to deliver installation-related updates (consent states, HMAC keys, etc.) across devices. Use this dedicated operation to update the sync group state without needing to call the full `syncAll` process.
+
+:::code-group
+
+```js [Browser]
+await client.syncGroup.sync();
+```
+
+```js [Node]
+await client.syncGroup.sync();
+```
+
+```tsx [React Native]
+await client.syncGroup.sync();
+```
+
+```kotlin [Kotlin]
+client.syncGroup.sync()
+```
+
+```swift [Swift]
+try await client.syncGroup.sync()
 ```
 
 :::


### PR DESCRIPTION
Adds documentation to surface the functionality enabled by the work in https://github.com/xmtp/libxmtp/pull/1857 and https://github.com/xmtp/libxmtp/pull/1849