### PR TITLE
Add Browser SDK and Node SDK code samples using SDK test files as reference

### DIFF
--- a/docs/pages/inboxes/list-and-stream.mdx
+++ b/docs/pages/inboxes/list-and-stream.mdx
@@ -83,6 +83,20 @@ Listens to the network for new group chats and DMs. Whenever a new conversation 
 
 :::code-group
 
+```js [Browser]
+const stream = await client.conversations.stream();
+
+try {
+  for await (const conversation of stream) {
+    // Received a conversation
+    console.log("New conversation:", conversation);
+  }
+} catch (error) {
+  // Log any stream errors
+  console.error(error);
+}
+```
+
 ```js [Node]
 const stream = await client.conversations.stream();
 // to stream only groups, use `client.conversations.streamGroups()`
@@ -129,6 +143,20 @@ The stream is infinite. Therefore, any looping construct used with the stream wo
 :::
 
 :::code-group
+
+```js [Browser]
+const stream = await client.conversations.streamAllMessages();
+
+try {
+  for await (const message of stream) {
+    // Received a message
+    console.log("New message:", message);
+  }
+} catch (error) {
+  // Log any stream errors
+  console.error(error);
+}
+```
 
 ```js [Node]
 // stream all messages from all conversations

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -37,13 +37,11 @@ This function is delicate and should be used with caution. Adding an identity to
 :::code-group
 
 ```tsx [Browser]
-// where identityToAdd is a signer for the identity to add
-await client.unsafe_addAccount(identityToAdd, true)
+await client.unsafe_addAccount(signer, true)
 ```
 
 ```tsx [Node]
-// where identityToAdd is a signer for the identity to add
-await client.unsafe_addAccount(identityToAdd, true)
+await client.unsafe_addAccount(signer, true)
 ```
 
 ```jsx [React Native]
@@ -117,11 +115,11 @@ When the user revokes all other installations, the action removes their identity
 :::code-group
 
 ```tsx [Browser]
-await client.revokeAllOtherInstallations
+await client.revokeAllOtherInstallations()
 ```
 
 ```tsx [Node]
-await client.revokeAllOtherInstallations
+await client.revokeAllOtherInstallations()
 ```
 
 ```jsx [React Native]

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -36,6 +36,14 @@ This function is delicate and should be used with caution. Adding an identity to
 
 :::code-group
 
+```tsx [Browser]
+await client.unsafe_addAccount(identityToAdd)
+```
+
+```tsx [Node]
+await client.unsafe_addAccount(identityToAdd)
+```
+
 ```jsx [React Native]
 await client.addAccount(identityToAdd)
 ```
@@ -57,6 +65,14 @@ try await client.addAccount(newAccount: identityToAdd)
 :::
 
 :::code-group
+
+```tsx [Browser]
+await client.removeAccount(recoveryIdentity, identityToRemove)
+```
+
+```tsx [Node]
+await client.removeAccount(recoveryIdentity, identityToRemove)
+```
 
 ```jsx [React Native]
 await client.removeAccount(recoveryIdentity, identityToRemove)
@@ -98,6 +114,14 @@ When the user revokes all other installations, the action removes their identity
 
 :::code-group
 
+```tsx [Browser]
+await client.revokeAllOtherInstallations(recoveryIdentity)
+```
+
+```tsx [Node]
+await client.revokeAllOtherInstallations(recoveryIdentity)
+```
+
 ```jsx [React Native]
 await client.revokeAllOtherInstallations(recoveryIdentity)
 ```
@@ -118,6 +142,14 @@ Find an `inboxId` for an identity:
 
 :::code-group
 
+```tsx [Browser]
+const inboxState = await client.preferences.inboxState()
+```
+
+```tsx [Node]
+const inboxState = await client.preferences.inboxState()
+```
+
 ```jsx [React Native]
 const inboxId = await client.inboxIdFromIdentity(identity)
 ```
@@ -137,6 +169,16 @@ View the state of any inbox to see the identities, installations, and other info
 **Sample request**
 
 :::code-group
+
+```tsx [Browser]
+const state = await client.preferences.inboxState(true)
+const states = await client.preferences.inboxStateFromInboxIds(true, [inboxId, inboxId])
+```
+
+```tsx [Node]
+const state = await client.preferences.inboxState(true)
+const states = await client.preferences.inboxStateFromInboxIds(true, [inboxId, inboxId])
+```
 
 ```jsx [React Native]
 const state = await client.inboxState(true)

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -37,11 +37,13 @@ This function is delicate and should be used with caution. Adding an identity to
 :::code-group
 
 ```tsx [Browser]
-await client.unsafe_addAccount(identityToAdd)
+// where identityToAdd is a signer for the identity to add
+await client.unsafe_addAccount(identityToAdd, true)
 ```
 
 ```tsx [Node]
-await client.unsafe_addAccount(identityToAdd)
+// where identityToAdd is a signer for the identity to add
+await client.unsafe_addAccount(identityToAdd, true)
 ```
 
 ```jsx [React Native]
@@ -67,11 +69,11 @@ try await client.addAccount(newAccount: identityToAdd)
 :::code-group
 
 ```tsx [Browser]
-await client.removeAccount(recoveryIdentity, identityToRemove)
+await client.removeAccount(identifier)
 ```
 
 ```tsx [Node]
-await client.removeAccount(recoveryIdentity, identityToRemove)
+await client.removeAccount(identifier)
 ```
 
 ```jsx [React Native]
@@ -115,11 +117,11 @@ When the user revokes all other installations, the action removes their identity
 :::code-group
 
 ```tsx [Browser]
-await client.revokeAllOtherInstallations(recoveryIdentity)
+await client.revokeAllOtherInstallations
 ```
 
 ```tsx [Node]
-await client.revokeAllOtherInstallations(recoveryIdentity)
+await client.revokeAllOtherInstallations
 ```
 
 ```jsx [React Native]
@@ -171,13 +173,13 @@ View the state of any inbox to see the identities, installations, and other info
 :::code-group
 
 ```tsx [Browser]
-const state = await client.preferences.inboxState(true)
-const states = await client.preferences.inboxStateFromInboxIds(true, [inboxId, inboxId])
+// the second argument is optional and refreshes the state from the network.
+const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
 ```
 
 ```tsx [Node]
-const state = await client.preferences.inboxState(true)
-const states = await client.preferences.inboxStateFromInboxIds(true, [inboxId, inboxId])
+// the second argument is optional and refreshes the state from the network.
+const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
 ```
 
 ```jsx [React Native]

--- a/docs/pages/inboxes/send-messages.md
+++ b/docs/pages/inboxes/send-messages.md
@@ -370,8 +370,8 @@ await client.conversations.newDm(
   inboxId,
   {
     messageDisappearingSettings: {
-      fromNs: 1738620126404999936,
-      inNs: 1800000000000000
+      fromNs: 1738620126404999936n,
+      inNs: 1800000000000000n
     }
   }
 )
@@ -381,8 +381,8 @@ await client.conversations.newGroup(
   [inboxId],
   { 
     messageDisappearingSettings: {
-      fromNs: 1738620126404999936,
-      inNs: 1800000000000000
+      fromNs: 1738620126404999936n,
+      inNs: 1800000000000000n
     }
   }
 )
@@ -494,7 +494,7 @@ await conversation.removeMessageDisappearingSettings()
 
 ```tsx [Node]
 // Update disappearing message settings
-await conversation.updateMessageDisappearingSettings(1738620126404999936n, 1800000000000000n)
+await conversation.updateMessageDisappearingSettings(1738620126404999936, 1800000000000000)
 
 // Clear disappearing message settings
 await conversation.removeMessageDisappearingSettings()

--- a/docs/pages/inboxes/send-messages.md
+++ b/docs/pages/inboxes/send-messages.md
@@ -366,12 +366,12 @@ For example:
 
 ```js [Browser]
 // DM
-await client.conversations.newConversation(
+await client.conversations.newDm(
   inboxId,
   {
-    disappearingMessageSettings: {
-      disappearStartingAtNs: 1738620126404999936,
-      retentionDurationInNs: 1800000000000000
+    messageDisappearingSettings: {
+      fromNs: 1738620126404999936,
+      inNs: 1800000000000000
     }
   }
 )
@@ -380,9 +380,9 @@ await client.conversations.newConversation(
 await client.conversations.newGroup(
   [inboxId],
   { 
-    disappearingMessageSettings: {
-      disappearStartingAtNs: 1738620126404999936,
-      retentionDurationInNs: 1800000000000000
+    messageDisappearingSettings: {
+      fromNs: 1738620126404999936,
+      inNs: 1800000000000000
     }
   }
 )
@@ -390,12 +390,12 @@ await client.conversations.newGroup(
 
 ```js [Node]
 // DM
-await client.conversations.newConversation(
+await client.conversations.newDm(
   inboxId,
   {
-    disappearingMessageSettings: {
-      disappearStartingAtNs: 1738620126404999936,
-      retentionDurationInNs: 1800000000000000
+    messageDisappearingSettings: {
+      fromNs: 1738620126404999936,
+      inNs: 1800000000000000
     }
   }
 )
@@ -404,9 +404,9 @@ await client.conversations.newConversation(
 await client.conversations.newGroup(
   [inboxId],
   { 
-    disappearingMessageSettings: {
-      disappearStartingAtNs: 1738620126404999936,
-      retentionDurationInNs: 1800000000000000
+    messageDisappearingSettings: {
+      fromNs: 1738620126404999936,
+      inNs: 1800000000000000
     }
   }
 )
@@ -486,24 +486,18 @@ For example:
 
 ```tsx [Browser]
 // Update disappearing message settings
-await conversation.updateDisappearingMessageSettings({
-  disappearStartingAtNs: 1738620126404999936,
-  retentionDurationInNs: 1800000000000000
-})
+await conversation.updateMessageDisappearingSettings(1738620126404999936n, 1800000000000000n)
 
 // Clear disappearing message settings
-await conversation.clearDisappearingMessageSettings()
+await conversation.removeMessageDisappearingSettings()
 ```
 
 ```tsx [Node]
 // Update disappearing message settings
-await conversation.updateDisappearingMessageSettings({
-  disappearStartingAtNs: 1738620126404999936,
-  retentionDurationInNs: 1800000000000000
-})
+await conversation.updateMessageDisappearingSettings(1738620126404999936n, 1800000000000000n)
 
 // Clear disappearing message settings
-await conversation.clearDisappearingMessageSettings()
+await conversation.removeMessageDisappearingSettings()
 ```
 
 ```tsx [React Native]
@@ -531,17 +525,16 @@ For example:
 
 ```tsx [Browser]
 // Get the disappearing message settings
-const settings = conversation.disappearingMessageSettings
+const settings = await conversation.messageDisappearingSettings()
 
 // Check if disappearing messages are enabled
-const isEnabled = conversation.isDisappearingMessagesEnabled()
+const isEnabled = await conversation.isDisappearingMessagesEnabled()
 ```
 
 ```tsx [Node]
 // Get the disappearing message settings
-const settings = conversation.disappearingMessageSettings
+const settings = conversation.messageDisappearingSettings()
 
-// Check if disappearing messages are enabled
 const isEnabled = conversation.isDisappearingMessagesEnabled()
 ```
 

--- a/docs/pages/inboxes/send-messages.md
+++ b/docs/pages/inboxes/send-messages.md
@@ -4,6 +4,22 @@ Once you have the group chat or DM conversation, you can send messages in the co
 
 :::code-group
 
+```tsx [Browser]
+// For a DM conversation
+await dm.send("Hello world");
+
+// OR for a group chat
+await group.send("Hello everyone");
+```
+
+```tsx [Node]
+// For a DM conversation
+await dm.send("Hello world");
+
+// OR for a group chat
+await group.send("Hello everyone");
+```
+
 ```tsx [React Native]
 // For a DM conversation
 const dm = await client.conversations.findOrCreateDm(recipientInboxId);
@@ -348,6 +364,54 @@ For example:
 
 :::code-group
 
+```js [Browser]
+// DM
+await client.conversations.newConversation(
+  inboxId,
+  {
+    disappearingMessageSettings: {
+      disappearStartingAtNs: 1738620126404999936,
+      retentionDurationInNs: 1800000000000000
+    }
+  }
+)
+
+// Group
+await client.conversations.newGroup(
+  [inboxId],
+  { 
+    disappearingMessageSettings: {
+      disappearStartingAtNs: 1738620126404999936,
+      retentionDurationInNs: 1800000000000000
+    }
+  }
+)
+```
+
+```js [Node]
+// DM
+await client.conversations.newConversation(
+  inboxId,
+  {
+    disappearingMessageSettings: {
+      disappearStartingAtNs: 1738620126404999936,
+      retentionDurationInNs: 1800000000000000
+    }
+  }
+)
+
+// Group
+await client.conversations.newGroup(
+  [inboxId],
+  { 
+    disappearingMessageSettings: {
+      disappearStartingAtNs: 1738620126404999936,
+      retentionDurationInNs: 1800000000000000
+    }
+  }
+)
+```
+
 ```tsx [React Native]
 // DM
 await client.conversations.newConversation(
@@ -420,6 +484,28 @@ For example:
 
 :::code-group
 
+```tsx [Browser]
+// Update disappearing message settings
+await conversation.updateDisappearingMessageSettings({
+  disappearStartingAtNs: 1738620126404999936,
+  retentionDurationInNs: 1800000000000000
+})
+
+// Clear disappearing message settings
+await conversation.clearDisappearingMessageSettings()
+```
+
+```tsx [Node]
+// Update disappearing message settings
+await conversation.updateDisappearingMessageSettings({
+  disappearStartingAtNs: 1738620126404999936,
+  retentionDurationInNs: 1800000000000000
+})
+
+// Clear disappearing message settings
+await conversation.clearDisappearingMessageSettings()
+```
+
 ```tsx [React Native]
 await conversation.updateDisappearingMessageSettings(updatedSettings)
 await conversation.clearDisappearingMessageSettings()
@@ -442,6 +528,22 @@ try await conversation.clearDisappearingMessageSettings()
 For example:
 
 :::code-group
+
+```tsx [Browser]
+// Get the disappearing message settings
+const settings = conversation.disappearingMessageSettings
+
+// Check if disappearing messages are enabled
+const isEnabled = conversation.isDisappearingMessagesEnabled()
+```
+
+```tsx [Node]
+// Get the disappearing message settings
+const settings = conversation.disappearingMessageSettings
+
+// Check if disappearing messages are enabled
+const isEnabled = conversation.isDisappearingMessagesEnabled()
+```
 
 ```tsx [React Native]
 conversation.disappearingMessageSettings

--- a/docs/pages/inboxes/user-consent/support-user-consent.md
+++ b/docs/pages/inboxes/user-consent/support-user-consent.md
@@ -12,6 +12,16 @@ Consent syncing is backed by XMTP's history system. Syncing works only if a [his
 
 :::code-group
 
+```tsx [Browser]
+// Sync all conversations to get the latest consent records
+await client.conversations.syncAllConversations()
+```
+
+```tsx [Node]
+// Sync all conversations to get the latest consent records
+await client.conversations.syncAllConversations()
+```
+
 ```tsx [React Native]
 await client.conversations.syncAllConversations()
 ```
@@ -145,6 +155,36 @@ Consent syncing is backed by XMTP's history system. Syncing works only if a [his
 :::
 
 :::code-group
+
+```tsx [Browser]
+// Stream consent records in real-time
+const stream = await client.preferences.streamConsent()
+
+try {
+  for await (const updates of stream) {
+    // Received consent updates
+    console.log("Consent updates:", updates)
+  }
+} catch (error) {
+  // Log any stream errors
+  console.error(error)
+}
+```
+
+```tsx [Node]
+// Stream consent records in real-time
+const stream = client.preferences.streamConsent()
+
+try {
+  for await (const updates of stream) {
+    // Received consent updates
+    console.log("Consent updates:", updates)
+  }
+} catch (error) {
+  // Log any stream errors
+  console.error(error)
+}
+```
 
 ```tsx [React Native]
 await client.preferences.streamConsent()
@@ -288,6 +328,22 @@ let inboxConsentState = try await client.preferences.inboxIdState(inboxId: inbox
 ## See who created and added you to a group
 
 Get the inbox ID of the individual who added you to a group or created the group to check the consent state for it:
+
+```tsx [Browser]
+// Get the inbox ID of the person who added you to the group
+const addedByInboxId = group.addedByInboxId
+
+// Get the inbox ID of the person who created the group
+const creatorInboxId = await group.creatorInboxId()
+```
+
+```tsx [Node]
+// Get the inbox ID of the person who added you to the group
+const addedByInboxId = group.addedByInboxId
+
+// Get the inbox ID of the person who created the group
+const creatorInboxId = await group.creatorInboxId()
+```
 
 ```tsx [React Native]
 group.addedByInboxId

--- a/docs/pages/inboxes/user-consent/support-user-consent.md
+++ b/docs/pages/inboxes/user-consent/support-user-consent.md
@@ -14,12 +14,12 @@ Consent syncing is backed by XMTP's history system. Syncing works only if a [his
 
 ```tsx [Browser]
 // Sync all conversations to get the latest consent records
-await client.conversations.syncAllConversations()
+await client.conversations.syncAll()
 ```
 
 ```tsx [Node]
 // Sync all conversations to get the latest consent records
-await client.conversations.syncAllConversations()
+await client.conversations.syncAll()
 ```
 
 ```tsx [React Native]

--- a/docs/pages/inboxes/user-consent/support-user-consent.md
+++ b/docs/pages/inboxes/user-consent/support-user-consent.md
@@ -329,22 +329,6 @@ let inboxConsentState = try await client.preferences.inboxIdState(inboxId: inbox
 
 Get the inbox ID of the individual who added you to a group or created the group to check the consent state for it:
 
-```tsx [Browser]
-// Get the inbox ID of the person who added you to the group
-const addedByInboxId = group.addedByInboxId
-
-// Get the inbox ID of the person who created the group
-const creatorInboxId = await group.creatorInboxId()
-```
-
-```tsx [Node]
-// Get the inbox ID of the person who added you to the group
-const addedByInboxId = group.addedByInboxId
-
-// Get the inbox ID of the person who created the group
-const creatorInboxId = await group.creatorInboxId()
-```
-
 ```tsx [React Native]
 group.addedByInboxId
 await group.creatorInboxId()


### PR DESCRIPTION
An experiment based on code sample work we've done for mobile - using test files to help generate code samples for the docs. Worked well for mobile.

- Added Browser code samples using the test files here: https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk/test

- Added Node code samples using the test files here: https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk/test