### PR TITLE
Add client create flowchart

### DIFF
--- a/docs/pages/inboxes/create-a-client.mdx
+++ b/docs/pages/inboxes/create-a-client.mdx
@@ -32,6 +32,10 @@ When you call `Client.create()`, the following steps happen under the hood:
       - If the `dbEncryptionKey` doesn't match, it creates a new local database and encrypts it with the provided key.
 4. Returns the XMTP client, ready to send and receive messages.
 
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/client-create.png" width="400px" />
+</div>
+
 ### Keep the database encryption key safe
 
 The `dbEncryptionKey` is critical to the stability and continuity of an XMTP client. It encrypts the local SQLite database created when you call `Client.create()`, and must be provided every time you create or build a client. 


### PR DESCRIPTION
### Add flowchart to client creation documentation to illustrate the process
Adds a visual diagram (`client-create.png`) to the client creation documentation in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/192/files#diff-0c5c0388326ee61df82030861ce3c5d225196038f620ceca1a2553916df3a2b8) between the numbered setup instructions and database encryption key section, with the image width set to 400px.

#### 📍Where to Start
Start with the documentation changes in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/192/files#diff-0c5c0388326ee61df82030861ce3c5d225196038f620ceca1a2553916df3a2b8) where the flowchart image has been added.

----

_[Macroscope](https://app.macroscope.com) summarized 4396f75._