### PR TITLE
Add list of updatable group chat metadata

### DIFF
--- a/docs/pages/inboxes/group-metadata.md
+++ b/docs/pages/inboxes/group-metadata.md
@@ -2,6 +2,15 @@
 
 Group chats can have metadata, like names, descriptions, and images. Metadata can help users more easily identify their group chats. You can set group chat metadata when [creating a group chat](/inboxes/create-conversations/#create-a-new-group-chat), and get and update metadata using these methods.
 
+## Updatable group chat metadata
+
+The following group chat metadata can be updated:
+
+- `group_name`: The name of the group chat
+- `description`: A description of the group chat
+- `image_url`: A URL pointing to an image for the group chat
+- `disappearing_message_settings`: Settings for disappearing messages in the group chat. To learn more about disappearing messages, see [Support disappearing messages](/inboxes/send-messages#support-disappearing-messages)
+
 ## Get a group chat name
 
 :::code-group
@@ -136,7 +145,7 @@ try group.imageUrl()
 
 :::code-group
 
-```js [Node]
+```js [Browser]
 await group.updateImageUrl("newurl.com");
 ```
 


### PR DESCRIPTION
### Document updatable metadata fields for group chats in the group metadata documentation
Updates [group-metadata.md](https://github.com/xmtp/docs-xmtp-org/pull/199/files#diff-0389d468baa87b44767e65f7b4fd04579e612d3185a095e6dda3d657ae36ddc8) to add a new section listing the updatable group chat metadata fields (`group_name`, `description`, `image_url`, `disappearing_message_settings`) and fixes a code example label from `[Node]` to `[Browser]`.

#### 📍Where to Start
Start with the new "Updatable group chat metadata" section in [group-metadata.md](https://github.com/xmtp/docs-xmtp-org/pull/199/files#diff-0389d468baa87b44767e65f7b4fd04579e612d3185a095e6dda3d657ae36ddc8).

----

_[Macroscope](https://app.macroscope.com) summarized b6e3d0f._