### PR TITLE
Update heading

### DIFF
--- a/docs/pages/inboxes/sync-and-syncall.mdx
+++ b/docs/pages/inboxes/sync-and-syncall.mdx
@@ -66,7 +66,7 @@ try await client.conversations.sync()
 
 :::
 
-## Sync all new welcomes, conversations, messages, and updates
+## Sync all new welcomes, conversations, messages, and preferences
 
 Sync all new welcomes, group chat and DM conversations, messages, and [preference updates](/inboxes/sync-preferences) from the network.
 


### PR DESCRIPTION
### Update heading text in sync documentation to replace 'updates' with 'preferences' in [sync-and-syncall.mdx](https://github.com/xmtp/docs-xmtp-org/pull/216/files#diff-7bee2f127ade739679f1f0e0510c278922c36d0a1f9951ba6cdb554347f584ab)
Changes the heading and description text in the sync documentation from 'Sync all new welcomes, conversations, messages, and updates' to 'Sync all new welcomes, conversations, messages, and preferences' in [sync-and-syncall.mdx](https://github.com/xmtp/docs-xmtp-org/pull/216/files#diff-7bee2f127ade739679f1f0e0510c278922c36d0a1f9951ba6cdb554347f584ab).

#### 📍Where to Start
Start with the heading section in [sync-and-syncall.mdx](https://github.com/xmtp/docs-xmtp-org/pull/216/files#diff-7bee2f127ade739679f1f0e0510c278922c36d0a1f9951ba6cdb554347f584ab) where the text change from 'updates' to 'preferences' has been made.

----

_[Macroscope](https://app.macroscope.com) summarized c723eea._