### PR TITLE
Update v2 read-only date

### DIFF
--- a/docs/pages/upgrade-from-legacy-V2.md
+++ b/docs/pages/upgrade-from-legacy-V2.md
@@ -20,7 +20,7 @@ As developers on V2 explore XMTP V3, many have found that its new architecture p
 :::info[Key takeaways]
 - **Most core methods from V2 work in a similar way in V3**, with some notable differences that are covered in this document.
 - **Primary XMTP identifier is now an inbox ID, not an Ethereum address**. As covered in this document, this inbox can have a list of identities including Ethereum addresses as well as other types in the future, such as Passkeys and Bitcoin**.
-- ⛔️ **Rolling brownouts of the V2 network start on May 1, 2025. V2 will be deprecated on June 1, 2025**, after which all V2 conversations and messages will become read-only. To learn more, see [XIP-53: XIP V2 deprecation plan](https://community.xmtp.org/t/xip-53-xmtp-v2-deprecation-plan/867). Users will still be able to access their V2 communications in read-only format using [https://legacy.xmtp.chat/](https://legacy.xmtp.chat/).
+- ⛔️ **Rolling brownouts of the V2 network start on May 1, 2025. V2 will be deprecated on June 23, 2025**, after which all V2 conversations and messages will become read-only. To learn more, see [XIP-53: XIP V2 deprecation plan](https://community.xmtp.org/t/xip-53-xmtp-v2-deprecation-plan/867). Users will still be able to access their V2 communications in read-only format using [https://legacy.xmtp.chat/](https://legacy.xmtp.chat/).
 :::
 
 ## Upgrade to XMTP V3


### PR DESCRIPTION
### Update V2 network deprecation date from June 1, 2025 to June 23, 2025 in upgrade documentation
The V2 network deprecation date is changed from June 1, 2025 to June 23, 2025 in the 'Key takeaways' section of [docs/pages/upgrade-from-legacy-V2.md](https://github.com/xmtp/docs-xmtp-org/pull/220/files#diff-6a55f7e56c802722c9a5dc6e1a352fe0a2268b11ece60ddeb5d0fbb2f3689fbb).

#### 📍Where to Start
Start with the 'Key takeaways' section in [docs/pages/upgrade-from-legacy-V2.md](https://github.com/xmtp/docs-xmtp-org/pull/220/files#diff-6a55f7e56c802722c9a5dc6e1a352fe0a2268b11ece60ddeb5d0fbb2f3689fbb) where the deprecation date is updated.

----

_[Macroscope](https://app.macroscope.com) summarized 16d2ba3._