### PR TITLE
History sync beta callout

### DIFF
--- a/docs/pages/inboxes/history-sync.mdx
+++ b/docs/pages/inboxes/history-sync.mdx
@@ -2,7 +2,7 @@
 
 :::warning[This feature is in beta]
 
-To provide feedback, please post to [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
+History sync is still in active development as we work on its reliability and performance. To provide feedback on this feature, please post to [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
 
 :::
 


### PR DESCRIPTION
### Add beta status callout to history sync documentation
Adds a box at the beginning of [docs/pages/inboxes/history-sync.mdx](https://github.com/xmtp/docs-xmtp-org/pull/222/files#diff-7cba3e0d813a15a0942b2fbe133c6fbc2495cc57330bf149ea157abbc4596d18) indicating that the history sync feature is in beta status and under active development with focus on reliability and performance. The warning includes a link to the XMTP Community Forums for user feedback.

#### 📍Where to Start
Start with the warning box addition at the beginning of [docs/pages/inboxes/history-sync.mdx](https://github.com/xmtp/docs-xmtp-org/pull/222/files#diff-7cba3e0d813a15a0942b2fbe133c6fbc2495cc57330bf149ea157abbc4596d18).

----

_[Macroscope](https://app.macroscope.com) summarized 99b019b._