### PR TITLE
Fixes to list spacing

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -200,5 +200,5 @@ li ol ~ p {
 
 /* Code groups */
 .vocs_CodeBlock {
-  margin: 1rem 0;
+  margin: 0.5rem 0;
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -183,9 +183,9 @@ table td {
 
 /* ====== NESTED LIST CONTENT SPACING FIXES ====== */
 
-/* Core rules for paragraphs within list items */
+/* Core rules for paragraphs within list items - increased spacing */
 .vocs_Content li p {
-  margin-top: 0.75rem;
+  margin-top: 1.5rem;
 }
 
 .vocs_Content li p:not(:last-child) {
@@ -194,6 +194,11 @@ table td {
 
 .vocs_Content li > p:first-child {
   margin-top: 0;
+}
+
+/* Add more space between consecutive paragraphs within the same list item */
+.vocs_ListItem .vocs_Paragraph + .vocs_Paragraph {
+  margin-top: 0.5rem !important;
 }
 
 /* Nested lists and general list content spacing */

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -183,39 +183,19 @@ table td {
 
 /* ====== NESTED LIST CONTENT SPACING FIXES ====== */
 
-/* Core rules for paragraphs within list items - increased spacing */
-.vocs_Content li p {
-  margin-top: 1.5rem;
-}
-
 .vocs_Content li p:not(:last-child) {
   margin-bottom: 0.5rem;
 }
 
-.vocs_Content li > p:first-child {
-  margin-top: 0;
-}
-
-/* Add more space between consecutive paragraphs within the same list item */
-.vocs_ListItem .vocs_Paragraph + .vocs_Paragraph {
+/* Handles paragraphs following nested lists. */
+li ul ~ p,
+li ol ~ p {
   margin-top: 0.5rem !important;
 }
 
-/* Nested lists and general list content spacing */
-li > ul:not(:last-child),
-li > ol:not(:last-child) {
-  margin-bottom: 0.5rem;
-}
-
-/* Key fix: paragraphs following nested lists */
-li ul ~ p,
-li ol ~ p {
-  margin-top: 1rem !important;
-}
-
-/* Nested list items spacing */
-li li:not(:last-child) {
-  margin-bottom: 0.25rem;
+/* Handles a paragraph within the same list item */
+.vocs_ListItem .vocs_Paragraph + .vocs_Paragraph {
+  margin-top: 0.5rem !important;
 }
 
 /* Code groups */

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -180,3 +180,40 @@ table td {
   vertical-align: top;
   padding: 4px; /* Add padding for more margin */
 }
+
+/* ====== NESTED LIST CONTENT SPACING FIXES ====== */
+
+/* Core rules for paragraphs within list items */
+.vocs_Content li p {
+  margin-top: 0.75rem;
+}
+
+.vocs_Content li p:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+.vocs_Content li > p:first-child {
+  margin-top: 0;
+}
+
+/* Nested lists and general list content spacing */
+li > ul:not(:last-child),
+li > ol:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+/* Key fix: paragraphs following nested lists */
+li ul ~ p,
+li ol ~ p {
+  margin-top: 1rem !important;
+}
+
+/* Nested list items spacing */
+li li:not(:last-child) {
+  margin-bottom: 0.25rem;
+}
+
+/* Code groups */
+.vocs_CodeBlock {
+  margin: 1rem 0;
+}


### PR DESCRIPTION
### Fix list spacing by adding CSS rules for paragraph margins within list items and code blocks in documentation styles
Adds CSS rules to [docs/styles.css](https://github.com/xmtp/docs-xmtp-org/pull/228/files#diff-642dd6b337eceefea97f017b0bac03ef7601bde8c4986a6022db316aab7b3c5c) to address spacing issues in documentation formatting:

- Adds 0.5rem bottom margin for paragraphs within list items that aren't the last child
- Adds 0.5rem top margin for paragraphs following nested lists  
- Adds 0.5rem top margin between consecutive paragraphs within the same list item
- Adds 0.5rem vertical margins for code blocks

#### 📍Where to Start
Start with the CSS rule additions in [docs/styles.css](https://github.com/xmtp/docs-xmtp-org/pull/228/files#diff-642dd6b337eceefea97f017b0bac03ef7601bde8c4986a6022db316aab7b3c5c) to understand the spacing modifications for list items and code blocks.

----

_[Macroscope](https://app.macroscope.com) summarized 343cab5._