### PR TITLE
updates to node list

### DIFF
--- a/docs/pages/network/network-nodes.mdx
+++ b/docs/pages/network/network-nodes.mdx
@@ -1,7 +1,6 @@
 # XMTP testnet nodes
 
 For real-time statuses of nodes in the XMTP testnet, see [XMTP Node Status](https://status.testnet.xmtp-partners.xyz/).
-
 The following table lists the nodes currently registered to power the XMTP testnet.
 
 |  | Node operator | Node address |
@@ -27,3 +26,5 @@ Here is a map of node locations:
     loading="lazy"
   ></iframe>
 </div>
+
+A purple pin indicates that the node is operated by a non-profit organization.

--- a/docs/pages/network/network-nodes.mdx
+++ b/docs/pages/network/network-nodes.mdx
@@ -7,13 +7,15 @@ The following table lists the nodes currently registered to power the XMTP testn
 |  | Node operator | Node address |
 |-----|---------------|--------------|
 | 1 | Artifact Capital | xmtp.artifact.systems:443 |
-| 2 | Encapsulate | lb.validator.xmtp.testnet.encapsulate.xyz:443 |
-| 3 | Ethereum Name Service (ENS) | grpc.ens-xmtp.com:443 |
-| 4 | Laminated Labs | xmtp.validators.laminatedlabs.net:443 |
-| 5 | Next.id | xmtp.nextnext.id:443 |
-| 6 | Nodle | xmtpd.nodleprotocol.io:443 |
-| 7 | Ephemera | grpc.testnet.xmtp.network:443 |
-| 8 | Ephemera | grpc2.testnet.xmtp.network:443 |
+| 2 | Crystal One | xmtp.node-op.com:443 |
+| 3 | Emerald Onion | xmtp.disobey.net:443 |
+| 4 | Encapsulate | lb.validator.xmtp.testnet.encapsulate.xyz:443 |
+| 5 | Ethereum Name Service (ENS) | grpc.ens-xmtp.com:443 |
+| 6 | Laminated Labs | xmtp.validators.laminatedlabs.net:443 |
+| 7 | Next.id | xmtp.nextnext.id:443 |
+| 8 | Nodle | xmtpd.nodleprotocol.io:443 |
+| 9 | Ephemera | grpc.testnet.xmtp.network:443 |
+| 10 | Ephemera | grpc2.testnet.xmtp.network:443 |
 
 Here is a map of node locations:
 

--- a/docs/pages/network/run-a-node.mdx
+++ b/docs/pages/network/run-a-node.mdx
@@ -1,6 +1,6 @@
 # Run an XMTP network node
 
-A testnet of the decentralized XMTP network was launched in early December 2024. The XMTP testnet is powered by registered node operators running [xmtpd](https://github.com/xmtp/xmtpd), XMTP daemon software. xmtpd will also power mainnet.
+A [testnet of the decentralized XMTP network](/network/network-nodes) was launched in early December 2024. The XMTP testnet is powered by registered node operators running [xmtpd](https://github.com/xmtp/xmtpd), XMTP daemon software. xmtpd will also power mainnet.
 
 To learn more about the decentralized network, see [Decentralizing XMTP](https://xmtp.org/decentralizing-xmtp).
 


### PR DESCRIPTION
### Update XMTP testnet node list to include Crystal One and Emerald Onion operators
- Adds two new node operators (Crystal One at `xmtp.node-op.com:443` and Emerald Onion at `xmtp.disobey.net:443`) to the registered nodes table in [docs/pages/network/network-nodes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/230/files#diff-36d3bc418f7ad6ef4ba5093a66d04c760c40316701e6220f5cf42c81a8b03405)
- Renumbers existing table entries from positions 2-8 to 4-10 to accommodate the new additions
- Adds documentation note explaining purple pin indicators for non-profit organizations
- Adds internal link from "testnet of the decentralized XMTP network" text to the network nodes page in [docs/pages/network/run-a-node.mdx](https://github.com/xmtp/docs-xmtp-org/pull/230/files#diff-7fd963dbba49ed2a24eb409f7fb83021563d717f58d0eeb1dc0e74c4daef2c9f)

#### 📍Where to Start
Start with the node operators table in [docs/pages/network/network-nodes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/230/files#diff-36d3bc418f7ad6ef4ba5093a66d04c760c40316701e6220f5cf42c81a8b03405) to review the new entries and renumbering changes.

----

_[Macroscope](https://app.macroscope.com) summarized 8fbd6ba._