### PR TITLE
Add link to status page

### DIFF
--- a/docs/footer.tsx
+++ b/docs/footer.tsx
@@ -4,6 +4,32 @@ export default function Footer() {
       <div>
         <small>
         <a
+            href="https://status.xmtp.org/"
+            target="_blank"
+            style={{
+              "--vocs_ExternalLink_iconUrl":
+                "url(/.vocs/icons/arrow-diagonal.svg)",
+            }}
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
+          >
+            XMTP status
+          </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </small>
+        <small>
+        <a
+            href="https://xmtp.chat/"
+            target="_blank"
+            style={{
+              "--vocs_ExternalLink_iconUrl":
+                "url(/.vocs/icons/arrow-diagonal.svg)",
+            }}
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
+          >
+            XMTP.chat
+          </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </small>
+        <small>
+        <a
             href="https://xmtp.org/"
             target="_blank"
             style={{
@@ -12,7 +38,7 @@ export default function Footer() {
             }}
             className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
           >
-            Visit xmtp.org
+            XMTP.org
           </a>
         </small>
       </div>

--- a/docs/pages/intro/dev-support.md
+++ b/docs/pages/intro/dev-support.md
@@ -1,0 +1,11 @@
+# Get dev support for building with XMTP
+
+Building with XMTP and need help or think you've found a bug?
+
+Please open an issue in the relevant repo:
+
+- [Browser SDK](https://github.com/xmtp/xmtp-js/issues)
+- [Node SDK](https://github.com/xmtp/xmtp-js/issues)
+- [React Native SDK](https://github.com/xmtp/xmtp-react-native/issues)
+- [Android SDK](https://github.com/xmtp/xmtp-android/issues)
+- [iOS SDK](https://github.com/xmtp/xmtp-ios/issues)

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -28,8 +28,8 @@ export default defineConfig({
   },
   iconUrl: "/x-mark-blue.png",
   topNav: [
+    { text: "XMTP status", link: "https://xmtp.chat/" },
     { text: "XMTP.chat", link: "https://xmtp.chat/" },
-    { text: "Dev support", link: "https://github.com/xmtp" },
     { text: "XMTP.org", link: "https://xmtp.org/" },
   ],
   ogImageUrl: {
@@ -77,6 +77,10 @@ export default defineConfig({
         {
           text: "Build with LLMs",
           link: "/intro/build-with-llms",
+        },
+        {
+          text: "Dev support",
+          link: "/intro/dev-support",
         },
       ],
     },


### PR DESCRIPTION
### Add XMTP status page link to documentation navigation and footer
The documentation site navigation and footer are updated to include new links to XMTP resources. The changes include:

- Footer component in [docs/footer.tsx](https://github.com/xmtp/docs-xmtp-org/pull/232/files#diff-aa793144904cfdf3cebd9b480f73587ae40edf53e0a6533806e4a8cc8277061a) adds two new links: 'XMTP status' pointing to 'https://status.xmtp.org/' and 'XMTP.chat' pointing to 'https://xmtp.chat/', while updating the existing link text from 'Visit xmtp.org' to 'XMTP.org'
- Navigation configuration in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/232/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) removes the 'Dev support' link from top navigation and adds an 'XMTP status' link pointing to 'https://xmtp.chat/', plus adds a new 'Dev support' item to the sidebar under the intro section
- New developer support documentation page [docs/pages/intro/dev-support.md](https://github.com/xmtp/docs-xmtp-org/pull/232/files#diff-6421046df1e762480a6c6d0a3ea47db808f81d97d9ae601a7bcc8fb0bf98a9db) provides links to GitHub issue repositories for different XMTP SDKs

#### 📍Where to Start
Start with the navigation configuration changes in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/232/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) to understand how the site structure has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized ae18b05._