### PR TITLE
Add doc for clearing network statistics

### DIFF
--- a/docs/pages/inboxes/debug-your-app.md
+++ b/docs/pages/inboxes/debug-your-app.md
@@ -10,7 +10,7 @@ To learn more, see [XMTP Debug](https://github.com/xmtp/libxmtp/blob/main/xmtp_d
 
 ## Forked group debugging tool
 
-:::tip[Preventing forks is XMTP’s responsibility]
+:::tip[Preventing forks is XMTP's responsibility]
 
 This tool helps you identify potential forked groups in your app, but preventing forks in the first place is XMTP's responsibility. This diagnostic tool is just a temporary aid, not a shift in responsibility to your app.
 
@@ -59,13 +59,14 @@ For an example UI implementation, see PR to [add new persistent log debug menu o
 
 You can use these statistics to see which and how many API, identity, and streaming calls are going across the network, which can help you better manage network usage and debug potential rate limiting issues.
 
-A client has a function called `client.debugInformation` These statistics are maintained per client instance, so each app installation has its own separate counter. Each one is a rolling counter for the entire session since the gRPC client was created. To get a snapshot of statistics at a moment in time, you can check the counter, run the action, get the counter again, and then diff the counter with the original counter.
-
-Use the `client.debugInformation.clearAllStatistics()` function to reset all API, identity, and stream statistics to zero. This is useful when you want to get a clean baseline before running specific actions. It is also particularly helpful for managing memory usage on mobile devices where gRPC client caching can accumulate large statistics.
+These statistics are maintained per client instance, so each app installation has its own separate counter. Each one is a rolling counter for the entire session since the gRPC client was created. To get a snapshot of statistics at a moment in time, you can check the counter, run the action, get the counter again, and then diff the counter with the original counter.
 
 ### Get aggregated statistics
 
-Use the `client.debugInformation.aggregateStatistics` function to return these aggregated statistics.
+To return aggregated statistics, you can run:
+
+- Browser and Node SDKs: `client.apiAggregateStatistics()`
+- React Native, iOS, and Android SDKs: `client.debugInformation.aggregateStatistics` 
 
 ```text
 Aggregate Stats:
@@ -88,7 +89,23 @@ SubscribeWelcomes       0
 
 ### Get an individual statistic
 
-You can return an individual statistic as a number. For example, you can run `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeypackage` only.
+To return an individual statistic as a number, you can run:
+
+- Browser and Node SDKs:
+  - `client.apiStatistics().uploadKeyPackage` to track `uploadKeyPackage` only
+  - `client.apiIdentityStatistics().publishIdentityUpdate` to track `PublishIdentityUpdate` only
+- React Native, iOS, and Android SDKs: 
+  - `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeyPackage` only
+  - `client.debugInformation.apiIdentityStatistics.publishIdentityUpdate` to track `publishIdentityUpdate` only
+
+### Clear statistics
+
+To clear all API, identity, and stream statistics and set them to zero, you can run:
+
+- Browser and Node SDKs: `client.clearAllStatistics()`
+- React Native, iOS, and Android SDKs: `client.debugInformation.clearAllStatistics()`
+
+This is useful when you want to get a clean baseline before running specific actions. It's also particularly helpful for managing memory usage on mobile devices where gRPC client caching can accumulate large statistics.
 
 ### Statistic descriptions
 

--- a/docs/pages/inboxes/debug-your-app.md
+++ b/docs/pages/inboxes/debug-your-app.md
@@ -61,6 +61,8 @@ You can use these statistics to see which and how many API, identity, and stream
 
 A client has a function called `client.debugInformation` These statistics are maintained per client instance, so each app installation has its own separate counter. Each one is a rolling counter for the entire session since the gRPC client was created. To get a snapshot of statistics at a moment in time, you can check the counter, run the action, get the counter again, and then diff the counter with the original counter.
 
+Use the `client.debugInformation.clearAllStatistics()` function to reset all API, identity, and stream statistics to zero. This is useful when you want to get a clean baseline before running specific actions. It is also particularly helpful for managing memory usage on mobile devices where gRPC client caching can accumulate large statistics.
+
 ### Get aggregated statistics
 
 Use the `client.debugInformation.aggregateStatistics` function to return these aggregated statistics.


### PR DESCRIPTION
### Add documentation for clearing network statistics using `client.debugInformation.clearAllStatistics()` function in debug documentation
Adds a new paragraph to the debug documentation explaining the `client.debugInformation.clearAllStatistics()` function. The documentation describes that this function resets all API, identity, and stream statistics to zero and explains its use for establishing clean baselines and managing memory usage on mobile devices where gRPC client caching can accumulate statistics. The changes are made to [docs/pages/inboxes/debug-your-app.md](https://github.com/xmtp/docs-xmtp-org/pull/235/files#diff-494e288b115bcb23dd0effd89bf3d2b5e3f54a38ad92e539434bad9008227adf).

#### 📍Where to Start
Start with the newly added paragraph in [docs/pages/inboxes/debug-your-app.md](https://github.com/xmtp/docs-xmtp-org/pull/235/files#diff-494e288b115bcb23dd0effd89bf3d2b5e3f54a38ad92e539434bad9008227adf) that documents the `client.debugInformation.clearAllStatistics()` function.



#### Changes since #235 opened

- Restructured debugging API documentation to provide platform-specific method signatures and access patterns [5b9911e]
- Added documentation for individual statistics retrieval and statistics clearing functionality [5b9911e]
----

_[Macroscope](https://app.macroscope.com) summarized 2dbcdf9._