### PR TITLE
Add docs for the onchain transaction content type

### DIFF
--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -82,6 +82,10 @@ const addressFromInboxId = inboxState[0].identifiers[0].identifier;
 
 To learn more, see [View the inbox state](/inboxes/manage-inboxes#view-the-inbox-state).
 
+### Support onchain transactions
+
+To learn more, see the [Support onchain transactions](/inboxes/content-types/transactions) documentation and the example [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) agent.
+
 ### Try out your agent using xmtp.chat
 
 Test and interact with your agent using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.

--- a/docs/pages/inboxes/content-types/transactions.md
+++ b/docs/pages/inboxes/content-types/transactions.md
@@ -1,0 +1,86 @@
+# Support onchain transactions in your app built with XMTP
+
+This package provides an XMTP content type to support sending transactions to a wallet for execution. 
+
+:::tip[Open for feedback]
+
+You are welcome to provide feedback on this implementation by commenting on [XIP-59: Trigger on-chain calls via wallet_sendCalls](https://community.xmtp.org/t/xip-59-trigger-on-chain-calls-via-wallet-sendcalls/889).
+
+:::
+
+## Install the package
+
+```bash
+# npm
+npm i @xmtp/content-type-wallet-send-calls
+
+# yarn
+yarn add @xmtp/content-type-wallet-send-calls
+
+# pnpm
+pnpm i @xmtp/content-type-wallet-send-calls
+```
+
+## Create a transaction request
+
+With XMTP, a transaction request is represented using `wallet_sendCalls` with additional metadata for display:
+
+```tsx [Browser]
+const walletSendCalls: WalletSendCallsParams = {
+  version: "1.0",
+  from: "0x123...abc",
+  chainId: "0x2105",
+  calls: [
+    {
+      to: "0x456...def",
+      value: "0x5AF3107A4000",
+      metadata: {
+        description: "Send 0.0001 ETH on base to 0x456...def",
+        transactionType: "transfer",
+        currency: "ETH",
+        amount: 100000000000000,
+        decimals: 18,
+        toAddress: "0x456...def",
+      },
+    },
+    {
+      to: "0x789...cba",
+      data: "0xdead...beef",
+      metadata: {
+        description: "Lend 10 USDC on base with Morpho @ 8.5% APY",
+        transactionType: "lend",
+        currency: "USDC",
+        amount: 10000000,
+        decimals: 6,
+        platform: "morpho",
+        apy: "8.5",
+      },
+    },
+  ],
+};
+```
+
+## Send a transaction request
+
+Once you have a transaction reference, you can send it as part of your conversation:
+
+```tsx [Browser]
+await conversation.messages.send(walletSendCalls, {
+  contentType: ContentTypeWalletSendCalls,
+});
+Receive a transaction request
+To receive and process a transaction request:
+
+// Assume `loadLastMessage` is a thing you have
+const message: DecodedMessage = await loadLastMessage();
+
+if (!message.contentType.sameAs(ContentTypeWalletSendCalls)) {
+  // Handle non-transaction request message
+  return;
+}
+
+const walletSendCalls: WalletSendCallsParams = message.content;
+// Process the transaction request here
+```
+
+:::

--- a/docs/pages/inboxes/content-types/transactions.md
+++ b/docs/pages/inboxes/content-types/transactions.md
@@ -84,3 +84,7 @@ const walletSendCalls: WalletSendCallsParams = message.content;
 ```
 
 :::
+
+## Examples
+
+For an example of an agent that implements the transaction content type, see [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions).

--- a/docs/pages/inboxes/content-types/transactions.md
+++ b/docs/pages/inboxes/content-types/transactions.md
@@ -2,6 +2,10 @@
 
 This package provides an XMTP content type to support sending transactions to a wallet for execution. 
 
+Currently, this content type is supported in the Browser, Node, and React Native SDKs only.
+
+For an example of an agent that implements the transaction content type, see [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions).
+
 :::tip[Open for feedback]
 
 You are welcome to provide feedback on this implementation by commenting on [XIP-59: Trigger on-chain calls via wallet_sendCalls](https://community.xmtp.org/t/xip-59-trigger-on-chain-calls-via-wallet-sendcalls/889).
@@ -10,7 +14,7 @@ You are welcome to provide feedback on this implementation by commenting on [XIP
 
 ## Install the package
 
-```bash
+```bash [Bash]
 # npm
 npm i @xmtp/content-type-wallet-send-calls
 
@@ -23,9 +27,9 @@ pnpm i @xmtp/content-type-wallet-send-calls
 
 ## Create a transaction request
 
-With XMTP, a transaction request is represented using `wallet_sendCalls` with additional metadata for display:
+With XMTP, a transaction request is represented using `wallet_sendCalls` with additional metadata for display.
 
-```tsx [Browser]
+```tsx [TypeScript]
 const walletSendCalls: WalletSendCallsParams = {
   version: "1.0",
   from: "0x123...abc",
@@ -64,13 +68,17 @@ const walletSendCalls: WalletSendCallsParams = {
 
 Once you have a transaction reference, you can send it as part of your conversation:
 
-```tsx [Browser]
+```tsx [TypeScript]
 await conversation.messages.send(walletSendCalls, {
   contentType: ContentTypeWalletSendCalls,
 });
-Receive a transaction request
+```
+
+## Receive a transaction request
+
 To receive and process a transaction request:
 
+```tsx [TypeScript]
 // Assume `loadLastMessage` is a thing you have
 const message: DecodedMessage = await loadLastMessage();
 
@@ -82,9 +90,3 @@ if (!message.contentType.sameAs(ContentTypeWalletSendCalls)) {
 const walletSendCalls: WalletSendCallsParams = message.content;
 // Process the transaction request here
 ```
-
-:::
-
-## Examples
-
-For an example of an agent that implements the transaction content type, see [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions).

--- a/docs/pages/inboxes/quickstart.md
+++ b/docs/pages/inboxes/quickstart.md
@@ -80,6 +80,7 @@ Explore the examples and docs in [xmtp-agent-examples](https://github.com/epheme
    - [Reactions](/inboxes/content-types/reactions)
    - [Replies](/inboxes/content-types/replies)
    - [Read receipts](/inboxes/content-types/read-receipts)
+   - [Onchain transactions](/inboxes/content-types/transactions)
    - [Onchain transaction references](/inboxes/content-types/transaction-refs)
 
 3. [Implement push notifications](/inboxes/push-notifs/understand-push-notifs).

--- a/llms/llms-full.txt
+++ b/llms/llms-full.txt
@@ -12,153 +12,6 @@ This documentation includes code samples for multiple SDKs. Please use the code 
 
 Ensure that you select the correct code block to avoid compatibility issues.
 
-## pages/privacy.md
-# Privacy policy
-
-`docs.xmtp.org` does not use cookies and does not collect any personal data or personally-identifiable information (PII).
-
-The site does use Plausible analytics to track overall trends in website traffic. Plausible does not track individual visitors. All analytics data is aggregated data only and it contains no personal information.
-
-The site uses Plausible analytics for the sole purpose of helping site contributors understand how to best deliver content that serves the needs of the XMTP community.
-
-To learn more about the data Plausible tracks, see the [Plausible Data Policy](https://plausible.io/data-policy).
-
-If you have any questions about this privacy policy, post to the [XMTP Community Forums](https://community.xmtp.org/).
-
-
-## pages/index.mdx
-import { CustomHomePage } from "../components/CustomHomePage";
-import "../styles.css";
-
-<CustomHomePage.Root>
-  <CustomHomePage.Headline>Build with XMTP</CustomHomePage.Headline>
-  <CustomHomePage.Subhead>
-    The largest and most secure decentralized messaging network
-  </CustomHomePage.Subhead>
-  <CustomHomePage.TileGrid>
-    <CustomHomePage.Tile
-      href="/upgrade-from-legacy-V2"
-      title="Upgrade to XMTP V3"
-      description="Get tips for upgrading from a legacy SDK to a stable XMTP V3 SDK"
-      icon="🚀"
-    />
-    <CustomHomePage.Tile
-      href="/intro/intro"
-      title="Intro to XMTP"
-      description="Get an intro to XMTP and why devs choose it to build messaging apps"
-      icon="🤝"
-    />
-    <CustomHomePage.Tile
-      href="/inboxes/pick-an-sdk"
-      title="Build chat inboxes"
-      description="Build standalone inbox apps with 1:1 and group chats built with MLS"
-      icon="📥"
-    />
-    <CustomHomePage.Tile
-      href="https://xmtp.chat/"
-      title="Build with xmtp.chat"
-      description="Build an inbox app with the help of this interactive developer tool and chat app"
-      icon="🧑🏽‍💻"
-      isExternal={true}
-    />
-    <CustomHomePage.Tile
-      href="https://github.com/ephemeraHQ/xmtp-agent-examples"
-      title="Build agents"
-      description="Explore examples of agents built with the XMTP Node SDK"
-      icon="🤖"
-      isExternal={true}
-    />
-    <CustomHomePage.Tile
-      href="/network/run-a-node"
-      title="Run an XMTP node"
-      description="Learn about network nodes and how to become a registered node operator"
-      icon="🕸️"
-    />
-    <CustomHomePage.Tile
-      href="/protocol/security"
-      title="Learn protocol concepts"
-      description="Dive deeper into XMTP by learning about key protocol concepts"
-      icon="🧠"
-    />
-    <CustomHomePage.Tile
-      href="/intro/xips"
-      title="Review XIPs"
-      description="Read and provide feedback on the latest XMTP Improvement Proposals"
-      icon="⚒️"
-    />
-  </CustomHomePage.TileGrid>
-</CustomHomePage.Root>
-
-
-## pages/terms.md
----
-description: "We are pleased to license much of the documentation on this site under terms that explicitly encourage people to take, modify, reuse, re-purpose, and remix this content as they see fit."
----
-
-# Terms of service
-
-Our content licensing policies are based on those of the [Google Developer](https://developers.google.com/site-policies) website.
-
-We are pleased to license much of the documentation on `docs.xmtp.org` under terms that explicitly encourage people to take, modify, reuse, re-purpose, and remix this content as they see fit.
-
-You will find the following notice at the bottom of pages on `docs.xmtp.org`:
-
-> CC BY 4.0
-
-This means that except as otherwise noted, page content is licensed under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/) and code samples are licensed under the [MIT License](http://opensource.org/licenses/MIT).
-
-When you see a page with this notice, you are free to use [nearly everything](#what-is-not-licensed) on the page in your own creations. For example, you could quote the text in a book, cut-and-paste sections to your blog, record it as an audiobook for the visually impaired, or even translate it into Swahili. Really. That's what open content licenses are all about. We just ask that you give us [attribution](#attribution) when you reuse our work.
-
-If you have any questions about these terms of service, post to the [XMTP Community Forums](https://community.xmtp.org/).
-
-## What is _not_ licensed?
-
-We say “nearly everything” as there are a few simple conditions that apply.
-
-Trademarks and other brand features are not included in this license.
-
-In some cases, a page might include content consisting of images, audio or video material, or a link to content on a different webpage (such as videos or slide decks). This content is not covered by the license, unless specifically noted.
-
-## Attribution
-
-Proper attribution is required when you reuse or create modified versions of content that appears on a page made available under the terms of the Creative Commons Attribution license. The complete requirements for attribution can be found in section 3 of the [Creative Commons legal code](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-In practice, we ask that you provide attribution to XMTP to the best of the ability of the medium in which you are producing the work.
-
-There are several typical ways in which this might apply:
-
-#### Exact reproductions
-
-If your online work _exactly reproduces_ text or images from this site, in whole or in part, please include a paragraph at the bottom of your page that reads:
-
->Portions of this page are reproduced from work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
-
-Also, please link back to the original source page so that readers can refer to it for more information.
-
-#### Modified versions
-
-If your online work shows _modified_ text or images based on the content from this site, please include a paragraph at the bottom of your page that reads:
-
->Portions of this page are modifications based on work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
-
-Again, please link back to the original source page so that readers can refer to it for more information. This is even more important when the content has been modified.
-
-#### Other media
-
-If you produce non-hypertext works, such as books, audio, or video, we ask that you make a best effort to include a spoken or written attribution in the spirit of the messages above.
-
-
-## pages/doc-feedback.md
-# Documentation feedback
-
-We’re excited to share documentation for the latest version of XMTP.
-
-We continuously release new and updated documentation.
-
-Not seeing the specific documentation you need? [Open an issue](https://github.com/xmtp/docs-xmtp-org/issues/new/choose). We ❤️ doc requests.
-
-Onward builders! 🫡
-
 ## pages/upgrade-from-legacy-V3.md
 # Upgrade from a legacy XMTP V3 SDK to a stable XMTP V3 SDK
 
@@ -283,6 +136,78 @@ Now, developers can use `inboxId` to create a new DM conversation because with t
 ```tsx
 const dm = await alix.conversations.findOrCreateDm(bo.inboxId);
 ```
+
+
+## pages/terms.md
+---
+description: "We are pleased to license much of the documentation on this site under terms that explicitly encourage people to take, modify, reuse, re-purpose, and remix this content as they see fit."
+---
+
+# Terms of service
+
+Our content licensing policies are based on those of the [Google Developer](https://developers.google.com/site-policies) website.
+
+We are pleased to license much of the documentation on `docs.xmtp.org` under terms that explicitly encourage people to take, modify, reuse, re-purpose, and remix this content as they see fit.
+
+You will find the following notice at the bottom of pages on `docs.xmtp.org`:
+
+> CC BY 4.0
+
+This means that except as otherwise noted, page content is licensed under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/) and code samples are licensed under the [MIT License](http://opensource.org/licenses/MIT).
+
+When you see a page with this notice, you are free to use [nearly everything](#what-is-not-licensed) on the page in your own creations. For example, you could quote the text in a book, cut-and-paste sections to your blog, record it as an audiobook for the visually impaired, or even translate it into Swahili. Really. That's what open content licenses are all about. We just ask that you give us [attribution](#attribution) when you reuse our work.
+
+If you have any questions about these terms of service, post to the [XMTP Community Forums](https://community.xmtp.org/).
+
+## What is _not_ licensed?
+
+We say “nearly everything” as there are a few simple conditions that apply.
+
+Trademarks and other brand features are not included in this license.
+
+In some cases, a page might include content consisting of images, audio or video material, or a link to content on a different webpage (such as videos or slide decks). This content is not covered by the license, unless specifically noted.
+
+## Attribution
+
+Proper attribution is required when you reuse or create modified versions of content that appears on a page made available under the terms of the Creative Commons Attribution license. The complete requirements for attribution can be found in section 3 of the [Creative Commons legal code](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+In practice, we ask that you provide attribution to XMTP to the best of the ability of the medium in which you are producing the work.
+
+There are several typical ways in which this might apply:
+
+#### Exact reproductions
+
+If your online work _exactly reproduces_ text or images from this site, in whole or in part, please include a paragraph at the bottom of your page that reads:
+
+>Portions of this page are reproduced from work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
+
+Also, please link back to the original source page so that readers can refer to it for more information.
+
+#### Modified versions
+
+If your online work shows _modified_ text or images based on the content from this site, please include a paragraph at the bottom of your page that reads:
+
+>Portions of this page are modifications based on work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
+
+Again, please link back to the original source page so that readers can refer to it for more information. This is even more important when the content has been modified.
+
+#### Other media
+
+If you produce non-hypertext works, such as books, audio, or video, we ask that you make a best effort to include a spoken or written attribution in the spirit of the messages above.
+
+
+## pages/privacy.md
+# Privacy policy
+
+`docs.xmtp.org` does not use cookies and does not collect any personal data or personally-identifiable information (PII).
+
+The site does use Plausible analytics to track overall trends in website traffic. Plausible does not track individual visitors. All analytics data is aggregated data only and it contains no personal information.
+
+The site uses Plausible analytics for the sole purpose of helping site contributors understand how to best deliver content that serves the needs of the XMTP community.
+
+To learn more about the data Plausible tracks, see the [Plausible Data Policy](https://plausible.io/data-policy).
+
+If you have any questions about this privacy policy, post to the [XMTP Community Forums](https://community.xmtp.org/).
 
 
 ## pages/upgrade-from-legacy-V2.md
@@ -529,876 +454,185 @@ While we don’t recommend it, you can store V2 conversations in a local databas
 We don’t recommend using this approach because not all of the peer addresses may be reachable on the V3 network, which means that only some conversations would be seeded.
 
 
-## pages/network/network-nodes.mdx
-# XMTP testnet nodes
-
-For real-time statuses of nodes in the XMTP testnet, see [XMTP Node Status](https://status.testnet.xmtp-partners.xyz/).
-The following table lists the nodes currently registered to power the XMTP testnet.
-
-|  | Node operator | Node address |
-|-----|---------------|--------------|
-| 1 | Artifact Capital | xmtp.artifact.systems:443 |
-| 2 | Crystal One | xmtp.node-op.com:443 |
-| 3 | Emerald Onion | xmtp.disobey.net:443 |
-| 4 | Encapsulate | lb.validator.xmtp.testnet.encapsulate.xyz:443 |
-| 5 | Ethereum Name Service (ENS) | grpc.ens-xmtp.com:443 |
-| 6 | Laminated Labs | xmtp.validators.laminatedlabs.net:443 |
-| 7 | Next.id | xmtp.nextnext.id:443 |
-| 8 | Nodle | xmtpd.nodleprotocol.io:443 |
-| 9 | Ephemera | grpc.testnet.xmtp.network:443 |
-| 10 | Ephemera | grpc2.testnet.xmtp.network:443 |
-
-Here is a map of node locations:
-
-<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden" }}>
-  <iframe
-    src="https://www.google.com/maps/d/embed?mid=18y4nFTXQKdgiSJCQbEGl5dojPoHL3LQ&ehbc=2E312F&noprof=1"
-    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
-    allowFullScreen=""
-    loading="lazy"
-  ></iframe>
-</div>
-
-A purple pin indicates that the node is operated by a non-profit organization.
-
-## pages/network/run-a-node.mdx
-# Run an XMTP network node
-
-A [testnet of the decentralized XMTP network](/network/network-nodes) was launched in early December 2024. The XMTP testnet is powered by registered node operators running [xmtpd](https://github.com/xmtp/xmtpd), XMTP daemon software. xmtpd will also power mainnet.
-
-To learn more about the decentralized network, see [Decentralizing XMTP](https://xmtp.org/decentralizing-xmtp).
-
-## Interested in becoming a registered XMTP node operator?
-
-1. Review [XIP-54: XMTP network node operator qualification criteria](https://community.xmtp.org/t/xip-54-xmtp-network-node-operator-qualification-criteria/868).
-2. [Submit an application](https://docs.google.com/forms/d/e/1FAIpQLScBpJ0i962xBPpZZeI6q7-UMo5Bc2JkhvHR_v2rliLDoBkzXQ/viewform?usp=sharing) to become a registered node operator.
-
-## Already a registered node operator?
-
-To get started, see the [xmtpd-infrastructure](https://github.com/xmtp/xmtpd-infrastructure) repository, which provides infrastructure-as-code examples and tooling to help node operators deploy and manage xmtpd nodes.
-
-## FAQ about the XMTP network
-
-To follow and provide feedback on the engineering work covered in this FAQ, see the [Replication tracking task](https://github.com/xmtp/xmtpd/issues/118) in the [xmtpd repo](https://github.com/xmtp/xmtpd).
-
-### Is the XMTP network decentralized?
-
-A testnet of the decentralized XMTP network was launched in early December 2024.
-
-All of the nodes in the `dev` and `production` XMTP network environments are still operated by [Ephemera](https://ephemerahq.com/) (the company) and powered by [xmtp-node-go](https://github.com/xmtp/xmtp-node-go).
-
-These nodes in the `dev` and `production` XMTP network environments operate in US jurisdiction in compliance with Office of Foreign Assets Control (OFAC) sanctions and Committee on Foreign Investment in the United States (CFIUS) export compliance regulations. Accordingly, IP-based geoblocking is in place for the following countries/territories:
-
-- Cuba
-- Iran
-- North Korea 
-- Syria
-- The Crimea, Donetsk People’s Republic, and Luhansk People’s Republic regions of Ukraine
-
-### Is XMTP a blockchain?
-
-The testnet of the decentralized XMTP network includes two distributed systems:
-
-- The XMTP broadcast network
-- The XMTP appchain, which is an L3 blockchain securing all metadata that require strict ordering.
-
-To learn more, see [Decentralizing XMTP](https://xmtp.org/decentralizing-xmtp).
-
-The `dev` and `production` XMTP network environments do not use a blockchain. Nodes in these networks run software to store and transfer messages between blockchain accounts. For secure and reliable delivery of messages, the nodes participate in a consensus mechanism.
-
-### Will I be able to run my own XMTP node?
-
-At this time, not everyone will be able to run an XMTP node in the production decentralized XMTP network. 
-
-To learn more, see [XIP-54: XMTP network node operator qualification criteria](https://community.xmtp.org/t/xip-54-xmtp-network-node-operator-qualification-criteria/868).
-
-### Does XMTP have a token?
-
-XMTP does not currently have a token. Disregard any information regarding airdrops or token sales. If and when an official token is introduced, announcements will be made exclusively through XMTP's official channels.
-
-
-## pages/protocol/security.mdx
-# Messaging security properties with XMTP 
-
-XMTP delivers end-to-end encrypted 1:1 and group chat using the following resources:
-
-- Advanced cryptographic techniques
-- Secure key management practices
-- MLS ([Messaging Layer Security](https://www.rfc-editor.org/rfc/rfc9420.html))
-
-Specifically, XMTP messaging provides the comprehensive security properties covered in the following sections. In these sections, **group** refers to the MLS concept of a group, which includes both 1:1 and group conversations.
-
-🎥 **walkthrough: XMTP and MLS**
-
-This video provides a walkthrough of XMTP's implementation of MLS.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/g6I9qXOkDMo?si=o5pD2xwa_yynoP5s" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
-
-To dive deeper into how XMTP implements MLS, see the [XMTP MLS protocol specification](https://github.com/xmtp/libxmtp/tree/main/xmtp_mls).
-
-## A deep dive into messaging security properties
-
-### Message confidentiality
-
-Ensures that the contents of messages in transit can't be read without the corresponding encryption keys.
-
-Message confidentiality is achieved through symmetric encryption, ensuring that only intended recipients can read the message content. [AEAD](#cryptographic-tools-in-use) (Authenticated Encryption with Associated Data) is used to encrypt the message content, providing robust protection against unauthorized access.
-
-## Forward secrecy
-
-Ensures that even if current session keys are compromised, past messages remain secure. 
-
-MLS achieves this by using the ratcheting mechanism, where the keys used to encrypt application messages are ratcheted forward every time a message is sent. When the old key is deleted, old messages can't be decrypted, even if the newer keys are known. This property is supported by using ephemeral keys during the key encapsulation process.
-
-## Post-compromise security
-
-Ensures that future messages remain secure even if current encryption keys are compromised.
-
-XMTP uses regular key rotation achieved through a commit mechanism with a specific update path in MLS, meaning a new group secret is encrypted to all other members. This essentially resets the key and an attacker with the old state can't derive the new secret, as long as the private key from the leaf node in the ratchet tree construction hasn't been compromised. This ensures forward secrecy and protection against future compromises.
-
-## Message authentication
-
-Validates the identity of the participants in the conversation, preventing impersonation.
-
-XMTP uses digital signatures to strongly guarantee message authenticity. These signatures ensure that each message is cryptographically signed by the sender, verifying the sender’s identity without revealing it to unauthorized parties. This prevents attackers from impersonating conversation participants.
-
-## Message integrity
-
-Ensures that messages can't be tampered with during transit and that messages are genuine and unaltered. 
-
-XMTP achieves this through the use of MLS. The combination of digital signatures and [AEAD](#cryptographic-tools-in-use) enables XMTP to detect changes to message content.
-
-## User anonymity
-
-Ensures that outsiders can't deduce the participants of a group, users who have interacted with each other, or the sender or recipient of individual messages.
-
-User anonymity is achieved through a combination of the following functions:
-
-- MLS Welcome messages encrypt the sender metadata and group ID, protecting the social graph.
-
-- XMTP adds a layer of encryption to MLS Welcome messages using [HPKE](#cryptographic-tools-in-use) (Hybrid Public Key Encryption). This prevents multiple recipients of the same Welcome message from being correlated to the same group.
-
-- XMTP uses MLS [PrivateMessage](https://www.rfc-editor.org/rfc/rfc9420.html#name-confidentiality-of-sender-d) framing to hide the sender and content of group messages.
-
-- XMTP’s backend doesn't authenticate reads or writes and only implements per-IP rate limits. Aside from Welcome messages, all payloads for a given group are stored under a single group ID, and any client may anonymously query or write to any group ID. Only legitimate members possess the correct encryption keys for a given group.
-
-It's technically possible for XMTP network node operators to analyze query patterns per IP address. However, clients may choose to obfuscate this information using proxying/onion routing.
-
-XMTP currently hides the sender of Welcome messages (used to add users to a group) but doesn't hide the Welcome message recipients. This makes it possible to determine how many groups a user was invited to but not whether the user did anything about the invitations.
-
-## Cryptographic tools in use
-
-XMTP messaging uses the ciphersuite _MLS_128_HPKEX25519_CHACHA20POLY1305_SHA256_Ed25519_.
-
-Here is a summary of individual cryptographic tools used to collectively ensure that XMTP messaging is secure, authenticated, and tamper-proof:
-
-- [HPKE](https://www.rfc-editor.org/rfc/rfc9180.html)
-
-    Used to encrypt Welcome messages, protect the identities of group invitees, and maintain the confidentiality of group membership. We use the ciphersuite HPKEX25519.
-
-- [AEAD](https://developers.google.com/tink/aead)
-
-    Used to ensure both confidentiality and integrity of messages. In particular, we use the ciphersuite CHACHA20POLY1305.
-
-- [SHA3_256 and SHA2_256](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)
-
-    XMTP uses two cryptographic hash functions to ensure data integrity and provide strong cryptographic binding. SHA3_256 is used in the multi-wallet identity structure. SHA2_256 is used in MLS. The ciphersuite is SHA256.
-
-- [Ed25519](https://ed25519.cr.yp.to/ed25519-20110926.pdf)
-
-    Used for digital signatures to provide secure, high-performance signing and verification of messages. The ciphersuite is Ed25519.
-
-
-## pages/protocol/signatures.md
----
-description: "Learn about wallet signature types when using XMTP"
----
-
-# Wallet signatures with XMTP
-
-Learn about the types of wallet address signatures you might be prompted to provide when using apps built with XMTP. These signatures are always made with a specific wallet address controlled by your wallet.
-
-## First-time app installation use
-
-The first time you use an installation of an app built with XMTP, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. For example:
-
-```text
-XMTP : Authenticate to inbox
-
-Inbox ID: ${INBOX_ID}
-Current time: ${YYYY-MM-DD HH:MM:SS UTC}
-```
-
-More specifically, the message will request that you sign:
-
-- A **Grant messaging access to app** message to grant the app installation access to messaging owned by your signing wallet address. For example:
-
-  ```text
-  - Grant messaging access to app
-    (ID: ${hex(INSTALLATION_PUBLIC_KEY)})
-  ```
-
-- A **Create inbox** message to create an XMTP inbox owned by your signing address, but only if you have never used an app installation built with XMTP v3 before. For example:
-
-  ```text
-  - Create inbox
-    (Owner: ${INITIAL_ADDRESS})
-  ```
-
-Sign the **XMTP : Authenticate to inbox** message with your wallet address to consent to the message requests.
-
-<img width="400" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/authen-to-inbox.PNG" alt="MetaMask wallet browser extension Sign this message? window showing an XMTP: Authenticate to inbox message" />
-
-## Sign to add another address to your inbox
-
-You can add another wallet address to your inbox at any time. For example, you might have started using an app with one wallet address and now want to use the app with an additional wallet address.
-
-If you decide to add another wallet address to your inbox, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign a **Link address to inbox** message. For example:
-
-```text
-- Link address to inbox
-  (Address: ${ASSOCIATED_ADDRESS})
-```
-
-Sign with the wallet address you want to add to grant it access to the inbox. You can now use your inbox to exchange messages using the wallet address you just added.
-
-## Sign to remove address from your inbox
-
-You can remove a wallet address from your inbox at any time.
-
-If you decide to remove a wallet address from your inbox, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign an **Unlink address from inbox** message. For example:
-
-```text
-- Unlink address from inbox
-  (Address: ${ASSOCIATED_ADDRESS})
-```
-
-Sign with the wallet address you want to remove to unlink it from your inbox. You can no longer access your inbox using the wallet address you removed.
-
-## Sign to change inbox recovery address
-
-The first time you used an app installation built with XMTP v3, the wallet address you used to create an inbox is automatically set as the inbox recovery address. You can change the recovery address to a different wallet address at any time.
-
-If you decide to change the recovery address, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign a **Change inbox recovery address** message. For example:
-
-```text
-- Change inbox recovery address
-  (Address: ${NEW_RECOVERY_ADDRESS})
-```
-
-Sign with the wallet address you want to set as the recovery address to change the recovery address.
-
-## Sign to consent to receive broadcast messages
-
-When you click a **Subscribe** button built with XMTP’s consent standards, you're prompted to sign an **XMTP : Grant inbox consent to sender** message.
-
-For example, here’s the MetaMask **Signature request** window that displays when clicking the **Subscribe** button on this [example subscription page](https://subscribe-broadcast.vercel.app/subscribe/button) connected to the XMTP `dev` network. You typically see **Subscribe** buttons like this on a web page or in a dapp.
-
-![MetaMask wallet browser extension Signature request window showing an "XMTP: Grant inbox consent to sender" message](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/consent-proof-sign.png)
-
-When you click **Sign**, you're consenting to receive broadcast messages from the publisher at your connected wallet address. You can see the publisher's sending address in the **Signature request** window.
-
-When you provide consent, you're adding the publisher's address to your personal XMTP allowed contacts list. This enables messages from the publisher to be displayed in your main inbox instead of being treated as a message from an unknown sender and placed in a secondary view.
-
-To learn about XMTP's consent standards, see [Understand how user consent preferences support spam-free inboxes](/inboxes/user-consent/user-consent).
-
-
-## pages/intro/intro.md
-# What is XMTP?
-
-XMTP (Extensible Message Transport Protocol) is the largest and most secure decentralized messaging network
-
-XMTP is open and permissionless, empowering any developer to build end-to-end encrypted 1:1, group, and agent messaging experiences, and more.
-
-## Why should I build with XMTP?
-
-Build with XMTP to:
-
-- **Deliver secure and private messaging**
-
-    Using the [Messaging Layer Security](/protocol/security) (MLS) standard, a ratified [IETF](https://www.ietf.org/about/introduction/) standard, XMTP provides end-to-end encrypted messaging with forward secrecy and post-compromise security.
-
-- **Provide spam-free inboxes**
-
-    In any open and permissionless messaging ecosystem, spam is an inevitable reality, and XMTP is no exception. However, with XMTP [user consent preferences](/inboxes/user-consent/user-consent), developers can give their users spam-free inboxes displaying conversations with chosen contacts only.
-
-- **Build on native crypto rails**
-    
-    Build with XMTP to tap into the capabilities of crypto and web3. Support decentralized identities, crypto transactions, and more, directly in a messaging experience.
-
-- **Empower users to own and control their communications**
-
-    With apps built with XMTP, users own their conversations, data, and identity. Combined with the interoperability that comes with protocols, this means users can access their end-to-end encrypted communications using any app built with XMTP.
-    
-- **Create with confidence**
-
-    Developers are free to create the messaging experiences their users want—on a censorship-resistant protocol architected to last forever. Because XMTP isn't a closed proprietary platform, developers can build confidently, knowing their access and functionality can't be revoked by a central authority.
-
-## Try an app built with XMTP
-
-One of the best ways to understand XMTP is to use an app built with XMTP.
-
-- Try [xmtp.chat](https://xmtp.chat/), an app made for devs to learn to build with XMTP—using an app built with XMTP.
-
-- Try the [Convos](https://www.convos.org/) messaging app. Convos is open source courtesy of [Ephemera](https://ephemerahq.com/), the company stewarding the development and adoption of XMTP.
-
-## Join the XMTP community
-
-- **XMTP builds in the open**
-
-    - Explore the documentation on this site
-    - Explore the open [XMTP GitHub org](https://github.com/xmtp), which contains code for LibXMTP, XMTP SDKs, and xmtpd, node software powering the XMTP testnet.
-    - Explore the open source code for [xmtp.chat](https://github.com/xmtp/xmtp-js/tree/main/apps/xmtp.chat), an app made for devs to learn to build with XMTP—using an app built with XMTP.
-
-- **XMTP is for everyone**
-
-    - [Join the conversation](https://community.xmtp.org/) and become part of the movement to redefine digital communications.
-
-
-## pages/intro/xips.md
-# XMTP Improvement Proposals (XIPs)
-
-An XIP is a design document that proposes a new feature or improvement for XMTP or its processes or environment.
-
-XIPs intend to be the primary mechanisms for:
-
-- Proposing new features
-- Collecting community technical input on an issue
-- Documenting the design decisions that have gone into XMTP
-
-For these reasons, XIPs are a great way to learn about XMTP's newest features and participate in shaping the evolution of the protocol.
-
-To review the latest XIPs, see [Improvement Proposals](https://community.xmtp.org/c/xips/xip-drafts/53).
-
-To learn more about XIPs and how to participate in the process, including authoring an XIP of your own, see [XIP purpose, process, and guidelines](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md).
-
-
-## pages/intro/build-with-llms.md
-# Use XMTP documentation with AI coding assistants
-
-To make it easier to use AI coding agents to build with XMTP, you can find an `llms-full.txt` file at [https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-full.txt](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-full.txt).
-
-This `llms-full.txt` file includes all XMTP documentation in a single plain text file for easy parsing by AI agents.
-
-If you’re using an LLM tool that allows custom context, you can upload or point to `llms-full.txt` to enhance your AI coding experience with XMTP.
-
-
-## pages/intro/faq.mdx
-# FAQ about XMTP
-
-Get answers to the most frequently asked questions about XMTP.
-
-## What works with XMTP?
-
-In the spirit of web3 composability, here are **just a few** of the building blocks that work well with XMTP. Building your app with these tools can help you deliver and distribute an app—faster and with quality.
-
-:::tip
-This list is not exhaustive and is just a starting point. A highly extensible protocol like XMTP can work with more tools than those listed in each section.
+## pages/index.mdx
+import { CustomHomePage } from "../components/CustomHomePage";
+import "../styles.css";
+
+<CustomHomePage.Root>
+  <CustomHomePage.Headline>Build with XMTP</CustomHomePage.Headline>
+  <CustomHomePage.Subhead>
+    The largest and most secure decentralized messaging network
+  </CustomHomePage.Subhead>
+  <CustomHomePage.TileGrid>
+    <CustomHomePage.Tile
+      href="/upgrade-from-legacy-V2"
+      title="Upgrade to XMTP V3"
+      description="Get tips for upgrading from a legacy SDK to a stable XMTP V3 SDK"
+      icon="🚀"
+    />
+    <CustomHomePage.Tile
+      href="/intro/intro"
+      title="Intro to XMTP"
+      description="Get an intro to XMTP and why devs choose it to build messaging apps"
+      icon="🤝"
+    />
+    <CustomHomePage.Tile
+      href="/inboxes/pick-an-sdk"
+      title="Build chat inboxes"
+      description="Build standalone inbox apps with 1:1 and group chats built with MLS"
+      icon="📥"
+    />
+    <CustomHomePage.Tile
+      href="https://xmtp.chat/"
+      title="Build with xmtp.chat"
+      description="Build an inbox app with the help of this interactive developer tool and chat app"
+      icon="🧑🏽‍💻"
+      isExternal={true}
+    />
+    <CustomHomePage.Tile
+      href="https://github.com/ephemeraHQ/xmtp-agent-examples"
+      title="Build agents"
+      description="Explore examples of agents built with the XMTP Node SDK"
+      icon="🤖"
+      isExternal={true}
+    />
+    <CustomHomePage.Tile
+      href="/network/run-a-node"
+      title="Run an XMTP node"
+      description="Learn about network nodes and how to become a registered node operator"
+      icon="🕸️"
+    />
+    <CustomHomePage.Tile
+      href="/protocol/security"
+      title="Learn protocol concepts"
+      description="Dive deeper into XMTP by learning about key protocol concepts"
+      icon="🧠"
+    />
+    <CustomHomePage.Tile
+      href="/intro/xips"
+      title="Review XIPs"
+      description="Read and provide feedback on the latest XMTP Improvement Proposals"
+      icon="⚒️"
+    />
+  </CustomHomePage.TileGrid>
+</CustomHomePage.Root>
+
+
+## pages/doc-feedback.md
+# Documentation feedback
+
+We’re excited to share documentation for the latest version of XMTP.
+
+We continuously release new and updated documentation.
+
+Not seeing the specific documentation you need? [Open an issue](https://github.com/xmtp/docs-xmtp-org/issues/new/choose). We ❤️ doc requests.
+
+Onward builders! 🫡
+
+## pages/inboxes/sync-and-syncall.mdx
+# Sync conversations and messages
+
+:::tip[Note]
+Syncing does not refetch existing conversations and messages. It also does not fetch messages for group chats you are no longer a part of.
 :::
 
-### Wallet connectors
+## 🎥 walkthrough: Syncing
 
-Here are some options for connecting wallets to your app built with XMTP:
+This video provides a walkthrough of key concepts required to implement syncing correctly.
 
-- [RainbowKit](https://www.rainbowkit.com/)  
-  Support for WalletConnect v2 is now standard in RainbowKit. To learn how to upgrade, see [Migrating to WalletConnect v2](https://www.rainbowkit.com/guides/walletconnect-v2).
-- [Thirdweb](https://thirdweb.com/)
-- [wagmi](https://wagmi.sh/)
+<iframe width="560" height="315" src="https://www.youtube.com/embed/jl7P0onApxw?si=YNafIHebx9Kxycos" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
 
-### Message payload storage
+## Sync a specific conversation
 
-Here are some options for storing encrypted message payload content:
-
-- [IPFS](https://ipfs.io/)
-- [ThirdwebStorage](https://portal.thirdweb.com/infrastructure/storage/how-storage-works)
-- [web3.storage](https://web3.storage/)
-
-### Wallet apps
-
-XMTP can be used with EVM-compatible wallet apps that support ECDSA signing on the secp256k1 elliptic curve. These include common wallet apps such as:
-
-- [Coinbase Wallet](https://www.coinbase.com/wallet)
-- [MetaMask](https://metamask.io/)
-- [Rainbow Wallet](https://rainbow.me/)
-- Most wallets in the [WalletConnect network](https://explorer.walletconnect.com/?type=wallet)
-
-The XMTP SDK **does not** include a wallet app abstraction, as XMTP assumes that developers have a way to obtain a wallet app connection.
-
-### Chains 
-
-XMTP can work with signatures from any private public key pair and currently supports EOAs and SCWs on Ethereum and Ethereum side-chains and L2s. 
-
-Because all Ethereum Virtual Machine (EVM) chains share the same Ethereum wallet and address format and XMTP messages are stored off-chain, XMTP is interoperable across EVM chains, including testnets. (XMTP itself does not use EVMs.) 
-
-For example, whether a user has their wallet app connected to Ethereum or an Ethereum side-chain or L2, their private key can generate and retrieve their XMTP key pair to give them access to XMTP. 
-
-XMTP is also chain-agnostic, so multi-chain support is possible.
-
-Here are just a few chains that work with XMTP:
-
-- [Arbitrum](https://arbitrum.foundation/)
-- [Avalanche](https://www.avax.com/)
-- [Base](https://base.org/)
-- [(BNB) Chain](https://www.bnbchain.org/)
-- [Ethereum](https://ethereum.org/)
-- [zk-EVM](https://linea.build/)
-- [Optimism](https://www.optimism.io/)
-- [Polygon](https://polygon.technology/)
-- [Scroll](https://www.scroll.io/)
-
-## Build with XMTP
-
-### Which languages does the XMTP SDK support?
-
-XMTP SDKs are [available for multiple languages](/inboxes/pick-an-sdk).
-
-### Which web3 libraries does the XMTP SDK require?
-
-The XMTP SDK currently requires you to use [ethers](https://ethers.org/) or another web3 library capable of supplying an [ethers Signer](https://docs.ethers.io/v5/api/signer/), such as [wagmi](https://wagmi.sh/).
-
-### What is the invalid key package error?
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hNlby-SfPzw?si=V7LqaBxk-i4xhbNC" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
-
-### Where can I get official XMTP brand assets?
-
-See the [XMTP brand guidelines](https://github.com/xmtp/brand) GitHub repo.
-
-## Network
-
-See [Network FAQ](/network/run-a-node/#faq-about-the-xmtp-network).
-
-## Fees
-
-### Does XMTP have fees?
-
-XMTP core developers and researchers are working on a specific fee model for XMTP, with the following guiding principles in mind:
-
-- Fees will be dynamic to protect the network from Denial of Service (DoS) attacks.
-- Infrastructure costs for the network must remain low even when decentralized, and comparable to the costs for an equivalent centralized messaging service.
-- There must be a low "take rate": the biggest driver of cost must be infrastructure costs, with any remaining cost returned to the network.
-
-Have questions or feedback about the fee model for XMTP? See [XIP-57: Messaging fee collection](https://community.xmtp.org/t/xip-57-messaging-fee-collection/876) in the XMTP Community Forums.
-
-## Security
-
-### Has XMTP undergone a security audit?
-
-A security assessment of [LibXMTP](https://github.com/xmtp/libxmtp) and its use of Messaging Layer Security (MLS) was completed by [NCC Group](https://www.nccgroup.com/) in Dec 2024. 
-
-See [Public Report: XMTP MLS Implementation Review](https://www.nccgroup.com/us/research-blog/public-report-xmtp-mls-implementation-review/).
-
-## Storage
-
-### Where are XMTP messages stored?
-
-XMTP stores messages in the XMTP network before and after retrieval. App-specific message storage policies may vary.
-
-### What are the XMTP message retention policies?
-
-#### For XMTP’s blockchain and node databases:
-
-Currently, encrypted payloads are stored indefinitely.
-
-In the coming year, a retention policy will be added. 
-
-This retention policy would represent a minimum retention period, not a maximum.
-
-For example, a retention policy may look something like the following, though specifics are subject to change:
-  - One year for messages
-  - Indefinite storage for account information and personal preferences  
-
-The team is researching a way to provide this indefinite storage and have it scale forever. 
-- If research shows that it's possible, we'll share a plan for how it will be achieved. 
-- If research shows that it isn't possible, we'll share a plan that shows how retention periods will provide a permanent solution to storage scaling.
-
-Have questions or feedback regarding message storage and retention? Post to the [XMTP Community Forums](https://community.xmtp.org/c/development/ideas/54).
-
-#### For the on-device database managed by the XMTP SDK:
-
-Messages are stored for as long as the user decides to keep them. However, encryption keys are regularly rotated.
-
-### What are XMTP message storage and retrieval costs?
-
-Messages are stored off-chain on the XMTP network, with all nodes currently hosted by Ephemera. Ephemera currently absorbs all message storage and retrieval costs.
-
-Today, there are no message storage and retrieval-related fees incurred by developers for building with the XMTP SDK.
-
-## Messages
-
-### Which message formats does XMTP support?
-
-XMTP transports a message payload as a set of bytes that can represent any format that a developer wants to support, such as plain text, JSON, or non-text binary or media content.
-
-With XMTP, these message formats are called content types. Currently, there are two basic content types available. These content types aim to establish broad compatibility among apps built with XMTP.
-
-The XMTP community can propose and adopt standards for other content types, either informally or through a governance process.
-
-To learn more about content types, see [Content types](/inboxes/content-types/content-types).
-
-To learn more about the XMTP improvement proposals governance process, see [What is an XIP?](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md)
- 
-### Does XMTP have a maximum message size?
-
-Yes. Messages sent on the XMTP network are limited to just short of 1MB (1048214 bytes).
-
-For this reason, XMTP supports [remote attachments](/inboxes/content-types/attachments).
-
-### Does XMTP support message deletion and editing?
-
-Not currently. However, Ephemera is exploring ways to support message deletion and editing.
-
-Have ideas about message deletion and editing? Post to the [XMTP Community Forums](https://community.xmtp.org/c/development/ideas/54).
-
-### Is XMTP more like email or chat?
-
-XMTP enables developers to implement messaging features and UX paradigms that best fit their needs. As a result, messages sent using apps built with XMTP might resemble many typical forms of communication, such as email, direct and group messaging, broadcasts, text messaging, push notifications, and more.
-
-## What is Ephemera?
-
-Ephemera is a web3 software company that contributes to XMTP, an open network, protocol, and standards for secure messaging between blockchain accounts.
-
-Ephemera employees work alongside other XMTP community members to build with and extend XMTP. Community [contributions and participation](https://community.xmtp.org/) are critical to the development and adoption of XMTP.
-
-Ephemera focuses on serving developers. We build [SDKs](/inboxes/pick-an-sdk), developer tools, and example apps that help developers build great experiences with XMTP.
-
-Ephemera [acquired Converse](https://paragraph.xyz/@ephemera/converse) in June 2024. Converse is now [Convos](https://github.com/ephemeraHQ/convos-app), open-sourced for the entire XMTP network.
-
-
-## pages/inboxes/create-conversations.md
-# Create conversations
-
-## Check if an identity is reachable
-
-The first step to creating a conversation is to verify that participants’ identities are reachable on XMTP. The `canMessage` method checks each identity's compatibility, returning a response indicating whether each identity can receive messages.
-
-Once you have the verified identities, you can create a new conversation, whether it's a group chat or direct message (DM).
+Get all new messages and group updates (name, description, etc.) for a specific conversation from the network.
 
 :::code-group
 
 ```js [Browser]
-import { Client } from "@xmtp/browser-sdk";
-
-// response is a Map of string (identity) => boolean (is reachable)
-const response = await Client.canMessage([bo.identity, caro.identity]);
+await client.conversation.sync();
 ```
 
 ```js [Node]
-import { Client } from "@xmtp/node-sdk";
-
-// response is a Map of string (identity) => boolean (is reachable)
-const response = await Client.canMessage([bo.identity, caro.identity]);
+await client.conversation.sync();
 ```
 
 ```tsx [React Native]
-// Request
-const canMessage = await client.canMessage([
-  boIdentity,
-  v2OnlyIdentity,
-  badIdentity,
-])
-
-// Response
-{
-  "0xboAddress": true,
-  "0xV2OnlyAddress": false,
-  "0xBadAddress": false,
-}
+await client.conversation.sync();
 ```
 
 ```kotlin [Kotlin]
-// Request
-val boIdentity = Identity(ETHEREUM, '0xboAddress')
-val v2Identity = Identity(ETHEREUM, '0xV2OnlyAddress')
-val badIdentity = Identity(ETHEREUM, '0xBadAddress')
-
-val canMessage = client.canMessage(listOf(boIdentity, v2Identity, badIdentity))
-
-// Response
-[
-  "0xboAddress": true,
-  "0xV2OnlyAddress": false,
-  "0xBadAddress": false,
-]
+client.conversation.sync()
 ```
 
 ```swift [Swift]
-// Request
-let canMessage = try await client.canMessage([boIdentity, v2OnlyIdentity, badIdentity])
-
-// Response
-[
-  "0xboAddress": true,
-  "0xV2OnlyAddress": false,
-  "0xBadAddress": false,
-]
+try await client.conversation.sync()
 ```
 
 :::
 
-## Create a new group chat
+## Sync new conversations
 
-Once you have the verified identities, create a new group chat. The maximum group chat size is 220 members.
-
-:::tip
-If you want to provide faster and offline group creation, consider using [optimistic group chat creation](#optimistically-create-a-group-chat) instead. This approach enables instant group creation and message preparation before adding members and even when offline.
-:::
+Get any new group chat or DM conversations from the network.
 
 :::code-group
 
 ```js [Browser]
-const group = await client.conversations.newGroup(
-  [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
-);
+await client.conversations.sync();
 ```
 
 ```js [Node]
-const group = await client.conversations.newGroup(
-  [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
-);
+await client.conversations.sync();
 ```
 
 ```tsx [React Native]
-// New Group
-const group = await alix.conversations.newGroup([bo.inboxId, caro.inboxId]);
-
-// New Group with Metadata
-const group = await alix.conversations.newGroup([bo.inboxId, caro.inboxId], {
-  name: "The Group Name",
-  imageUrl: "www.groupImage.com",
-  description: "The description of the group",
-  permissionLevel: "admin_only", // 'all_members' | 'admin_only'
-});
+await client.conversations.sync();
 ```
 
 ```kotlin [Kotlin]
-// New Group
-val group = alix.conversations.newGroup(listOf(bo.inboxId, caro.inboxId))
-
-// New Group with Metadata
-val group = alix.conversations.newGroup(listOf(bo.inboxId, caro.inboxId),
-  permissionLevel = GroupPermissionPreconfiguration.ALL_MEMBERS, // ALL_MEMBERS | ADMIN_ONLY
-  name = "The Group Name",
-  imageUrl = "www.groupImage.com",
-  description = "The description of the group",
-)
+client.conversations.sync()
 ```
 
 ```swift [Swift]
-// New Group
-let group = try await alix.conversations.newGroup([bo.inboxId, caro.inboxId])
-
-// New Group with Metadata
-let group = try await alix.conversations.newGroup([bo.inboxId, caro.inboxId],
-  permissionLevel: .admin_only, // .all_members | .admin_only
-  name: "The Group Name",
-  imageUrl: "www.groupImage.com",
-  description: "The description of the group",
-)
+try await client.conversations.sync()
 ```
 
 :::
 
-## Optimistically create a new group chat
+## Sync all new welcomes, conversations, messages, and preferences
 
-Optimistic group creation enables instant group chat creation and message preparation before adding members and even when offline. This approach prioritizes user experience by allowing immediate interaction with the group chat, while handling the network synchronization in the background when members are added.
+Sync all new welcomes, group chat and DM conversations, messages, and [preference updates](/inboxes/sync-preferences) from the network.
 
-Use this method to optimistically create a group chat, which enables a user to create a group chat now and add members later.
+By default, `syncAll` streams only conversations with a [consent state](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set) of allowed or unknown.
 
-The group chat can be created with any number of [standard options](/inboxes/group-metadata#updatable-group-chat-metadata), or no options. The group chat is stored only in the local storage of the app installation used to create it. In other words, the group chat is visible only to the creator and in the app installation they used to create it.
+We recommend streaming messages for allowed conversations only. This ensures that spammy conversations with a consent state of unknown don't take up networking resources. This also ensures that unwanted spam messages aren't stored in the user's local database.
 
-You can prepare messages for the optimistic group chat immediately using `prepareMessage()`. As with the group chat itself, these messages are stored locally only.
+To sync all conversations regardless of consent state, pass `[ALLOWED, UNKNOWN, DENIED]`.
 
-When you want to add members, you use [`addMembers()`](/inboxes/group-permissions#add-members-by-inbox-id) with a list of inbox IDs.
-
-Adding a member will automatically sync the group chat to the network. Once synced, the group chat becomes visible to the added members and across other app installations.
-
-After adding members, you must explicitly call `publishMessages()` to send any prepared messages to the network.
-
-To learn more about optimistically sending messages using `prepareMessage()` and `publishMessages()`, see [Optimistically send messages](/inboxes/send-messages#optimistically-send-messages).
-
-:::code-group
-
-```tsx [Browser]
-// create optimistic group (stays local)
-const optimisticGroup = await alixClient.conversations.newGroupOptimistic();
-
-// send optimistic message (stays local)
-await optimisticGroup.sendOptimistic("gm");
-
-// later, sync the group by adding members
-await optimisticGroup.addMembers([boClient.inboxId]);
-// or publishing messages
-await optimisticGroup.publishMessages();
-```
-
-```ts [Node]
-// create optimistic group (stays local)
-const optimisticGroup = client.conversations.newGroupOptimistic();
-
-// send optimistic message (stays local)
-optimisticGroup.sendOptimistic("gm");
-
-// later, sync the group by adding members
-await optimisticGroup.addMembers([boClient.inboxId]);
-// or publishing messages
-await optimisticGroup.publishMessages();
-```
-
-```tsx [React Native]
-const optimisticGroup = await boClient.conversations.newGroupOptimistic();
-
-// Prepare a message (stays local)
-await optimisticGroup.prepareMessage("Hello group!");
-
-// Later, add members and sync
-await optimisticGroup.addMembers([alixClient.inboxId]); // also syncs group to the network
-await optimisticGroup.publishMessages(); // Publish prepared messages
-```
-
-```kotlin [Kotlin]
-// Create optimistic group (stays local)
-val optimisticGroup = boClient.conversations.newGroupOptimistic(groupName = "Testing")
-
-// Prepare a message (stays local)
-optimisticGroup.prepareMessage("Hello group!")
-
-// Later, add members and sync
-optimisticGroup.addMembers(listOf(alixClient.inboxId)) // also syncs group to the network
-optimisticGroup.publishMessages() // Publish prepared messages
-```
-
-```swift [Swift]
-// Create optimistic group (stays local)
-let optimisticGroup = try await boClient.conversations.newGroupOptimistic(groupName: "Testing")
-
-// Prepare a message (stays local)
-try await optimisticGroup.prepareMessage("Hello group!")
-
-// Later, add members and sync
-try await  optimisticGroup.addMembers([alixClient.inboxId]) // also syncs group to the network
-try await  optimisticGroup.publishMessages() // Publish prepared messages
-```
-
-:::
-
-## Create a new DM
-
-Once you have the verified identity, get its inbox ID and create a new DM:
+To sync preferences only, you can call [`preferences.sync`](/inboxes/sync-preferences). Note that `preferences.sync` will also sync welcomes to ensure that you have all potential new installations before syncing.
 
 :::code-group
 
 ```js [Browser]
-const group = await client.conversations.newDm(bo.inboxId);
+await client.conversations.syncAll(["allowed"]);
 ```
 
 ```js [Node]
-const group = await client.conversations.newDm(bo.inboxId);
+await client.conversations.syncAll(["allowed"]);
 ```
 
 ```tsx [React Native]
-const dm = await alix.conversations.findOrCreateDm(bo.inboxId);
+await client.conversations.syncAllConversations(["allowed"]);
 ```
 
 ```kotlin [Kotlin]
-val dm = alix.conversations.findOrCreateDm(bo.inboxId)
-
-// calls the above function under the hood but returns a type conversation instead of a dm
-val conversation = client.conversations.newConversation(inboxId)
+client.conversations.syncAllConversations(consentState: listOf(ConsentState.ALLOWED))
 ```
 
 ```swift [Swift]
-let dm = try await alix.conversations.findOrCreateDm(with: bo.inboxId)
-
-// calls the above function under the hood but returns a type conversation instead of a dm
-let conversation = try await client.conversations.newConversation(inboxId)
+try await client.conversations.syncAllConversations(consentState: [.allowed])
 ```
 
 :::
-
-## Conversation helper methods
-
-Use these helper methods to quickly locate and access specific conversations—whether by conversation ID, topic, group ID, or DM identity—returning the appropriate ConversationContainer, group, or DM object.
-
-:::code-group
-
-```js [Browser]
-// get a conversation by its ID
-const conversationById = await client.conversations.getConversationById(
-  conversationId
-);
-
-// get a message by its ID
-const messageById = await client.conversations.getMessageById(messageId);
-
-// get a 1:1 conversation by a peer's inbox ID
-const dmByInboxId = await client.conversations.getDmByInboxId(peerInboxId);
-```
-
-```js [Node]
-// get a conversation by its ID
-const conversationById = await client.conversations.getConversationById(
-  conversationId
-);
-
-// get a message by its ID
-const messageById = await client.conversations.getMessageById(messageId);
-
-// get a 1:1 conversation by a peer's inbox ID
-const dmByInboxId = await client.conversations.getDmByInboxId(peerInboxId);
-```
-
-```tsx [React Native]
-// Returns a ConversationContainer
-await alix.conversations.findConversation(conversation.id);
-await alix.conversations.findConversationByTopic(conversation.topic);
-// Returns a Group
-await alix.conversations.findGroup(group.id);
-// Returns a DM
-await alix.conversations.findDmByIdentity(bo.identity);
-```
-
-```kotlin [Kotlin]
-// Returns a ConversationContainer
-alix.conversations.findConversation(conversation.id)
-alix.conversations.findConversationByTopic(conversation.topic)
-// Returns a Group
-alix.conversations.findGroup(group.id)
-// Returns a DM
-alix.conversations.findDmbyInboxId(bo.inboxId);
-```
-
-```swift [Swift]
-// Returns a ConversationContainer
-try alix.conversations.findConversation(conversation.id)
-try alix.conversations.findConversationByTopic(conversation.topic)
-// Returns a Group
-try alix.conversations.findGroup(group.id)
-// Returns a DM
-try alix.conversations. findDmbyInboxId(bo.inboxId)
-```
-
-:::
-
-## Conversation union type
-
-Serves as a unified structure for managing both group chats and DMs. It provides a consistent set of properties and methods to seamlessly handle various conversation types.
-
-- React Native: [Conversation.ts](https://github.com/xmtp/xmtp-react-native/blob/main/src/lib/Conversation.ts)
-
-## Group class
-
-Represents a group chat conversation, providing methods to manage group-specific functionalities such as sending messages, synchronizing state, and handling group membership.
-
-- React Native: [Group.ts](https://github.com/xmtp/xmtp-react-native/blob/main/src/lib/Group.ts)
-
-## Dm class
-
-Represents a DM conversation, providing methods to manage one-on-one communications, such as sending messages, synchronizing state, and handling message streams.
-
-- React Native: [Dm.ts](https://github.com/xmtp/xmtp-react-native/blob/main/src/lib/Dm.ts)
 
 
 ## pages/inboxes/create-a-client.mdx
@@ -1835,1158 +1069,125 @@ try await client.deleteLocalDatabase()
 :::
 
 
-## pages/inboxes/sync-and-syncall.mdx
-# Sync conversations and messages
+## pages/inboxes/debug-your-app.md
+# Debug your inbox app
 
-:::tip[Note]
-Syncing does not refetch existing conversations and messages. It also does not fetch messages for group chats you are no longer a part of.
-:::
+This document covers tools and features available for debugging building with XMTP, including stress testing, group chat diagnostics, logging, and network monitoring capabilities.
 
-## 🎥 walkthrough: Syncing
+## XMTP Debug
 
-This video provides a walkthrough of key concepts required to implement syncing correctly.
+You can use the XMTP Debug tool to stress and burn-in test your inbox app on the `local` and `dev` XMTP environments.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/jl7P0onApxw?si=YNafIHebx9Kxycos" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+To learn more, see [XMTP Debug](https://github.com/xmtp/libxmtp/blob/main/xmtp_debug/README.md).
 
-## Sync a specific conversation
+## Forked group debugging tool
 
-Get all new messages and group updates (name, description, etc.) for a specific conversation from the network.
+:::tip[Preventing forks is XMTP’s responsibility]
 
-:::code-group
-
-```js [Browser]
-await client.conversation.sync();
-```
-
-```js [Node]
-await client.conversation.sync();
-```
-
-```tsx [React Native]
-await client.conversation.sync();
-```
-
-```kotlin [Kotlin]
-client.conversation.sync()
-```
-
-```swift [Swift]
-try await client.conversation.sync()
-```
+This tool helps you identify potential forked groups in your app, but preventing forks in the first place is XMTP's responsibility. This diagnostic tool is just a temporary aid, not a shift in responsibility to your app.
 
 :::
 
-## Sync new conversations
+A conversation now has `getDebugInformation`. You can use this to see:
 
-Get any new group chat or DM conversations from the network.
+- The MLS epoch of a group chat conversation for a member
+- Whether a group chat might be forked for a member
+- Details of a potential fork
 
-:::code-group
+The function that provides this information is called `maybeForked` because it is difficult to be 100% certain whether a group is forked.
 
-```js [Browser]
-await client.conversations.sync();
-```
-
-```js [Node]
-await client.conversations.sync();
-```
-
-```tsx [React Native]
-await client.conversations.sync();
-```
-
-```kotlin [Kotlin]
-client.conversations.sync()
-```
-
-```swift [Swift]
-try await client.conversations.sync()
-```
-
-:::
-
-## Sync all new welcomes, conversations, messages, and preferences
-
-Sync all new welcomes, group chat and DM conversations, messages, and [preference updates](/inboxes/sync-preferences) from the network.
-
-By default, `syncAll` streams only conversations with a [consent state](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set) of allowed or unknown.
-
-We recommend streaming messages for allowed conversations only. This ensures that spammy conversations with a consent state of unknown don't take up networking resources. This also ensures that unwanted spam messages aren't stored in the user's local database.
-
-To sync all conversations regardless of consent state, pass `[ALLOWED, UNKNOWN, DENIED]`.
-
-To sync preferences only, you can call [`preferences.sync`](/inboxes/sync-preferences). Note that `preferences.sync` will also sync welcomes to ensure that you have all potential new installations before syncing.
-
-:::code-group
-
-```js [Browser]
-await client.conversations.syncAll(["allowed"]);
-```
-
-```js [Node]
-await client.conversations.syncAll(["allowed"]);
-```
-
-```tsx [React Native]
-await client.conversations.syncAllConversations(["allowed"]);
-```
-
-```kotlin [Kotlin]
-client.conversations.syncAllConversations(consentState: listOf(ConsentState.ALLOWED))
-```
-
-```swift [Swift]
-try await client.conversations.syncAllConversations(consentState: [.allowed])
-```
-
-:::
-
-
-## pages/inboxes/use-signatures.md
-# Use signatures with XMTP
-
-With XMTP, you can use various types of signatures to sign and verify payloads.
-
-## Sign with an external wallet
-
-When a user creates, adds, removes, or revokes an XMTP inbox’s identity or installation, a signature is required.
-
-## Sign with an XMTP key
-
-You can sign something with XMTP keys. For example, you can sign with XMTP keys to send a payload to a backend.
-
-:::code-group
-
-```js [Node]
-const signature = client.signWithInstallationKey(signatureText);
-```
-
-```jsx [React Native]
-const signature = await client.signWithInstallationKey(signatureText)
-```
-
-```kotlin [Kotlin]
-val signature = client.signWithInstallationKey(signatureText)
-```
-
-```swift [Swift]
-let signature = try client.signWithInstallationKey(message: signatureText)
-```
-
-:::
-
-## Verify with the same installation that signed
-
- You can also sign with XMTP keys and verify that a payload was sent by the same client. 
-
-:::code-group
-
-```js [Node]
-const isValidSignature = client.verifySignedWithInstallationKey(signatureText, signature);
-```
-
-```jsx [React Native]
-const isVerified = await client.verifySignature(signatureText, signature)
-```
-
-```kotlin [Kotlin]
-val isVerified = client.verifySignature(signatureText, signature)
-```
-
-```swift [Swift]
-let isVerified = try client.verifySignature(
-            message: signatureText, 
-            signature: signature
-        )
-
-```
-
-:::
-
-## Verify with the same inbox ID that signed
-
-You can use an XMTP key’s `installationId` to create a signature, then pass both the signature and `installationId` to another `installationId` with the same `inboxId` to verify that the signature came from a trusted sender.
-
-:::code-group
-
-```js [Node]
-const isValidSignature = client.verifySignedWithPrivateKey(signatureText, signature, installationId);
-```
-
-```kotlin [Kotlin]
-val isVerified = client.verifySignatureWithInstallationId(
-            signatureText, 
-            signature, 
-            installationId
-      )
-```
-
-```swift [Swift]
-let isVerified = try client.verifySignatureWithInstallationId(
-                message: signatureText,
-                signature: signature,
-                installationId: installationId
-            )
-```
-
-:::
-
-
-## pages/inboxes/quickstart.md
-# Quickstart: Build an app with XMTP
-
-This quickstart provides a map to building a [secure messaging app](/protocol/security) with XMTP, including support for:
-
-- End-to-end encrypted direct message and group chat conversations
-- Rich content types (attachments, reactions, replies, and more)
-- Real-time push notifications
-- Spam-free inboxes using user consent preferences
-
-:::tip[🤖 Building an agent instead?]
-
-Explore the examples and docs in [xmtp-agent-examples](https://github.com/ephemeraHQ/xmtp-agent-examples).
-
-:::
-
-## 🏗️ Phase I: Setup
-
-1. Select the XMTP SDK that matches your platform.
-
-   - Mobile development
-     - [React Native SDK](https://github.com/xmtp/xmtp-react-native)
-     - [Kotlin SDK](https://github.com/xmtp/xmtp-android)
-     - [Swift SDK](https://github.com/xmtp/xmtp-ios)
-
-   - Web development
-     - [Browser SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk) (for web apps)
-     - [Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk) (for servers)
-
-   Need an SDK for a different platform? Let us know in [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
-
-2. [Run a local XMTP node](https://github.com/xmtp/xmtp-local-node/tree/main) for development and testing.
-
-3. You can [use llms-full.txt](http://localhost:5173/intro/build-with-llms) to provide the full text of the XMTP developer documentation to an AI coding assistant.
-
-
-## 💬 Phase II: Build core messaging
-
-1. [Create an EOA or SCW signer](/inboxes/create-a-signer#create-a-eoa-or-scw-signer).
-
-2. [Create an XMTP client](/inboxes/create-a-client).
-
-3. [Check if an identity is reachable on XMTP](/inboxes/create-conversations#check-if-an-identity-is-reachable).
-
-4. Create a [group chat](/inboxes/create-conversations#create-a-new-group-chat) or [direct message](/inboxes/create-conversations#create-a-new-dm) (DM) conversation. 
-   
-   With XMTP, "conversation" refers to both group chat and DM conversations.
-
-5. [Send messages](/inboxes/send-messages) in a conversation.
-
-6. Manage group chat [permissions](/inboxes/group-permissions) and [metadata](/inboxes/group-metadata).
-
-7. [Manage identities, inboxes, and installations](/inboxes/manage-inboxes).
-
-## 📩 Phase III: Manage conversations and messages
-
-1. [List existing conversations](/inboxes/list-and-stream#list-existing-conversations) from local storage.
-
-2. [Stream new conversations](/inboxes/list-and-stream#stream-all-group-chats-and-dms) from the network.
-
-3. [Stream new messages](/inboxes/list-and-stream#stream-all-group-chat-and-dm-messages-and-preferences) from the network.
-
-4. [Sync new conversations](/inboxes/sync-and-syncall#sync-new-conversations) from the network.
-
-5. [Sync a specific conversation's messages and preference updates](/inboxes/sync-and-syncall#sync-a-specific-conversation) from the network.
-
-## 💅🏽 Phase IV: Enhance the user experience
-
-1. [Implement user consent](/inboxes/user-consent/support-user-consent), which provides a consent value of either **unknown**, **allowed** or **denied** to each of a user's contacts. You can use these consent values to filter conversations. For example:
-   
-   - Conversations with **allowed** contacts go to a user's main inbox
-   - Conversations with **unknown** contacts go to a possible spam tab
-   - Conversations with **denied** contacts are hidden from view.
-  
-2. Support rich [content types](/inboxes/content-types/content-types).
-   
-   - [Attachments](/inboxes/content-types/attachments)
-     - Single remote attachment
-     - Multiple remote attachments
-     - Attachments smaller than 1MB
-   - [Reactions](/inboxes/content-types/reactions)
-   - [Replies](/inboxes/content-types/replies)
-   - [Read receipts](/inboxes/content-types/read-receipts)
-   - [Onchain transaction references](/inboxes/content-types/transaction-refs)
-
-3. [Implement push notifications](/inboxes/push-notifs/understand-push-notifs).
-
-## 🧪 Phase V: Test and debug
-
-- [Stress and burn-in test](/inboxes/debug-your-app#xmtp-debug) your inbox app.
-
-- [Enable file logging](/inboxes/debug-your-app#file-logging).
-
-- [Capture network statistics](/inboxes/debug-your-app#network-statistics).
-
-- Found a bug or need support? Please file an issue in the relevant SDK repo:
-  
-  - [React Native SDK](https://github.com/xmtp/xmtp-react-native/issues)
-  - [Kotlin SDK](https://github.com/xmtp/xmtp-android/issues)
-  - [Swift SDK](https://github.com/xmtp/xmtp-ios/issues)
-  - [Browser SDK](https://github.com/xmtp/xmtp-js/issues)
-  - [Node SDK](https://github.com/xmtp/xmtp-js/issues)
-
-
-## pages/inboxes/sync-preferences.mdx
-# Sync preferences
-
-Preference sync enables you to sync the following preference-related information across multiple existing app installations:
-
-- Conversation [consent preferences](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set)
-- Conversation HMAC keys (for [push notifications](/inboxes/push-notifs/understand-push-notifs))
-
-## Databases used by preference sync
-
-Each xmtpd node contains:
-
-- A **welcomes database**: Keeps a ledger of all groups an inbox ID is a part of.
-- A **group messages database**: Keeps a ledger of all messages in the groups an inbox ID is a part of.
-
-<div>
-  <img alt="databases in each xmtpd node" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/xmtpd-dbs.png" width="300px" />
-</div>
-
-In the welcomes database, the groups are of these types:
-
-- **1:1 chat**: A group that handles conversations between an inbox ID and one other user.
-- **Group chat**: A group that handles conversations between an inbox ID and multiple other users.
-- **Preferences**: A group that handles syncing preferences between an inbox ID's existing app installations.
-
-One-to-one chat, group chat, and preferences groups in the welcome database are updated by apps as follows:
-
-- 1:1 chats
-    - `conversations.list`
-    - `syncAll`
-    - `streamAll`
-- Group chats
-    - `conversations.list`
-    - `syncAll`
-    - `streamAll`
-- Preferences
-    - `preferences.sync`
-    - `syncAll`
-    - `streamAll`
-
-<div>
-  <img alt="groups in the welcome database" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/welcomes-db.png" width="500px" />
-</div>
-
-## Preferences group
-
-To describe preference sync, let's first focus on how the preferences group works.
-
-1. A preferences group has one member, which is one inbox ID.
-   
-2. Let's say Inbox ID Alix has an Installation A of App A on their phone. At this time, Inbox ID Alix has a preferences group that looks like this:
-
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-1.png" width="300px" />
-   </div>
-
-3. Inbox ID Alix then logs in to an Installation B of App B on their phone. The next time Installation A runs `preferences.sync`, `syncAll`, or `streamAll`, it updates the preferences group as follows:
-    
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-2.png" width="300px" />
-   </div>
-    
-4. Then let's say Inbox ID Alix logs in to an Installation C of App A on their tablet. The next time Installation A or B runs `preferences.sync`, `syncAll`, or `streamAll`, it updates the preferences group as follows:
-    
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-3.png" width="300px" />
-   </div>
-    
-## Preferences sync worker
-
-Now, let's describe how the preferences sync worker helps keep user consent preferences in sync across existing app installations.
-
-1. Let's say Inbox ID Alix uses Installation A to block Inbox ID Bo.
-
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/a-block-bo.png" width="200px" />
-   </div>    
-    
-2. This sends a message to the preferences group in the group message database. This is not an actual chat message, but a serialized proto message that is not shown to app users.
-    
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/gm-pg.png" width="300px" />
-   </div>    
-    
-3. When Installation B calls `preferences.sync`, `syncAll`, or `streamAll`, it gets the message from the preferences group. The sync worker listens for these preferences group messages and processes the message to block Inbox ID Bo in Installation B.
-    
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/b-block-bo.png" width="200px" />
-   </div> 
-    
-4. Likewise, when Installation C calls `preferences.sync`, `syncAll`, or `streamAll`, it gets the message from the preferences group, and the sync worker ensures Inbox ID Bo is blocked there as well.
-    
-   <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/c-block-bo.png" width="200px" />
-   </div>   
-
-Preferences sync handles syncing HMAC keys in the same way.
-
-For example, it will handle syncing an HMAC key shared by Installation B to other installations. When Installation A and C call `preferences.sync`, `syncAll`, or `streamAll`, the sync worker gets Installation B's HMAC key message from the preferences group and ensures that Installation A and C get the HMAC key for Installation B.
-
-## Sync preferences
-
-Use this call to sync preferences (consent preferences and HMAC keys) across app installations in a preferences group. This will also sync welcomes to ensure that you have all potential new installations before syncing.
-
-This is a lighter-weight alternative to syncing preferences using [`syncAll`](/inboxes/sync-and-syncall#sync-all-new-conversations-messages-and-preferences) or [`streamAll`](/inboxes/list-and-stream#stream-all-group-chat-and-dm-messages-and-preferences).
-
-:::code-group
-
-```js [Browser]
-await client.preferences.sync();
-```
-
-```js [Node]
-await client.preferences.sync();
-```
-
-```tsx [React Native]
-await client.preferences.sync()
-```
-
-```kotlin [Kotlin]
-client.preferences.sync()
-```
-
-```swift [Swift]
-try await client.preferences.sync()
-```
-
-:::
-
-
-## pages/inboxes/manage-inboxes.mdx
-# Manage XMTP inboxes and installations
-
-With XMTP, a user can have one or more inboxes they use to access their messages. An inbox can have multiple identities associated with it. An identity has a kind, such as EOA or SCW, and a string, which in the case of an EOA or SCW, is an Ethereum address. However, this extensible inbox-based identity model means that support for additional kinds of identities, such as Passkey or Bitcoin, can be added in the future.
-
-All messages associated with these identities flow through the one inbox ID and are accessible in any XMTP app.
-
-The first time someone uses your app with an identity they've never used with any app built with XMTP, your app creates an inbox ID and installation ID associated with the identity. To do this, you [create a client](/inboxes/create-a-client) for their identity. 
-
-The client creates an inbox ID and installation ID associated with the identity. By default, this identity is designated as the recovery identity. A recovery identity will always have the same inbox ID and cannot be reassigned to a different inbox ID.
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/create-inbox-install.png" width="250px" />
-</div>
-
-When you make subsequent calls to create a client for the same identity and a local database is not present, the client uses the same inbox ID, but creates a new installation ID.
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-installation.png" width="250px" />
-</div>
-
-You can enable a user to add multiple identities to their inbox. Added identities use the same inbox ID and the installation ID of the installation used to add the identity.
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-id.png" width="350px" />
-</div>
-
-You can enable a user to remove an identity from their inbox. You cannot remove the recovery identity.
-
-## Add an identity to an inbox
-
-:::warning[Warning]
-
-This function is delicate and should be used with caution. Adding an identity to an inbox ID B when it's already associated with an inbox ID A will cause the identity to lose access to inbox ID A.
-
-:::
-
-:::code-group
-
-```tsx [Browser]
-await client.unsafe_addAccount(signer, true)
-```
-
-```tsx [Node]
-await client.unsafe_addAccount(signer, true)
-```
-
-```jsx [React Native]
-await client.addAccount(identityToAdd)
-```
-
-```kotlin [Kotlin]
-client.addAccount(identityToAdd)
-```
-
-```swift [Swift]
-try await client.addAccount(newAccount: identityToAdd)
-```
-
-:::
-
-## Remove an identity from an inbox
-
-:::tip[Note]
- A recovery identity cannot be removed. For example, if an inbox has only one associated identity, that identity serves as the recovery identity and cannot be removed.
-:::
-
-:::code-group
-
-```tsx [Browser]
-await client.removeAccount(identifier)
-```
-
-```tsx [Node]
-await client.removeAccount(identifier)
-```
-
-```jsx [React Native]
-await client.removeAccount(recoveryIdentity, identityToRemove)
-```
-
-```kotlin [Kotlin]
-client.removeAccount(recoveryIdentity, identityToRemove)
-```
-
-```swift [Swift]
-try await client.removeAccount(recoveryIdentity: recoveryIdentity, identityToRemove: identityToRemove)
-```
-
-:::
-
-## Revoke installations
-
-### 🎥 walkthrough: Revoking installations
-
-This video provides a walkthrough of revoking installations, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/MIw9x1Z4WXw?si=4bcbfkHTDvsM0uDG" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
-
-### Revoke all other installations
-
-You can revoke all installations other than the currently accessed installation.
+- If `maybeForked` returns `true`, it is highly likely that the group chat is forked.
+- If `maybeForked` returns `false`, it is highly likely that the group chat is NOT forked.
 
-For example, consider a user using this current installation:
+To learn about group chat forks, see [MLS Group State Forks: What, Why, How](https://cryspen.com/post/mls-fork-resolution/).
 
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/current-install-id.png" width="350px" />
-</div>
+If you believe you are experiencing a forked group, please [open an issue](https://github.com/xmtp/libxmtp/issues) in the LibXMTP repo to get support. Please include logs, the epoch, and other fork details.
 
-When the user revokes all other installations, the action removes their identity's access to all installations other than the current installation:
+Forked groups are not recoverable. Your options are to:
 
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/revoke-install-id.png" width="350px" />
-</div>
+- Remove all members from the forked group and then re-add them to the group.
+- Start a new group.
 
-:::code-group
+## File logging
 
-```tsx [Browser]
-await client.revokeAllOtherInstallations()
-```
-
-```tsx [Node]
-await client.revokeAllOtherInstallations()
-```
-
-```jsx [React Native]
-await client.revokeAllOtherInstallations(recoveryIdentity)
-```
-
-```kotlin [Kotlin]
-client.revokeAllOtherInstallations(recoveryIdentity)
-```
-
-```swift [Swift]
-try await client.revokeAllOtherInstallations(signingKey: recoveryIdentity)
-```
-
-:::
-
-## View the inbox state
-
-Find an `inboxId` for an identity:
-
-:::code-group
-
-```tsx [Browser]
-const inboxState = await client.preferences.inboxState()
-```
-
-```tsx [Node]
-const inboxState = await client.preferences.inboxState()
-```
-
-```jsx [React Native]
-const inboxId = await client.inboxIdFromIdentity(identity)
-```
-
-```kotlin [Kotlin]
-val inboxId = client.inboxIdFromIdentity(identity)
-```
-
-```swift [Swift]
-let inboxId = try await client.inboxIdFromIdentity(identity: identity)
-```
-
-:::
-
-View the state of any inbox to see the identities, installations, and other information associated with the `inboxId`.
-
-**Sample request**
-
-:::code-group
-
-```tsx [Browser]
-// the second argument is optional and refreshes the state from the network.
-const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
-```
-
-```tsx [Node]
-// the second argument is optional and refreshes the state from the network.
-const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
-```
-
-```jsx [React Native]
-const state = await client.inboxState(true)
-const states = await client.inboxStates(true, [inboxId, inboxId])
-```
-
-```kotlin [Kotlin]
-val state = client.inboxState(true) 
-val states = client.inboxStatesForInboxIds(true, listOf(inboxID, inboxID))
-```
-
-```swift [Swift]
-let state = try await client.inboxState(refreshFromNetwork: true)
-let states = try await client.inboxStatesForInboxIds(
-	refreshFromNetwork: true,
-	inboxIds: [inboxID, inboxID]
-)
-```
-:::
-
-**Sample response**
-
-```json
-InboxState
-{
-  "recoveryIdentity": "string",
-  "identities": [
-    {
-      "kind": "ETHEREUM",
-      "identifier": "string",
-      "relyingPartner": "string"
-    },
-    {
-      "kind": "PASSKEY",  // not yet supported; provided as an example only.
-      "identifier": "string",
-      "relyingPartner": "string"
-    }
-  ],
-  "installations": ["string"],
-  "inboxId": "string"
-}
-```
-
-## FAQ
-
-### What happens when a user removes an identity?
-
-Consider an inbox with three associated identities:
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/three-ids.png" width="650px" />
-</div>
-
-If the user removes an identity from the inbox, the identity no longer has access to the inbox it was removed from.
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/removed-id.png" width="650px" />
-</div>
-
-The identity can no longer be added to or used to access conversations in that inbox. If someone sends a message to the identity, the message is not associated with the original inbox. If the user logs in to a new installation with the identity, this will create a new inbox ID.
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/new-inbox-id.png" width="650px" />
-</div>
-
-### How is the recovery identity used?
-
-The recovery identity and its signer can be used to sign transactions that remove identities and revoke installations.
-
-For example, Alix can give Bo access to their inbox so Bo can see their groups and conversations and respond for Alix.
-
-If Alix decides they no longer want Bo have access to their inbox, Alix can use their recovery identity signer to remove Bo. 
-
-However, while Bo has access to Alix's inbox, Bo cannot remove Alix from their own inbox because Bo does not have access to Alix's recovery identity signer.
-
-### If a user created two inboxes using two identities, is there a way to combine the inboxes?
-
-If a user logs in with an identity with address 0x62EE...309c and creates inbox 1 and then logs in with an identity with address 0xd0e4...DCe8 and creates inbox 2; there is no way to combine inbox 1 and 2.
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inboxes.png" width="350px" />
-</div>
-
-You can add an identity with address 0xd0e4...DCe8 to inbox 1, but both identities with addresses 0x62EE...309c and 0xd0e4...DCe8 would then have access to inbox 1 only. The identity with address 0xd0e4...DCe8 would no longer be able to access inbox 2. 
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inbox-remap-id.png" width="350px" />
-</div>
-
-To help users avoid this state, ensure that your UX surfaces their ability to add multiple identities to a single inbox.
-
-### What happens if I remove an identity from an inbox ID and then initiate a client with the private key of the removed identity?
-
-**Does the client create a new inbox ID or does it match it with the original inbox ID the identity was removed from?**
-
-The identity used to initiate a client should be matched to its original inbox ID. 
-
-You do have the ability to rotate inbox IDs if a user reaches the limit of 257 identity actions (adding, removing, or revoking identities or installations). Hopefully, users won’t reach this limit, but if they do, inbox IDs have a nonce and can be created an infinite number of times. 
-
-However, anytime a new inbox ID is created for an identity, the conversations and messages in any existing inbox ID associated with the identity are lost.
-
-### I have multiple identities associated with one inbox ID. If I log in with any one of these identities, does it access that inbox ID, or does it create a new inbox ID?
-
-The identity accesses that inbox ID and does not create a new inbox ID.
-
-For example, let's say that you create a client with an identity with address 0x62EE...309c. Inbox ID 1 is generated from that identity. 
-
-<div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1.png" width="150px" />
-</div>
-
-If you then add an identity with address 0xd0e4...DCe8 to inbox ID 1, the identity is also associated with inbox ID 1.
-
-If you then log into a new app installation with the identity with address 0xd0e4...DCe8, it accesses inbox ID 1 and does not create a new inbox ID.
-
-Once the identity with address 0xd0e4...DCe8 has been associated with inbox ID 1, it can then be used to log into inbox ID 1 using a new app installation.
-
-<div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2.png" width="350px" />
-</div>
-
-The inverse is also true. Let's say an identity with address 0xd0e4...DCe8 was previously used to create and log into inbox ID 2.
-
-<div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-inbox2-id2.png" width="350px" />
-</div>
-
-If the identity is then added as an associated identity to inbox ID 1, the identity will no longer be able to log into inbox ID 2.
-
-<div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2-inverse.png" width="350px" />
-</div>
-
-To enable the user of the identity with address 0xd0e4...DCe8 to log into inbox ID 2 again, you can use the recovery identity for inbox ID 2 to add a different identity to inbox ID 2 and have the user use that identity access it.
-
-If you are interested in providing this functionality in your app and want some guidance, post to the [XMTP Community Forums](https://community.xmtp.org).
-
-
-## pages/inboxes/history-sync.mdx
-# Enable history sync for apps built with XMTP
-
-:::warning[This feature is in beta]
-
-History sync is still in active development as we work on its reliability and performance. To provide feedback on this feature, please post to [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
-
-:::
-
-Enable the history sync feature to give your users a way to sync decrypted historical data from an existing app installation to a new app installation.
-
-This historical data includes:
-
-- Conversations
-- Conversation messages
-- Consent state
-- HMAC keys (for push notifications)
-
-History sync enables your users pick up conversations where they left off, regardless of the app installation they use. All they need is a pre-existing and online app installation to provide the data.
-
-## 🎥 walkthrough: History sync
-
-This video provides a walkthrough of history sync, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/_FtNqtjk-ls?si=uZ_Mnh9phF6y2h-O" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
-
-## Enable history sync
-
-History sync is enabled by default and runs automatically. When [creating a client](/inboxes/create-a-client), the `historySyncUrl` client option is dynamically set to a default history sync server URL based on your `env` client option setting.
-
-- When `env` is set to `dev`, the `historySyncUrl` is set to `https://message-history.dev.ephemera.network/`
-- When `env` is set to `production`, the `historySyncUrl` is set to `https://message-history.production.ephemera.network`
-
-These default servers are managed and operated by [Ephemera](https://ephemerahq.com/), a steward of the development and adoption of XMTP.
-
-You can choose to [run your own server](https://github.com/xmtp/xmtp-message-history-server) and set the `historySyncUrl` to your server's URL.
-
-## How history sync works
+These file logging functions enable the XMTP rust process to write directly to persistent log files that roll during every hour of active usage and provide a 6-hour window of logs. This can be especially helpful when debugging group chat errors and other complex issues.
 
-When your app initializes an XMTP client and a `historySyncUrl` client option is present, history sync automatically triggers an initial sync request and creates an encrypted payload.
+The file logs complement Android and iOS system logs, which rely on memory buffer constraints, but often don't go back far enough to help catch when an issue occurs.
 
-<div>
-    <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step1.png" width="600px" />
-</div>
+To use file logging, call the following static functions:
 
-History sync then uploads the payload, sends a sync reply, and pulls all conversation state history into the new app installation, merging it with the existing app installations in the sync group.
+- `Client.activatePersistentLibXMTPLogWriter()`: Use to activate the file logging feature.
+  - We recommend using `LogLevel.Debug`, `LogRotation.Hourly`, and a `logMaxFiles` value of 5-10. Log files can grow to ~100mb each with active clients on debug level in an hour of usage.
+- `Client.getXMTPLogFilePaths()`: Use to get the full paths of log files written so far. This is useful for passing to iOS or Android Share functions.
+- Here are additional helper static functions in the XMTP Client object:
+  - `deactivatePersistentLibXMTPLogWriter()`
+  - `isLogWriterActive()`
+  - `readXMTPLogFile()`
+  - `clearXMTPLogs()`
 
-<div>
-    <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step2.png" width="600px" />
-</div>
+For an example UI implementation, see PR to [add new persistent log debug menu options](https://github.com/ephemeraHQ/convos-app/pull/6) to the Convos app, built with XMTP.
 
-Ongoing updates to history are streamed automatically. Updates, whether for user consent preferences or messages, are sent across the sync group, ensuring all app installations have up-to-date information.
+## Network statistics
 
-History syncs are accomplished using these components:
+You can use these statistics to see which and how many API, identity, and streaming calls are going across the network, which can help you better manage network usage and debug potential rate limiting issues.
 
-- Sync group
-- Sync worker
-- History server
+A client has a function called `client.debugInformation` These statistics are maintained per client instance, so each app installation has its own separate counter. Each one is a rolling counter for the entire session since the gRPC client was created. To get a snapshot of statistics at a moment in time, you can check the counter, run the action, get the counter again, and then diff the counter with the original counter.
 
-### Sync group
+### Get aggregated statistics
 
-A sync group is a special [Messaging Layer Security](/protocol/security) group that includes all of the user’s devices. The sync group is used to send serialized sync messages across the user's devices. The sync group is filtered out of most queries by default so they don’t appear in the user’s inbox.
+Use the `client.debugInformation.aggregateStatistics` function to return these aggregated statistics.
 
-### Sync worker
-
-A sync worker is a spawned background worker that listens for sync events, and processes them accordingly. This worker:
-
-- Emits and updates consent
-- Creates and consumes archive payloads for and from other devices
-- Keeps preferences synced across devices
-
-### History server
-
-A history server acts as a bucket that holds encrypted sync payloads. The URL location of these payloads and the password (cipher encryption key) to decrypt these payloads is sent over the sync group for the recipient to decrypt.
-
-## FAQ
-
-### A user logged into a new app installation and doesn't see their conversations. What's going on?
-
-A debounce feature checks for new app installations, at most, once every 30 minutes. To circumvent the cool-down timer, send a message using a pre-existing app installation. 
-
-Once [this issue](https://github.com/xmtp/libxmtp/issues/1309) is resolved, conversations will appear almost instantly.
-
-### A user logged into a new app installation and sees their conversations, but no messages. What's going on?
-
-Ensure that you've initiated a call to [sync messages](#sync-messages) and that the pre-existing app installation is online to receive the sync request, process and encrypt the payload, upload it to the history server, and send a sync reply message to the new app installation.
-
-### I called a sync method (messages, consent state, or conversations), but nothing is happening. What's going on?
-
-After requesting a sync for one app installation, ensure that the pre-existing app installation is online to receive the sync request.
-
-
-## pages/inboxes/pick-an-sdk.md
-# Pick an SDK
-
-Choose the appropriate XMTP SDK based on your app platform and development needs.
-
-## Web
-
-This SDK is designed for web-based apps, offering seamless integration with browser environments: [Browser SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk)
-
-## Server
-
-This SDK is designed for backend applications, offering seamless integration with server environments: [Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk)
-
-## Mobile
-
-These SDKs provide native support for mobile app development across different platforms and frameworks.
-
-- [React Native SDK](https://github.com/xmtp/xmtp-react-native) 
-
-- [Kotlin SDK](https://github.com/xmtp/xmtp-android)
-
-- [Swift SDK](https://github.com/xmtp/xmtp-ios)
-
-
-## pages/inboxes/list-and-stream.mdx
-# List and stream conversations and messages
-
-## List existing conversations
-
-Get a list of existing group chat and DM conversations in the local database.
-
-By default, `list` returns only conversations with a [consent state](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set) of allowed or unknown.
-
-We recommend listing allowed conversations only. This ensures that spammy conversations with a consent state of unknown don't degrade the user experience.
-
-To list all conversations regardless of consent state, pass `[ALLOWED, UNKNOWN, DENIED]`.
-
-Conversations are listed in descending order by their `lastMessage` created at value. If a conversation has no messages, the conversation is ordered by its `createdAt` value.
-
-:::code-group
-
-```js [Browser]
-const allConversations = await client.conversations.list(["allowed"]);
-const allGroups = await client.conversations.listGroups(["allowed"]);
-const allDms = await client.conversations.listDms(["allowed"]);
-```
-
-```js [Node]
-const allConversations = await client.conversations.list(["allowed"]);
-const allGroups = await client.conversations.listGroups(["allowed"]);
-const allDms = await client.conversations.listDms(["allowed"]);
-```
-
-```tsx [React Native]
-// List Conversation items
-await alix.conversations.list(["allowed"]);
-
-// List Conversation items and return only the fields set to true. Optimize data transfer
-// by requesting only the fields the app needs.
-await alix.conversations.list(
-  {
-    members: false,
-    consentState: false,
-    description: false,
-    creatorInboxId: false,
-    addedByInboxId: false,
-    isActive: false,
-    lastMessage: true,
-  },
-);
-```
-
-```kotlin [Kotlin]
-// List conversations (both groups and dms)
-val conversations = alix.conversations.list()
-val orderFilteredConversations = client.conversations.list(consentState: ALLOWED)
-
-// List just dms
-val conversations = alix.conversations.listDms()
-val orderFilteredConversations = client.conversations.listDms(consentState: ALLOWED)
-
-//List just groups
-val conversations = alix.conversations.listGroups()
-val orderFilteredConversations = client.conversations.listGroups(consentState: ALLOWED)
-
-```
-
-```swift [Swift]
-// List conversations (both groups and dms)
-let conversations = try await alix.conversations.list()
-let orderFilteredConversations = try await client.conversations.list(consentState: .allowed)
-
-// List just dms
-let conversations = try await alix.conversations.listDms()
-let orderFilteredConversations = try await client.conversations.listDms(consentState: .allowed)
-
-//List just groups
-let conversations = try await alix.conversations.listGroups()
-let orderFilteredConversations = try await client.conversations.listGroups(consentState: .allowed)
+```text
+Aggregate Stats:
+============ Api Stats ============
+UploadKeyPackage        1
+FetchKeyPackage         2
+SendGroupMessages       5
+SendWelcomeMessages     1
+QueryGroupMessages      7
+QueryWelcomeMessages    0
+============ Identity ============
+PublishIdentityUpdate    1
+GetIdentityUpdatesV2     4
+GetInboxIds             2
+VerifySCWSignatures     0
+============ Stream ============
+SubscribeMessages        0
+SubscribeWelcomes       0
 ```
 
-:::
+### Get an individual statistic
 
-## List a user's active conversations
+You can return an individual statistic as a number. For example, you can run `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeypackage` only.
 
-The `isActive()` method determines whether the current user is still an active member of a group conversation. For example:
+### Statistic descriptions
 
-- When a user is added to a group, `isActive()` returns `true` for that user
-- When a user is removed from a group, `isActive()` returns `false` for that user
+#### API statistics
 
-You can use a user's `isActive: true` value as a filter parameter when listing conversations. You can potentially have a separate section for "archived" or "inactive" conversations where you could use `isActive: false`.
+| Statistic | Description |
+|-----------|-------------|
+| UploadKeyPackage | Number of times key packages have been uploaded. |
+| FetchKeyPackage | Number of times key packages have been fetched. |
+| SendGroupMessages | Number of times messages have been sent to group chat and DM conversations. |
+| SendWelcomeMessages | Number of times welcome messages have been sent. |
+| QueryGroupMessages | Number of times queries have been made to fetch messages being sent to group chat and DM conversations. |
+| QueryWelcomeMessages | Number of times queries have been made to fetch welcome messages. |
 
-## Stream all group chats and DMs
+#### Identity statistics
 
-Listens to the network for new group chats and DMs. Whenever a new conversation starts, it triggers the provided callback function with a [`ConversationContainer` object](#conversationcontainer-interface). This allows the client to immediately respond to any new group chats or DMs initiated by other users.
+| Statistic | Description |
+|-----------|-------------|
+| PublishIdentityUpdate | Number of times identity updates have been published. |
+| GetIdentityUpdatesV2 | Number of times identity updates have been fetched. |
+| GetInboxIds | Number of times inbox ID queries have been made. |
+| VerifySCWSignatures | Number of times smart contract wallet signature verifications have been performed. |
 
-:::code-group
-
-```js [Browser]
-const stream = await client.conversations.stream();
-
-try {
-  for await (const conversation of stream) {
-    // Received a conversation
-    console.log("New conversation:", conversation);
-  }
-} catch (error) {
-  // Log any stream errors
-  console.error(error);
-}
-```
-
-```js [Node]
-const stream = await client.conversations.stream();
-// to stream only groups, use `client.conversations.streamGroups()`
-// to stream only dms, use `client.conversations.streamDms()`
-
-try {
-  for await (const conversation of stream) {
-    // Received a conversation
-  }
-} catch (error) {
-  // log any stream errors
-  console.error(error);
-}
-```
-
-```tsx [React Native]
-await alix.conversations.stream(async (conversation: Conversation<any>) => {
-  // Received a conversation
-});
-```
-
-```kotlin [Kotlin]
-alix.conversations.stream(type: /* OPTIONAL DMS, GROUPS, ALL */).collect {
-  // Received a conversation
-}
-```
-
-```swift [Swift]
-for await convo in try await alix.conversations.stream(type: /* OPTIONAL .dms, .groups, .all */) {
-  // Received a conversation
-}
-```
-
-:::
-
-## Stream all group chat and DM messages and preferences
-
-Listens to the network for new messages within all active group chats and DMs, as well as [preference updates](/inboxes/sync-preferences). 
-
-Whenever a new message is sent to any of these conversations, the callback is triggered with a `DecodedMessage` object. This keeps the inbox up to date by streaming in messages as they arrive.
-
-By default, `streamAll` streams only conversations with a [consent state](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set) of allowed or unknown.
-
-We recommend streaming messages for allowed conversations only. This ensures that spammy conversations with a consent state of unknown don't take up networking resources. This also ensures that unwanted spam messages aren't stored in the user's local database.
-
-To stream all conversations regardless of consent state, pass `[Allowed, Unknown, Denied]`.
-
-:::warning[Important]
-
-The stream is infinite. Therefore, any looping construct used with the stream won't terminate unless you explicitly initiate the termination. You can initiate the termination by breaking the loop or by making an external call to `return`.
-
-:::
-
-:::code-group
-
-```js [Browser]
-const stream = await client.conversations.streamAllMessages(["allowed"]);
- 
-try {
-  for await (const message of stream) {
-    // Received a message
-    console.log("New message:", message);
-  }
-} catch (error) {
-  // Log any stream errors
-  console.error(error);
-}
-```
-
-```js [Node]
-// stream all messages from all conversations
-const stream = await client.conversations.streamAllMessages(["allowed"]);
- 
-// stream only group messages
-const stream = await client.conversations.streamAllGroupMessages(["allowed"]);
- 
-// stream only dm messages
-const stream = await client.conversations.streamAllDmMessages(["allowed"]);
- 
-try {
-  for await (const message of stream) {
-    // Received a message
-  }
-} catch (error) {
-  // log any stream errors
-  console.error(error);
-}
-```
-
-```tsx [React Native]
-await alix.conversations.streamAllMessages(
-  async (message: DecodedMessage<any>) => {
-    // Received a message
-  },
-  { consentState: ["allowed"] }
-);
-```
-
-```kotlin [Kotlin]
-alix.conversations.streamAllMessages(type: /* OPTIONAL DMS, GROUPS, ALL */, consentState: listOf(ConsentState.ALLOWED)).collect {
-  // Received a message
-}
-```
-
-```swift [Swift]
-for await message in try await alix.conversations.streamAllMessages(type: /* OPTIONAL .dms, .groups, .all */, consentState: [.allowed]) {
-  // Received a message
-}
-```
-
-:::
-
-## Handle unsupported content types
-
-As more [custom](/inboxes/content-types/content-types#create-a-custom-content-type) and [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
-
-Each message is accompanied by a `fallback` property, which offers a descriptive string representing the content type's expected value. It's important to note that fallbacks are immutable and are predefined in the content type specification. In instances where `fallback` is `undefined`, such as read receipts, it indicates that the content is not intended to be rendered. If you're venturing into creating custom content types, you're provided with the flexibility to specify a custom fallback string. For a deeper dive into this, see [Build custom content types](/inboxes/content-types/custom).
-
-:::code-group
-
-```js [Browser]
-const codec = client.codecFor(content.contentType);
-if (!codec) {
-  /*Not supported content type*/
-  if (message.fallback !== undefined) {
-    return message.fallback;
-  }
-  // Handle other types like ReadReceipts which are not meant to be displayed
-}
-```
-
-```js [Node]
-const codec = client.codecFor(content.contentType);
-if (!codec) {
-  /*Not supported content type*/
-  if (message.fallback !== undefined) {
-    return message.fallback;
-  }
-  // Handle other types like ReadReceipts which are not meant to be displayed
-}
-```
-
-```jsx [React Native]
-//contentTypeID has the following structure `${contentType.authorityId}/${contentType.typeId}:${contentType.versionMajor}.${contentType.versionMinor}`;
-const isRegistered = message.contentTypeID in client.codecRegistry;
-if (!isRegistered) {
-  // Not supported content type
-  if (message?.fallback != null) {
-    return message?.fallback;
-  }
-  // Handle other types like ReadReceipts which are not meant to be displayed
-}
-```
-
-```kotlin [Kotlin]
-val codec = client.codecRegistry.find(options?.contentType)
-if (!codec) {
-  /*Not supported content type*/
-  if (message.fallback != null) {
-    return message.fallback
-  }
-  // Handle other types like ReadReceipts which are not meant to be displayed
-}
-```
-
-```swift [Swift]
-let codec = client.codecRegistry.find(for: contentType)
-if (!codec) {
-  /*Not supported content type*/
-  if (message.fallback != null) {
-    return message.fallback
-  }
-  // Handle other types like ReadReceipts which are not meant to be displayed
-}
-```
+#### Stream statistics
 
-:::
+| Statistic | Description |
+|-----------|-------------|
+| SubscribeMessages | Number of times message subscription requests have been made. This is streaming messages in a conversation. |
+| SubscribeWelcomes | Number of times welcome message subscription requests have been made. This is streaming conversations. |
 
 
 ## pages/inboxes/create-a-signer.md
@@ -3236,762 +1437,18 @@ public struct SCWallet: SigningKey {
 :::
 
 
-## pages/inboxes/group-permissions.mdx
-# Manage group permissions
+## pages/inboxes/references.md
+---
+description: "Access reference documentation for each XMTP client SDK"
+---
 
-Robust group chat permissions are key to providing users with a friendly and safe group chat experience.
+# XMTP SDK reference docs
 
-## Understand the group permissions system
+Use these reference docs as guides to integrating the capabilities of XMTP SDKs in your apps.
 
-### Member statuses
+- [Reference docs](https://xmtp.github.io/xmtp-react-native/modules.html) for the [React Native SDK](https://github.com/xmtp/xmtp-react-native)
 
-Member statuses are the roles that can be assigned to each participant (inbox ID) in a group chat. These are the available member statuses:
-
-- Member
-  - Everyone in a group chat is a member. A member can be granted admin or super admin status. If a member's admin or super admin status is removed, they are still a member of the group.
-- Admin
-- Super admin
-
-### Options
-
-Use options to assign a role to a permission. These are the available options:
-
-- All members
-- Admin only
-  - Includes super admins
-- Super admin only
-
-### Permissions
-
-Permissions are the actions a group chat participant can be allowed to take. These are the available permissions:
-
-- Grant admin status to a member
-- Remove admin status from a member
-- Add a member to the group
-- Remove a member from the group
-- Update [group metadata](/inboxes/group-metadata), such as group name, description, and image
-- Update group permissions on an item-by-item basis, such as calling `updateNamePermission` or `updateAddMemberPermission` . To learn more, see [Group.kt](https://github.com/xmtp/xmtp-android/blob/main/library/src/main/java/org/xmtp/android/library/Group.kt#L251-L313) in the xmtp-android SDK repo.
-
-The following permissions can be assigned by super admins only. This helps ensure that a “regular” admin cannot remove the super admin or otherwise destroy a group.
-
-- Grant super admin status to a member
-- Remove super admin status from a member
-- Update group permissions
-
-## How the group permissions system works
-
-When a group is created, all groups have the same initial member "roles" set:
-
-- There is one super admin, and it is the group creator
-- There are no admins
-- Each user added to the group starts out as a member
-
-The super admin has all of the [available permissions](#permissions) and can use them to adjust the group’s permissions and options.
-
-As the app developer, you can provide a UI that enables group participants to make further adjustments. For example, you can give the super admin the following permission options for group members when creating the group:
-
-- Add members
-- Update group metadata
-
-<div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/group-perm-toggles.png" width="300px" />
-</div>
-
-You can use member statuses, options, and permissions to create a custom policy set. The following table represents the valid policy options for each of the permissions:
-
-| Permission | Allow all | Deny all  | Admin only | Super admin only |
-| --- | --- | --- | --- | --- |
-| Add member | ✅ | ✅ | ✅ | ✅ |
-| Remove member | ✅ | ✅ | ✅ | ✅ |
-| Add admin | ❌ | ✅ | ✅ | ✅ |
-| Remove admin | ❌ | ✅ | ✅ | ✅ |
-| Update group permissions | ❌ | ❌ | ❌ | ✅ |
-| Update group metadata | ✅ | ✅ | ✅ | ✅ |
-
-If you aren’t opinionated and don’t set any permissions and options, groups will default to using the delivered `All_Members` policy set, which applies the following permissions and options:
-
-- Add member - All members
-- Remove member - Admin only
-- Add admin - Super admin only
-- Remove admin - Super admin only
-- Update group permissions - Super admin only
-- Update group metadata - All members
-
-To learn more about the `All_Members` and `Admin_Only` policy sets, see [group_permissions.rs](https://github.com/xmtp/libxmtp/blob/85dd6d36f46db1ed74fe98273eea6871fea2e078/xmtp_mls/src/groups/group_permissions.rs#L1192-L1226) in the LibXMTP repo.
-
-## Manage group chat admins
-
-### Check if inbox ID is an admin
-
-:::code-group
-
-```js [Browser]
-const isAdmin = group.isAdmin(inboxId);
-```
-
-```js [Node]
-const isAdmin = group.isAdmin(inboxId);
-```
-
-```tsx [React Native]
-// Assume group is an existing group chat object for client
-const isAdmin = await group.isAdmin(adminClient.inboxID);
-```
-
-```kotlin [Kotlin]
-//Assume group is an existing group chat object for client
-val isInboxIDAdmin = group.isAdmin(inboxId)
-```
-
-```swift [Swift]
-// Assume group is an existing group chat object for client
-try group.isAdmin(client.inboxID)
-```
-
-:::
-
-### Check if inbox ID is a super admin
-
-:::code-group
-
-```js [Browser]
-const isSuperAdmin = group.isSuperAdmin(inboxId);
-```
-
-```js [Node]
-const isSuperAdmin = group.isSuperAdmin(inboxId);
-```
-
-```tsx [React Native]
-//Assume group is an existing group chat object for client
-const isSuperAdmin = await group.isSuperAdmin(client.inboxID);
-```
-
-```kotlin [Kotlin]
-//Assume group is an existing group chat object for client
-val isInboxIDSuperAdmin = group.isSuperAdmin(inboxId)
-```
-
-```swift [Swift]
-try group.isSuperAdmin(inboxid: inboxID)
-```
-
-:::
-
-### List admins
-
-:::code-group
-
-```js [Browser]
-const admins = group.admins;
-```
-
-```js [Node]
-const admins = group.admins;
-```
-
-```tsx [React Native]
-await group.listAdmins();
-```
-
-```kotlin [Kotlin]
-// Returns a list of inboxIds of Admins
-group.listAdmins()
-```
-
-```swift [Swift]
-try group.listAdmins()
-```
-
-:::
-
-### List super admins
-
-:::code-group
-
-```js [Browser]
-const superAdmins = group.superAdmins;
-```
-
-```js [Node]
-const superAdmins = group.superAdmins;
-```
-
-```tsx [React Native]
-await group.listSuperAdmins();
-```
-
-```kotlin [Kotlin]
-// Returns a list of inboxIds of Super Admins
-group.listSuperAdmins()
-```
-
-```swift [Swift]
-try group.listSuperAdmins()
-```
-
-:::
-
-### Add admin status to inbox ID
-
-:::code-group
-
-```js [Browser]
-await group.addAdmin(inboxId);
-```
-
-```js [Node]
-await group.addAdmin(inboxId);
-```
-
-```tsx [React Native]
-await group.addAdmin(client.inboxID);
-```
-
-```kotlin [Kotlin]
-group.addAdmin(inboxId)
-```
-
-```swift [Swift]
-try await group.addAdmin(inboxid: inboxID)
-```
-
-:::
-
-### Add super admin status to inbox ID
-
-:::code-group
-
-```js [Browser]
-await group.addSuperAdmin(inboxId);
-```
-
-```js [Node]
-await group.addSuperAdmin(inboxId);
-```
-
-```tsx [React Native]
-await group.addSuperAdmin(client.inboxID);
-```
-
-```kotlin [Kotlin]
-group.addSuperAdmin(inboxId)
-```
-
-```swift [Swift]
-try await group.addSuperAdmin(inboxid: inboxID)
-```
-
-:::
-
-### Remove admin status from inbox ID
-
-:::code-group
-
-```js [Browser]
-await group.removeAdmin(inboxId);
-```
-
-```js [Node]
-await group.removeAdmin(inboxId);
-```
-
-```tsx [React Native]
-await group.removeAdmin(client.inboxID);
-```
-
-```kotlin [Kotlin]
-group.removeAdmin(inboxId)
-```
-
-```swift [Swift]
-try await group.removeAdmin(inboxid: inboxid)
-```
-
-:::
-
-### Remove super admin status from inbox ID
-
-:::code-group
-
-```js [Browser]
-await group.removeSuperAdmin(inboxId);
-```
-
-```js [Node]
-await group.removeSuperAdmin(inboxId);
-```
-
-```tsx [React Native]
-await group.removeSuperAdmin(client.inboxId);
-```
-
-```kotlin [Kotlin]
-group.removeSuperAdmin(inboxId)
-```
-
-```swift [Swift]
-try await group.removeSuperAdmin(inboxid: inboxID)
-```
-
-:::
-
-## Manage group chat membership
-
-### Add members by inbox ID
-
-The maximum group chat size is 220 members.
-
-:::code-group
-
-```js [Browser]
-await group.addMembers([inboxId]);
-```
-
-```js [Node]
-await group.addMembers([inboxId]);
-```
-
-```tsx [React Native]
-await group.addMembers([inboxId]);
-```
-
-```kotlin [Kotlin]
-group.addMembers(listOf(client.inboxId))
-```
-
-```swift [Swift]
-try await group.addMembers(inboxIds: [inboxId])
-```
-
-:::
-
-### Remove member by inbox ID
-
-:::code-group
-
-```js [Browser]
-await group.removeMembers([inboxId]);
-```
-
-```js [Node]
-await group.removeMembers([inboxId]);
-```
-
-```tsx [React Native]
-await group.removeMembers([inboxId]);
-```
-
-```kotlin [Kotlin]
-group.removeMembers(listOf(inboxId))
-```
-
-```swift [Swift]
-try await group.removeMembers(inboxIds: [inboxId])
-```
-
-:::
-
-### Get inbox IDs for members
-
-:::code-group
-
-```js [Browser]
-const inboxId = await client.findInboxIdByIdentities([bo.identity, caro.identity]);
-```
-
-```js [Node]
-const inboxId = await client.getInboxIdByIdentities([bo.identity, caro.identity]);
-```
-
-```tsx [React Native]
-await group.memberInboxIds();
-```
-
-```kotlin [Kotlin]
-val members = group.members()
-val inboxIds = members.map { it.inboxId }
-
-OR
-
-val inboxId = client.inboxIdFromIdentity(peerIdentity)
-```
-
-```swift [Swift]
-let members = try group.members.map(\.inboxId).sorted()
-
-OR
-
-try await client.inboxIdFromIdentity(identity: peerIdentity)
-```
-
-:::
-
-### Get identities for members
-
-:::code-group
-
-```js [Browser]
-// sync group first
-await group.sync();
-
-// get group members
-const members = await group.members();
-
-// map inbox ID to account identity
-const inboxIdIdentityMap = new Map(
-  members.map((member) => [member.inboxId, member.accountIdentity])
-);
-```
-
-```js [Node]
-// sync group first
-await group.sync();
-
-// get group members
-const members = group.members;
-
-// map inbox ID to account identity
-const inboxIdIdentityMap = new Map(
-  members.map((member) => [member.inboxId, member.accountIdentity])
-);
-```
-
-```tsx [React Native]
-const members = await group.members();
-const identities = members.map((member) => member.identities);
-```
-
-```kotlin [Kotlin]
-val members = group.members()
-val identities = members.map { it.identities }
-```
-
-```swift [Swift]
-let peerMembers = try Conversation.group(group).peerInboxIds.sorted()
-```
-
-:::
-
-### Get the inbox ID that added the current member
-
-:::code-group
-
-```js [Browser]
-const addedByInboxId = group.addedByInboxId;
-```
-
-```js [Node]
-const addedByInboxId = group.addedByInboxId;
-```
-
-```tsx [React Native]
-// this API is experimental and may change in the future
-
-const addedByInboxId = await group.addedByInboxId();
-```
-
-```kotlin [Kotlin]
-val addedByInboxId = group.addedByInboxId();
-```
-
-```swift [Swift]
-try await group.addedByInboxId();
-```
-
-:::
-
-
-## pages/inboxes/group-metadata.md
-# Manage group chat metadata
-
-Group chats can have metadata, like names, descriptions, and images. Metadata can help users more easily identify their group chats. You can set group chat metadata when [creating a group chat](/inboxes/create-conversations/#create-a-new-group-chat), and get and update metadata using these methods.
-
-## Updatable group chat metadata
-
-The following group chat metadata can be updated:
-
-- `group_name`: The name of the group chat
-- `description`: A description of the group chat
-- `image_url`: A URL pointing to an image for the group chat
-- `disappearing_message_settings`: Settings for disappearing messages in the group chat. To learn more about disappearing messages, see [Support disappearing messages](/inboxes/send-messages#support-disappearing-messages)
-
-## Get a group chat name
-
-:::code-group
-
-```js [Browser]
-const groupName = group.name;
-```
-
-```js [Node]
-const groupName = group.name;
-```
-
-```tsx [React Native]
-const groupName = await group.groupName();
-```
-
-```kotlin [Kotlin]
-group.name
-```
-
-```swift [Swift]
-try group.groupname()
-```
-
-:::
-
-## Update a group chat name
-
-:::code-group
-
-```js [Browser]
-await group.updateName("New Group Name");
-```
-
-```js [Node]
-await group.updateName("New Group Name");
-```
-
-```tsx [React Native]
-await group.updateName("New Group Name");
-```
-
-```kotlin [Kotlin]
-group.updateName("New Group Name")
-```
-
-```swift [Swift]
-try await group.updateName(groupname: "New Group Name")
-```
-
-:::
-
-## Get a group chat description
-
-:::code-group
-
-```js [Browser]
-const groupDescription = group.description;
-```
-
-```js [Node]
-const groupDescription = group.description;
-```
-
-```tsx [React Native]
-const groupDescription = await group.groupDescription();
-```
-
-```kotlin [Kotlin]
-group.description
-```
-
-```swift [Swift]
-try group.groupDescription()
-```
-
-:::
-
-## Update a group chat description
-
-:::code-group
-
-```js [Browser]
-await group.updateDescription("New Group Description");
-```
-
-```js [Node]
-await group.updateDescription("New Group Description");
-```
-
-```tsx [React Native]
-await group.updateDescription("New Group Description");
-```
-
-```kotlin [Kotlin]
-group.updateDescription("New Group Description")
-```
-
-```swift [Swift]
-try await group.updateDescription(Description: "New Group Description")
-```
-
-:::
-
-## Get a group chat image URL
-
-:::code-group
-
-```js [Browser]
-const groupImageUrl = group.imageUrl;
-```
-
-```js [Node]
-const groupImageUrl = group.imageUrl;
-```
-
-```tsx [React Native]
-const groupName = await group.imageUrl();
-```
-
-```kotlin [Kotlin]
-group.imageURL
-```
-
-```swift [Swift]
-try group.imageUrl()
-```
-
-:::
-
-## Update a group chat image URL
-
-:::code-group
-
-```js [Browser]
-await group.updateImageUrl("newurl.com");
-```
-
-```js [Node]
-await group.updateImageUrl("newurl.com");
-```
-
-```tsx [React Native]
-await group.updateImageUrl("ImageURL");
-```
-
-```kotlin [Kotlin]
-group.updateImageUrl("newurl.com")
-```
-
-```swift [Swift]
-try await group.updateImageUrl(imageUrl: "newurl.com")
-```
-
-:::
-
-
-## pages/inboxes/debug-your-app.md
-# Debug your inbox app
-
-This document covers tools and features available for debugging building with XMTP, including stress testing, group chat diagnostics, logging, and network monitoring capabilities.
-
-## XMTP Debug
-
-You can use the XMTP Debug tool to stress and burn-in test your inbox app on the `local` and `dev` XMTP environments.
-
-To learn more, see [XMTP Debug](https://github.com/xmtp/libxmtp/blob/main/xmtp_debug/README.md).
-
-## Forked group debugging tool
-
-:::tip[Preventing forks is XMTP’s responsibility]
-
-This tool helps you identify potential forked groups in your app, but preventing forks in the first place is XMTP's responsibility. This diagnostic tool is just a temporary aid, not a shift in responsibility to your app.
-
-:::
-
-A conversation now has `getDebugInformation`. You can use this to see:
-
-- The MLS epoch of a group chat conversation for a member
-- Whether a group chat might be forked for a member
-- Details of a potential fork
-
-The function that provides this information is called `maybeForked` because it is difficult to be 100% certain whether a group is forked.
-
-- If `maybeForked` returns `true`, it is highly likely that the group chat is forked.
-- If `maybeForked` returns `false`, it is highly likely that the group chat is NOT forked.
-
-To learn about group chat forks, see [MLS Group State Forks: What, Why, How](https://cryspen.com/post/mls-fork-resolution/).
-
-If you believe you are experiencing a forked group, please [open an issue](https://github.com/xmtp/libxmtp/issues) in the LibXMTP repo to get support. Please include logs, the epoch, and other fork details.
-
-Forked groups are not recoverable. Your options are to:
-
-- Remove all members from the forked group and then re-add them to the group.
-- Start a new group.
-
-## File logging
-
-These file logging functions enable the XMTP rust process to write directly to persistent log files that roll during every hour of active usage and provide a 6-hour window of logs. This can be especially helpful when debugging group chat errors and other complex issues.
-
-The file logs complement Android and iOS system logs, which rely on memory buffer constraints, but often don't go back far enough to help catch when an issue occurs.
-
-To use file logging, call the following static functions:
-
-- `Client.activatePersistentLibXMTPLogWriter()`: Use to activate the file logging feature.
-  - We recommend using `LogLevel.Debug`, `LogRotation.Hourly`, and a `logMaxFiles` value of 5-10. Log files can grow to ~100mb each with active clients on debug level in an hour of usage.
-- `Client.getXMTPLogFilePaths()`: Use to get the full paths of log files written so far. This is useful for passing to iOS or Android Share functions.
-- Here are additional helper static functions in the XMTP Client object:
-  - `deactivatePersistentLibXMTPLogWriter()`
-  - `isLogWriterActive()`
-  - `readXMTPLogFile()`
-  - `clearXMTPLogs()`
-
-For an example UI implementation, see PR to [add new persistent log debug menu options](https://github.com/ephemeraHQ/convos-app/pull/6) to the Convos app, built with XMTP.
-
-## Network statistics
-
-You can use these statistics to see which and how many API, identity, and streaming calls are going across the network, which can help you better manage network usage and debug potential rate limiting issues.
-
-A client has a function called `client.debugInformation` These statistics are maintained per client instance, so each app installation has its own separate counter. Each one is a rolling counter for the entire session since the gRPC client was created. To get a snapshot of statistics at a moment in time, you can check the counter, run the action, get the counter again, and then diff the counter with the original counter.
-
-### Get aggregated statistics
-
-Use the `client.debugInformation.aggregateStatistics` function to return these aggregated statistics.
-
-```text
-Aggregate Stats:
-============ Api Stats ============
-UploadKeyPackage        1
-FetchKeyPackage         2
-SendGroupMessages       5
-SendWelcomeMessages     1
-QueryGroupMessages      7
-QueryWelcomeMessages    0
-============ Identity ============
-PublishIdentityUpdate    1
-GetIdentityUpdatesV2     4
-GetInboxIds             2
-VerifySCWSignatures     0
-============ Stream ============
-SubscribeMessages        0
-SubscribeWelcomes       0
-```
-
-### Get an individual statistic
-
-You can return an individual statistic as a number. For example, you can run `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeypackage` only.
-
-### Statistic descriptions
-
-#### API statistics
-
-| Statistic | Description |
-|-----------|-------------|
-| UploadKeyPackage | Number of times key packages have been uploaded. |
-| FetchKeyPackage | Number of times key packages have been fetched. |
-| SendGroupMessages | Number of times messages have been sent to group chat and DM conversations. |
-| SendWelcomeMessages | Number of times welcome messages have been sent. |
-| QueryGroupMessages | Number of times queries have been made to fetch messages being sent to group chat and DM conversations. |
-| QueryWelcomeMessages | Number of times queries have been made to fetch welcome messages. |
-
-#### Identity statistics
-
-| Statistic | Description |
-|-----------|-------------|
-| PublishIdentityUpdate | Number of times identity updates have been published. |
-| GetIdentityUpdatesV2 | Number of times identity updates have been fetched. |
-| GetInboxIds | Number of times inbox ID queries have been made. |
-| VerifySCWSignatures | Number of times smart contract wallet signature verifications have been performed. |
-
-#### Stream statistics
-
-| Statistic | Description |
-|-----------|-------------|
-| SubscribeMessages | Number of times message subscription requests have been made. This is streaming messages in a conversation. |
-| SubscribeWelcomes | Number of times welcome message subscription requests have been made. This is streaming conversations. |
+- [Reference docs](https://xmtp.github.io/xmtp-android/) for the [Kotlin SDK](https://github.com/xmtp/xmtp-android)
 
 
 ## pages/inboxes/send-messages.md
@@ -4574,19 +2031,2246 @@ To ensure that users understand which messages are disappearing messages and the
 - A clear indication of the message's temporary nature: Use a visual cue, such as a timestamp or a countdown, to inform users that the message will disappear after a certain period.
 
 
-## pages/inboxes/references.md
----
-description: "Access reference documentation for each XMTP client SDK"
----
+## pages/inboxes/group-permissions.mdx
+# Manage group permissions
 
-# XMTP SDK reference docs
+Robust group chat permissions are key to providing users with a friendly and safe group chat experience.
 
-Use these reference docs as guides to integrating the capabilities of XMTP SDKs in your apps.
+## Understand the group permissions system
 
-- [Reference docs](https://xmtp.github.io/xmtp-react-native/modules.html) for the [React Native SDK](https://github.com/xmtp/xmtp-react-native)
+### Member statuses
 
-- [Reference docs](https://xmtp.github.io/xmtp-android/) for the [Kotlin SDK](https://github.com/xmtp/xmtp-android)
+Member statuses are the roles that can be assigned to each participant (inbox ID) in a group chat. These are the available member statuses:
 
+- Member
+  - Everyone in a group chat is a member. A member can be granted admin or super admin status. If a member's admin or super admin status is removed, they are still a member of the group.
+- Admin
+- Super admin
+
+### Options
+
+Use options to assign a role to a permission. These are the available options:
+
+- All members
+- Admin only
+  - Includes super admins
+- Super admin only
+
+### Permissions
+
+Permissions are the actions a group chat participant can be allowed to take. These are the available permissions:
+
+- Grant admin status to a member
+- Remove admin status from a member
+- Add a member to the group
+- Remove a member from the group
+- Update [group metadata](/inboxes/group-metadata), such as group name, description, and image
+- Update group permissions on an item-by-item basis, such as calling `updateNamePermission` or `updateAddMemberPermission` . To learn more, see [Group.kt](https://github.com/xmtp/xmtp-android/blob/main/library/src/main/java/org/xmtp/android/library/Group.kt#L251-L313) in the xmtp-android SDK repo.
+
+The following permissions can be assigned by super admins only. This helps ensure that a “regular” admin cannot remove the super admin or otherwise destroy a group.
+
+- Grant super admin status to a member
+- Remove super admin status from a member
+- Update group permissions
+
+## How the group permissions system works
+
+When a group is created, all groups have the same initial member "roles" set:
+
+- There is one super admin, and it is the group creator
+- There are no admins
+- Each user added to the group starts out as a member
+
+The super admin has all of the [available permissions](#permissions) and can use them to adjust the group’s permissions and options.
+
+As the app developer, you can provide a UI that enables group participants to make further adjustments. For example, you can give the super admin the following permission options for group members when creating the group:
+
+- Add members
+- Update group metadata
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/group-perm-toggles.png" width="300px" />
+</div>
+
+You can use member statuses, options, and permissions to create a custom policy set. The following table represents the valid policy options for each of the permissions:
+
+| Permission | Allow all | Deny all  | Admin only | Super admin only |
+| --- | --- | --- | --- | --- |
+| Add member | ✅ | ✅ | ✅ | ✅ |
+| Remove member | ✅ | ✅ | ✅ | ✅ |
+| Add admin | ❌ | ✅ | ✅ | ✅ |
+| Remove admin | ❌ | ✅ | ✅ | ✅ |
+| Update group permissions | ❌ | ❌ | ❌ | ✅ |
+| Update group metadata | ✅ | ✅ | ✅ | ✅ |
+
+If you aren’t opinionated and don’t set any permissions and options, groups will default to using the delivered `All_Members` policy set, which applies the following permissions and options:
+
+- Add member - All members
+- Remove member - Admin only
+- Add admin - Super admin only
+- Remove admin - Super admin only
+- Update group permissions - Super admin only
+- Update group metadata - All members
+
+To learn more about the `All_Members` and `Admin_Only` policy sets, see [group_permissions.rs](https://github.com/xmtp/libxmtp/blob/85dd6d36f46db1ed74fe98273eea6871fea2e078/xmtp_mls/src/groups/group_permissions.rs#L1192-L1226) in the LibXMTP repo.
+
+## Manage group chat admins
+
+### Check if inbox ID is an admin
+
+:::code-group
+
+```js [Browser]
+const isAdmin = group.isAdmin(inboxId);
+```
+
+```js [Node]
+const isAdmin = group.isAdmin(inboxId);
+```
+
+```tsx [React Native]
+// Assume group is an existing group chat object for client
+const isAdmin = await group.isAdmin(adminClient.inboxID);
+```
+
+```kotlin [Kotlin]
+//Assume group is an existing group chat object for client
+val isInboxIDAdmin = group.isAdmin(inboxId)
+```
+
+```swift [Swift]
+// Assume group is an existing group chat object for client
+try group.isAdmin(client.inboxID)
+```
+
+:::
+
+### Check if inbox ID is a super admin
+
+:::code-group
+
+```js [Browser]
+const isSuperAdmin = group.isSuperAdmin(inboxId);
+```
+
+```js [Node]
+const isSuperAdmin = group.isSuperAdmin(inboxId);
+```
+
+```tsx [React Native]
+//Assume group is an existing group chat object for client
+const isSuperAdmin = await group.isSuperAdmin(client.inboxID);
+```
+
+```kotlin [Kotlin]
+//Assume group is an existing group chat object for client
+val isInboxIDSuperAdmin = group.isSuperAdmin(inboxId)
+```
+
+```swift [Swift]
+try group.isSuperAdmin(inboxid: inboxID)
+```
+
+:::
+
+### List admins
+
+:::code-group
+
+```js [Browser]
+const admins = group.admins;
+```
+
+```js [Node]
+const admins = group.admins;
+```
+
+```tsx [React Native]
+await group.listAdmins();
+```
+
+```kotlin [Kotlin]
+// Returns a list of inboxIds of Admins
+group.listAdmins()
+```
+
+```swift [Swift]
+try group.listAdmins()
+```
+
+:::
+
+### List super admins
+
+:::code-group
+
+```js [Browser]
+const superAdmins = group.superAdmins;
+```
+
+```js [Node]
+const superAdmins = group.superAdmins;
+```
+
+```tsx [React Native]
+await group.listSuperAdmins();
+```
+
+```kotlin [Kotlin]
+// Returns a list of inboxIds of Super Admins
+group.listSuperAdmins()
+```
+
+```swift [Swift]
+try group.listSuperAdmins()
+```
+
+:::
+
+### Add admin status to inbox ID
+
+:::code-group
+
+```js [Browser]
+await group.addAdmin(inboxId);
+```
+
+```js [Node]
+await group.addAdmin(inboxId);
+```
+
+```tsx [React Native]
+await group.addAdmin(client.inboxID);
+```
+
+```kotlin [Kotlin]
+group.addAdmin(inboxId)
+```
+
+```swift [Swift]
+try await group.addAdmin(inboxid: inboxID)
+```
+
+:::
+
+### Add super admin status to inbox ID
+
+:::code-group
+
+```js [Browser]
+await group.addSuperAdmin(inboxId);
+```
+
+```js [Node]
+await group.addSuperAdmin(inboxId);
+```
+
+```tsx [React Native]
+await group.addSuperAdmin(client.inboxID);
+```
+
+```kotlin [Kotlin]
+group.addSuperAdmin(inboxId)
+```
+
+```swift [Swift]
+try await group.addSuperAdmin(inboxid: inboxID)
+```
+
+:::
+
+### Remove admin status from inbox ID
+
+:::code-group
+
+```js [Browser]
+await group.removeAdmin(inboxId);
+```
+
+```js [Node]
+await group.removeAdmin(inboxId);
+```
+
+```tsx [React Native]
+await group.removeAdmin(client.inboxID);
+```
+
+```kotlin [Kotlin]
+group.removeAdmin(inboxId)
+```
+
+```swift [Swift]
+try await group.removeAdmin(inboxid: inboxid)
+```
+
+:::
+
+### Remove super admin status from inbox ID
+
+:::code-group
+
+```js [Browser]
+await group.removeSuperAdmin(inboxId);
+```
+
+```js [Node]
+await group.removeSuperAdmin(inboxId);
+```
+
+```tsx [React Native]
+await group.removeSuperAdmin(client.inboxId);
+```
+
+```kotlin [Kotlin]
+group.removeSuperAdmin(inboxId)
+```
+
+```swift [Swift]
+try await group.removeSuperAdmin(inboxid: inboxID)
+```
+
+:::
+
+## Manage group chat membership
+
+### Add members by inbox ID
+
+The maximum group chat size is 220 members.
+
+:::code-group
+
+```js [Browser]
+await group.addMembers([inboxId]);
+```
+
+```js [Node]
+await group.addMembers([inboxId]);
+```
+
+```tsx [React Native]
+await group.addMembers([inboxId]);
+```
+
+```kotlin [Kotlin]
+group.addMembers(listOf(client.inboxId))
+```
+
+```swift [Swift]
+try await group.addMembers(inboxIds: [inboxId])
+```
+
+:::
+
+### Remove member by inbox ID
+
+:::code-group
+
+```js [Browser]
+await group.removeMembers([inboxId]);
+```
+
+```js [Node]
+await group.removeMembers([inboxId]);
+```
+
+```tsx [React Native]
+await group.removeMembers([inboxId]);
+```
+
+```kotlin [Kotlin]
+group.removeMembers(listOf(inboxId))
+```
+
+```swift [Swift]
+try await group.removeMembers(inboxIds: [inboxId])
+```
+
+:::
+
+### Get inbox IDs for members
+
+:::code-group
+
+```js [Browser]
+const inboxId = await client.findInboxIdByIdentities([bo.identity, caro.identity]);
+```
+
+```js [Node]
+const inboxId = await client.getInboxIdByIdentities([bo.identity, caro.identity]);
+```
+
+```tsx [React Native]
+await group.memberInboxIds();
+```
+
+```kotlin [Kotlin]
+val members = group.members()
+val inboxIds = members.map { it.inboxId }
+
+OR
+
+val inboxId = client.inboxIdFromIdentity(peerIdentity)
+```
+
+```swift [Swift]
+let members = try group.members.map(\.inboxId).sorted()
+
+OR
+
+try await client.inboxIdFromIdentity(identity: peerIdentity)
+```
+
+:::
+
+### Get identities for members
+
+:::code-group
+
+```js [Browser]
+// sync group first
+await group.sync();
+
+// get group members
+const members = await group.members();
+
+// map inbox ID to account identity
+const inboxIdIdentityMap = new Map(
+  members.map((member) => [member.inboxId, member.accountIdentity])
+);
+```
+
+```js [Node]
+// sync group first
+await group.sync();
+
+// get group members
+const members = group.members;
+
+// map inbox ID to account identity
+const inboxIdIdentityMap = new Map(
+  members.map((member) => [member.inboxId, member.accountIdentity])
+);
+```
+
+```tsx [React Native]
+const members = await group.members();
+const identities = members.map((member) => member.identities);
+```
+
+```kotlin [Kotlin]
+val members = group.members()
+val identities = members.map { it.identities }
+```
+
+```swift [Swift]
+let peerMembers = try Conversation.group(group).peerInboxIds.sorted()
+```
+
+:::
+
+### Get the inbox ID that added the current member
+
+:::code-group
+
+```js [Browser]
+const addedByInboxId = group.addedByInboxId;
+```
+
+```js [Node]
+const addedByInboxId = group.addedByInboxId;
+```
+
+```tsx [React Native]
+// this API is experimental and may change in the future
+
+const addedByInboxId = await group.addedByInboxId();
+```
+
+```kotlin [Kotlin]
+val addedByInboxId = group.addedByInboxId();
+```
+
+```swift [Swift]
+try await group.addedByInboxId();
+```
+
+:::
+
+
+## pages/inboxes/list-and-stream.mdx
+# List and stream conversations and messages
+
+## List existing conversations
+
+Get a list of existing group chat and DM conversations in the local database.
+
+By default, `list` returns only conversations with a [consent state](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set) of allowed or unknown.
+
+We recommend listing allowed conversations only. This ensures that spammy conversations with a consent state of unknown don't degrade the user experience.
+
+To list all conversations regardless of consent state, pass `[ALLOWED, UNKNOWN, DENIED]`.
+
+Conversations are listed in descending order by their `lastMessage` created at value. If a conversation has no messages, the conversation is ordered by its `createdAt` value.
+
+:::code-group
+
+```js [Browser]
+const allConversations = await client.conversations.list(["allowed"]);
+const allGroups = await client.conversations.listGroups(["allowed"]);
+const allDms = await client.conversations.listDms(["allowed"]);
+```
+
+```js [Node]
+const allConversations = await client.conversations.list(["allowed"]);
+const allGroups = await client.conversations.listGroups(["allowed"]);
+const allDms = await client.conversations.listDms(["allowed"]);
+```
+
+```tsx [React Native]
+// List Conversation items
+await alix.conversations.list(["allowed"]);
+
+// List Conversation items and return only the fields set to true. Optimize data transfer
+// by requesting only the fields the app needs.
+await alix.conversations.list(
+  {
+    members: false,
+    consentState: false,
+    description: false,
+    creatorInboxId: false,
+    addedByInboxId: false,
+    isActive: false,
+    lastMessage: true,
+  },
+);
+```
+
+```kotlin [Kotlin]
+// List conversations (both groups and dms)
+val conversations = alix.conversations.list()
+val orderFilteredConversations = client.conversations.list(consentState: ALLOWED)
+
+// List just dms
+val conversations = alix.conversations.listDms()
+val orderFilteredConversations = client.conversations.listDms(consentState: ALLOWED)
+
+//List just groups
+val conversations = alix.conversations.listGroups()
+val orderFilteredConversations = client.conversations.listGroups(consentState: ALLOWED)
+
+```
+
+```swift [Swift]
+// List conversations (both groups and dms)
+let conversations = try await alix.conversations.list()
+let orderFilteredConversations = try await client.conversations.list(consentState: .allowed)
+
+// List just dms
+let conversations = try await alix.conversations.listDms()
+let orderFilteredConversations = try await client.conversations.listDms(consentState: .allowed)
+
+//List just groups
+let conversations = try await alix.conversations.listGroups()
+let orderFilteredConversations = try await client.conversations.listGroups(consentState: .allowed)
+```
+
+:::
+
+## List a user's active conversations
+
+The `isActive()` method determines whether the current user is still an active member of a group conversation. For example:
+
+- When a user is added to a group, `isActive()` returns `true` for that user
+- When a user is removed from a group, `isActive()` returns `false` for that user
+
+You can use a user's `isActive: true` value as a filter parameter when listing conversations. You can potentially have a separate section for "archived" or "inactive" conversations where you could use `isActive: false`.
+
+## Stream all group chats and DMs
+
+Listens to the network for new group chats and DMs. Whenever a new conversation starts, it triggers the provided callback function with a [`ConversationContainer` object](#conversationcontainer-interface). This allows the client to immediately respond to any new group chats or DMs initiated by other users.
+
+:::code-group
+
+```js [Browser]
+const stream = await client.conversations.stream();
+
+try {
+  for await (const conversation of stream) {
+    // Received a conversation
+    console.log("New conversation:", conversation);
+  }
+} catch (error) {
+  // Log any stream errors
+  console.error(error);
+}
+```
+
+```js [Node]
+const stream = await client.conversations.stream();
+// to stream only groups, use `client.conversations.streamGroups()`
+// to stream only dms, use `client.conversations.streamDms()`
+
+try {
+  for await (const conversation of stream) {
+    // Received a conversation
+  }
+} catch (error) {
+  // log any stream errors
+  console.error(error);
+}
+```
+
+```tsx [React Native]
+await alix.conversations.stream(async (conversation: Conversation<any>) => {
+  // Received a conversation
+});
+```
+
+```kotlin [Kotlin]
+alix.conversations.stream(type: /* OPTIONAL DMS, GROUPS, ALL */).collect {
+  // Received a conversation
+}
+```
+
+```swift [Swift]
+for await convo in try await alix.conversations.stream(type: /* OPTIONAL .dms, .groups, .all */) {
+  // Received a conversation
+}
+```
+
+:::
+
+## Stream all group chat and DM messages and preferences
+
+Listens to the network for new messages within all active group chats and DMs, as well as [preference updates](/inboxes/sync-preferences). 
+
+Whenever a new message is sent to any of these conversations, the callback is triggered with a `DecodedMessage` object. This keeps the inbox up to date by streaming in messages as they arrive.
+
+By default, `streamAll` streams only conversations with a [consent state](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set) of allowed or unknown.
+
+We recommend streaming messages for allowed conversations only. This ensures that spammy conversations with a consent state of unknown don't take up networking resources. This also ensures that unwanted spam messages aren't stored in the user's local database.
+
+To stream all conversations regardless of consent state, pass `[Allowed, Unknown, Denied]`.
+
+:::warning[Important]
+
+The stream is infinite. Therefore, any looping construct used with the stream won't terminate unless you explicitly initiate the termination. You can initiate the termination by breaking the loop or by making an external call to `return`.
+
+:::
+
+:::code-group
+
+```js [Browser]
+const stream = await client.conversations.streamAllMessages(["allowed"]);
+ 
+try {
+  for await (const message of stream) {
+    // Received a message
+    console.log("New message:", message);
+  }
+} catch (error) {
+  // Log any stream errors
+  console.error(error);
+}
+```
+
+```js [Node]
+// stream all messages from all conversations
+const stream = await client.conversations.streamAllMessages(["allowed"]);
+ 
+// stream only group messages
+const stream = await client.conversations.streamAllGroupMessages(["allowed"]);
+ 
+// stream only dm messages
+const stream = await client.conversations.streamAllDmMessages(["allowed"]);
+ 
+try {
+  for await (const message of stream) {
+    // Received a message
+  }
+} catch (error) {
+  // log any stream errors
+  console.error(error);
+}
+```
+
+```tsx [React Native]
+await alix.conversations.streamAllMessages(
+  async (message: DecodedMessage<any>) => {
+    // Received a message
+  },
+  { consentState: ["allowed"] }
+);
+```
+
+```kotlin [Kotlin]
+alix.conversations.streamAllMessages(type: /* OPTIONAL DMS, GROUPS, ALL */, consentState: listOf(ConsentState.ALLOWED)).collect {
+  // Received a message
+}
+```
+
+```swift [Swift]
+for await message in try await alix.conversations.streamAllMessages(type: /* OPTIONAL .dms, .groups, .all */, consentState: [.allowed]) {
+  // Received a message
+}
+```
+
+:::
+
+## Handle unsupported content types
+
+As more [custom](/inboxes/content-types/content-types#create-a-custom-content-type) and [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
+
+Each message is accompanied by a `fallback` property, which offers a descriptive string representing the content type's expected value. It's important to note that fallbacks are immutable and are predefined in the content type specification. In instances where `fallback` is `undefined`, such as read receipts, it indicates that the content is not intended to be rendered. If you're venturing into creating custom content types, you're provided with the flexibility to specify a custom fallback string. For a deeper dive into this, see [Build custom content types](/inboxes/content-types/custom).
+
+:::code-group
+
+```js [Browser]
+const codec = client.codecFor(content.contentType);
+if (!codec) {
+  /*Not supported content type*/
+  if (message.fallback !== undefined) {
+    return message.fallback;
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
+}
+```
+
+```js [Node]
+const codec = client.codecFor(content.contentType);
+if (!codec) {
+  /*Not supported content type*/
+  if (message.fallback !== undefined) {
+    return message.fallback;
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
+}
+```
+
+```jsx [React Native]
+//contentTypeID has the following structure `${contentType.authorityId}/${contentType.typeId}:${contentType.versionMajor}.${contentType.versionMinor}`;
+const isRegistered = message.contentTypeID in client.codecRegistry;
+if (!isRegistered) {
+  // Not supported content type
+  if (message?.fallback != null) {
+    return message?.fallback;
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
+}
+```
+
+```kotlin [Kotlin]
+val codec = client.codecRegistry.find(options?.contentType)
+if (!codec) {
+  /*Not supported content type*/
+  if (message.fallback != null) {
+    return message.fallback
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
+}
+```
+
+```swift [Swift]
+let codec = client.codecRegistry.find(for: contentType)
+if (!codec) {
+  /*Not supported content type*/
+  if (message.fallback != null) {
+    return message.fallback
+  }
+  // Handle other types like ReadReceipts which are not meant to be displayed
+}
+```
+
+:::
+
+
+## pages/inboxes/history-sync.mdx
+# Enable history sync for apps built with XMTP
+
+:::warning[This feature is in beta]
+
+History sync is still in active development as we work on its reliability and performance. To provide feedback on this feature, please post to [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
+
+:::
+
+Enable the history sync feature to give your users a way to sync decrypted historical data from an existing app installation to a new app installation.
+
+This historical data includes:
+
+- Conversations
+- Conversation messages
+- Consent state
+- HMAC keys (for push notifications)
+
+History sync enables your users pick up conversations where they left off, regardless of the app installation they use. All they need is a pre-existing and online app installation to provide the data.
+
+## 🎥 walkthrough: History sync
+
+This video provides a walkthrough of history sync, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/_FtNqtjk-ls?si=uZ_Mnh9phF6y2h-O" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+
+## Enable history sync
+
+History sync is enabled by default and runs automatically. When [creating a client](/inboxes/create-a-client), the `historySyncUrl` client option is dynamically set to a default history sync server URL based on your `env` client option setting.
+
+- When `env` is set to `dev`, the `historySyncUrl` is set to `https://message-history.dev.ephemera.network/`
+- When `env` is set to `production`, the `historySyncUrl` is set to `https://message-history.production.ephemera.network`
+
+These default servers are managed and operated by [Ephemera](https://ephemerahq.com/), a steward of the development and adoption of XMTP.
+
+You can choose to [run your own server](https://github.com/xmtp/xmtp-message-history-server) and set the `historySyncUrl` to your server's URL.
+
+## How history sync works
+
+When your app initializes an XMTP client and a `historySyncUrl` client option is present, history sync automatically triggers an initial sync request and creates an encrypted payload.
+
+<div>
+    <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step1.png" width="600px" />
+</div>
+
+History sync then uploads the payload, sends a sync reply, and pulls all conversation state history into the new app installation, merging it with the existing app installations in the sync group.
+
+<div>
+    <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step2.png" width="600px" />
+</div>
+
+Ongoing updates to history are streamed automatically. Updates, whether for user consent preferences or messages, are sent across the sync group, ensuring all app installations have up-to-date information.
+
+History syncs are accomplished using these components:
+
+- Sync group
+- Sync worker
+- History server
+
+### Sync group
+
+A sync group is a special [Messaging Layer Security](/protocol/security) group that includes all of the user’s devices. The sync group is used to send serialized sync messages across the user's devices. The sync group is filtered out of most queries by default so they don’t appear in the user’s inbox.
+
+### Sync worker
+
+A sync worker is a spawned background worker that listens for sync events, and processes them accordingly. This worker:
+
+- Emits and updates consent
+- Creates and consumes archive payloads for and from other devices
+- Keeps preferences synced across devices
+
+### History server
+
+A history server acts as a bucket that holds encrypted sync payloads. The URL location of these payloads and the password (cipher encryption key) to decrypt these payloads is sent over the sync group for the recipient to decrypt.
+
+## FAQ
+
+### A user logged into a new app installation and doesn't see their conversations. What's going on?
+
+A debounce feature checks for new app installations, at most, once every 30 minutes. To circumvent the cool-down timer, send a message using a pre-existing app installation. 
+
+Once [this issue](https://github.com/xmtp/libxmtp/issues/1309) is resolved, conversations will appear almost instantly.
+
+### A user logged into a new app installation and sees their conversations, but no messages. What's going on?
+
+Ensure that you've initiated a call to [sync messages](#sync-messages) and that the pre-existing app installation is online to receive the sync request, process and encrypt the payload, upload it to the history server, and send a sync reply message to the new app installation.
+
+### I called a sync method (messages, consent state, or conversations), but nothing is happening. What's going on?
+
+After requesting a sync for one app installation, ensure that the pre-existing app installation is online to receive the sync request.
+
+
+## pages/inboxes/use-signatures.md
+# Use signatures with XMTP
+
+With XMTP, you can use various types of signatures to sign and verify payloads.
+
+## Sign with an external wallet
+
+When a user creates, adds, removes, or revokes an XMTP inbox’s identity or installation, a signature is required.
+
+## Sign with an XMTP key
+
+You can sign something with XMTP keys. For example, you can sign with XMTP keys to send a payload to a backend.
+
+:::code-group
+
+```js [Node]
+const signature = client.signWithInstallationKey(signatureText);
+```
+
+```jsx [React Native]
+const signature = await client.signWithInstallationKey(signatureText)
+```
+
+```kotlin [Kotlin]
+val signature = client.signWithInstallationKey(signatureText)
+```
+
+```swift [Swift]
+let signature = try client.signWithInstallationKey(message: signatureText)
+```
+
+:::
+
+## Verify with the same installation that signed
+
+ You can also sign with XMTP keys and verify that a payload was sent by the same client. 
+
+:::code-group
+
+```js [Node]
+const isValidSignature = client.verifySignedWithInstallationKey(signatureText, signature);
+```
+
+```jsx [React Native]
+const isVerified = await client.verifySignature(signatureText, signature)
+```
+
+```kotlin [Kotlin]
+val isVerified = client.verifySignature(signatureText, signature)
+```
+
+```swift [Swift]
+let isVerified = try client.verifySignature(
+            message: signatureText, 
+            signature: signature
+        )
+
+```
+
+:::
+
+## Verify with the same inbox ID that signed
+
+You can use an XMTP key’s `installationId` to create a signature, then pass both the signature and `installationId` to another `installationId` with the same `inboxId` to verify that the signature came from a trusted sender.
+
+:::code-group
+
+```js [Node]
+const isValidSignature = client.verifySignedWithPrivateKey(signatureText, signature, installationId);
+```
+
+```kotlin [Kotlin]
+val isVerified = client.verifySignatureWithInstallationId(
+            signatureText, 
+            signature, 
+            installationId
+      )
+```
+
+```swift [Swift]
+let isVerified = try client.verifySignatureWithInstallationId(
+                message: signatureText,
+                signature: signature,
+                installationId: installationId
+            )
+```
+
+:::
+
+
+## pages/inboxes/group-metadata.md
+# Manage group chat metadata
+
+Group chats can have metadata, like names, descriptions, and images. Metadata can help users more easily identify their group chats. You can set group chat metadata when [creating a group chat](/inboxes/create-conversations/#create-a-new-group-chat), and get and update metadata using these methods.
+
+## Updatable group chat metadata
+
+The following group chat metadata can be updated:
+
+- `group_name`: The name of the group chat
+- `description`: A description of the group chat
+- `image_url`: A URL pointing to an image for the group chat
+- `disappearing_message_settings`: Settings for disappearing messages in the group chat. To learn more about disappearing messages, see [Support disappearing messages](/inboxes/send-messages#support-disappearing-messages)
+
+## Get a group chat name
+
+:::code-group
+
+```js [Browser]
+const groupName = group.name;
+```
+
+```js [Node]
+const groupName = group.name;
+```
+
+```tsx [React Native]
+const groupName = await group.groupName();
+```
+
+```kotlin [Kotlin]
+group.name
+```
+
+```swift [Swift]
+try group.groupname()
+```
+
+:::
+
+## Update a group chat name
+
+:::code-group
+
+```js [Browser]
+await group.updateName("New Group Name");
+```
+
+```js [Node]
+await group.updateName("New Group Name");
+```
+
+```tsx [React Native]
+await group.updateName("New Group Name");
+```
+
+```kotlin [Kotlin]
+group.updateName("New Group Name")
+```
+
+```swift [Swift]
+try await group.updateName(groupname: "New Group Name")
+```
+
+:::
+
+## Get a group chat description
+
+:::code-group
+
+```js [Browser]
+const groupDescription = group.description;
+```
+
+```js [Node]
+const groupDescription = group.description;
+```
+
+```tsx [React Native]
+const groupDescription = await group.groupDescription();
+```
+
+```kotlin [Kotlin]
+group.description
+```
+
+```swift [Swift]
+try group.groupDescription()
+```
+
+:::
+
+## Update a group chat description
+
+:::code-group
+
+```js [Browser]
+await group.updateDescription("New Group Description");
+```
+
+```js [Node]
+await group.updateDescription("New Group Description");
+```
+
+```tsx [React Native]
+await group.updateDescription("New Group Description");
+```
+
+```kotlin [Kotlin]
+group.updateDescription("New Group Description")
+```
+
+```swift [Swift]
+try await group.updateDescription(Description: "New Group Description")
+```
+
+:::
+
+## Get a group chat image URL
+
+:::code-group
+
+```js [Browser]
+const groupImageUrl = group.imageUrl;
+```
+
+```js [Node]
+const groupImageUrl = group.imageUrl;
+```
+
+```tsx [React Native]
+const groupName = await group.imageUrl();
+```
+
+```kotlin [Kotlin]
+group.imageURL
+```
+
+```swift [Swift]
+try group.imageUrl()
+```
+
+:::
+
+## Update a group chat image URL
+
+:::code-group
+
+```js [Browser]
+await group.updateImageUrl("newurl.com");
+```
+
+```js [Node]
+await group.updateImageUrl("newurl.com");
+```
+
+```tsx [React Native]
+await group.updateImageUrl("ImageURL");
+```
+
+```kotlin [Kotlin]
+group.updateImageUrl("newurl.com")
+```
+
+```swift [Swift]
+try await group.updateImageUrl(imageUrl: "newurl.com")
+```
+
+:::
+
+
+## pages/inboxes/manage-inboxes.mdx
+# Manage XMTP inboxes and installations
+
+With XMTP, a user can have one or more inboxes they use to access their messages. An inbox can have multiple identities associated with it. An identity has a kind, such as EOA or SCW, and a string, which in the case of an EOA or SCW, is an Ethereum address. However, this extensible inbox-based identity model means that support for additional kinds of identities, such as Passkey or Bitcoin, can be added in the future.
+
+All messages associated with these identities flow through the one inbox ID and are accessible in any XMTP app.
+
+The first time someone uses your app with an identity they've never used with any app built with XMTP, your app creates an inbox ID and installation ID associated with the identity. To do this, you [create a client](/inboxes/create-a-client) for their identity. 
+
+The client creates an inbox ID and installation ID associated with the identity. By default, this identity is designated as the recovery identity. A recovery identity will always have the same inbox ID and cannot be reassigned to a different inbox ID.
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/create-inbox-install.png" width="250px" />
+</div>
+
+When you make subsequent calls to create a client for the same identity and a local database is not present, the client uses the same inbox ID, but creates a new installation ID.
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-installation.png" width="250px" />
+</div>
+
+You can enable a user to add multiple identities to their inbox. Added identities use the same inbox ID and the installation ID of the installation used to add the identity.
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-id.png" width="350px" />
+</div>
+
+You can enable a user to remove an identity from their inbox. You cannot remove the recovery identity.
+
+## Add an identity to an inbox
+
+:::warning[Warning]
+
+This function is delicate and should be used with caution. Adding an identity to an inbox ID B when it's already associated with an inbox ID A will cause the identity to lose access to inbox ID A.
+
+:::
+
+:::code-group
+
+```tsx [Browser]
+await client.unsafe_addAccount(signer, true)
+```
+
+```tsx [Node]
+await client.unsafe_addAccount(signer, true)
+```
+
+```jsx [React Native]
+await client.addAccount(identityToAdd)
+```
+
+```kotlin [Kotlin]
+client.addAccount(identityToAdd)
+```
+
+```swift [Swift]
+try await client.addAccount(newAccount: identityToAdd)
+```
+
+:::
+
+## Remove an identity from an inbox
+
+:::tip[Note]
+ A recovery identity cannot be removed. For example, if an inbox has only one associated identity, that identity serves as the recovery identity and cannot be removed.
+:::
+
+:::code-group
+
+```tsx [Browser]
+await client.removeAccount(identifier)
+```
+
+```tsx [Node]
+await client.removeAccount(identifier)
+```
+
+```jsx [React Native]
+await client.removeAccount(recoveryIdentity, identityToRemove)
+```
+
+```kotlin [Kotlin]
+client.removeAccount(recoveryIdentity, identityToRemove)
+```
+
+```swift [Swift]
+try await client.removeAccount(recoveryIdentity: recoveryIdentity, identityToRemove: identityToRemove)
+```
+
+:::
+
+## Revoke installations
+
+### 🎥 walkthrough: Revoking installations
+
+This video provides a walkthrough of revoking installations, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/MIw9x1Z4WXw?si=4bcbfkHTDvsM0uDG" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+
+### Revoke all other installations
+
+You can revoke all installations other than the currently accessed installation.
+
+For example, consider a user using this current installation:
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/current-install-id.png" width="350px" />
+</div>
+
+When the user revokes all other installations, the action removes their identity's access to all installations other than the current installation:
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/revoke-install-id.png" width="350px" />
+</div>
+
+:::code-group
+
+```tsx [Browser]
+await client.revokeAllOtherInstallations()
+```
+
+```tsx [Node]
+await client.revokeAllOtherInstallations()
+```
+
+```jsx [React Native]
+await client.revokeAllOtherInstallations(recoveryIdentity)
+```
+
+```kotlin [Kotlin]
+client.revokeAllOtherInstallations(recoveryIdentity)
+```
+
+```swift [Swift]
+try await client.revokeAllOtherInstallations(signingKey: recoveryIdentity)
+```
+
+:::
+
+## View the inbox state
+
+Find an `inboxId` for an identity:
+
+:::code-group
+
+```tsx [Browser]
+const inboxState = await client.preferences.inboxState()
+```
+
+```tsx [Node]
+const inboxState = await client.preferences.inboxState()
+```
+
+```jsx [React Native]
+const inboxId = await client.inboxIdFromIdentity(identity)
+```
+
+```kotlin [Kotlin]
+val inboxId = client.inboxIdFromIdentity(identity)
+```
+
+```swift [Swift]
+let inboxId = try await client.inboxIdFromIdentity(identity: identity)
+```
+
+:::
+
+View the state of any inbox to see the identities, installations, and other information associated with the `inboxId`.
+
+**Sample request**
+
+:::code-group
+
+```tsx [Browser]
+// the second argument is optional and refreshes the state from the network.
+const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
+```
+
+```tsx [Node]
+// the second argument is optional and refreshes the state from the network.
+const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
+```
+
+```jsx [React Native]
+const state = await client.inboxState(true)
+const states = await client.inboxStates(true, [inboxId, inboxId])
+```
+
+```kotlin [Kotlin]
+val state = client.inboxState(true) 
+val states = client.inboxStatesForInboxIds(true, listOf(inboxID, inboxID))
+```
+
+```swift [Swift]
+let state = try await client.inboxState(refreshFromNetwork: true)
+let states = try await client.inboxStatesForInboxIds(
+	refreshFromNetwork: true,
+	inboxIds: [inboxID, inboxID]
+)
+```
+:::
+
+**Sample response**
+
+```json
+InboxState
+{
+  "recoveryIdentity": "string",
+  "identities": [
+    {
+      "kind": "ETHEREUM",
+      "identifier": "string",
+      "relyingPartner": "string"
+    },
+    {
+      "kind": "PASSKEY",  // not yet supported; provided as an example only.
+      "identifier": "string",
+      "relyingPartner": "string"
+    }
+  ],
+  "installations": ["string"],
+  "inboxId": "string"
+}
+```
+
+## FAQ
+
+### What happens when a user removes an identity?
+
+Consider an inbox with three associated identities:
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/three-ids.png" width="650px" />
+</div>
+
+If the user removes an identity from the inbox, the identity no longer has access to the inbox it was removed from.
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/removed-id.png" width="650px" />
+</div>
+
+The identity can no longer be added to or used to access conversations in that inbox. If someone sends a message to the identity, the message is not associated with the original inbox. If the user logs in to a new installation with the identity, this will create a new inbox ID.
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/new-inbox-id.png" width="650px" />
+</div>
+
+### How is the recovery identity used?
+
+The recovery identity and its signer can be used to sign transactions that remove identities and revoke installations.
+
+For example, Alix can give Bo access to their inbox so Bo can see their groups and conversations and respond for Alix.
+
+If Alix decides they no longer want Bo have access to their inbox, Alix can use their recovery identity signer to remove Bo. 
+
+However, while Bo has access to Alix's inbox, Bo cannot remove Alix from their own inbox because Bo does not have access to Alix's recovery identity signer.
+
+### If a user created two inboxes using two identities, is there a way to combine the inboxes?
+
+If a user logs in with an identity with address 0x62EE...309c and creates inbox 1 and then logs in with an identity with address 0xd0e4...DCe8 and creates inbox 2; there is no way to combine inbox 1 and 2.
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inboxes.png" width="350px" />
+</div>
+
+You can add an identity with address 0xd0e4...DCe8 to inbox 1, but both identities with addresses 0x62EE...309c and 0xd0e4...DCe8 would then have access to inbox 1 only. The identity with address 0xd0e4...DCe8 would no longer be able to access inbox 2. 
+
+<div>
+  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inbox-remap-id.png" width="350px" />
+</div>
+
+To help users avoid this state, ensure that your UX surfaces their ability to add multiple identities to a single inbox.
+
+### What happens if I remove an identity from an inbox ID and then initiate a client with the private key of the removed identity?
+
+**Does the client create a new inbox ID or does it match it with the original inbox ID the identity was removed from?**
+
+The identity used to initiate a client should be matched to its original inbox ID. 
+
+You do have the ability to rotate inbox IDs if a user reaches the limit of 257 identity actions (adding, removing, or revoking identities or installations). Hopefully, users won’t reach this limit, but if they do, inbox IDs have a nonce and can be created an infinite number of times. 
+
+However, anytime a new inbox ID is created for an identity, the conversations and messages in any existing inbox ID associated with the identity are lost.
+
+### I have multiple identities associated with one inbox ID. If I log in with any one of these identities, does it access that inbox ID, or does it create a new inbox ID?
+
+The identity accesses that inbox ID and does not create a new inbox ID.
+
+For example, let's say that you create a client with an identity with address 0x62EE...309c. Inbox ID 1 is generated from that identity. 
+
+<div>
+<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1.png" width="150px" />
+</div>
+
+If you then add an identity with address 0xd0e4...DCe8 to inbox ID 1, the identity is also associated with inbox ID 1.
+
+If you then log into a new app installation with the identity with address 0xd0e4...DCe8, it accesses inbox ID 1 and does not create a new inbox ID.
+
+Once the identity with address 0xd0e4...DCe8 has been associated with inbox ID 1, it can then be used to log into inbox ID 1 using a new app installation.
+
+<div>
+<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2.png" width="350px" />
+</div>
+
+The inverse is also true. Let's say an identity with address 0xd0e4...DCe8 was previously used to create and log into inbox ID 2.
+
+<div>
+<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-inbox2-id2.png" width="350px" />
+</div>
+
+If the identity is then added as an associated identity to inbox ID 1, the identity will no longer be able to log into inbox ID 2.
+
+<div>
+<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2-inverse.png" width="350px" />
+</div>
+
+To enable the user of the identity with address 0xd0e4...DCe8 to log into inbox ID 2 again, you can use the recovery identity for inbox ID 2 to add a different identity to inbox ID 2 and have the user use that identity access it.
+
+If you are interested in providing this functionality in your app and want some guidance, post to the [XMTP Community Forums](https://community.xmtp.org).
+
+
+## pages/inboxes/quickstart.md
+# Quickstart: Build an app with XMTP
+
+This quickstart provides a map to building a [secure messaging app](/protocol/security) with XMTP, including support for:
+
+- End-to-end encrypted direct message and group chat conversations
+- Rich content types (attachments, reactions, replies, and more)
+- Real-time push notifications
+- Spam-free inboxes using user consent preferences
+
+:::tip[🤖 Building an agent instead?]
+
+Explore the examples and docs in [xmtp-agent-examples](https://github.com/ephemeraHQ/xmtp-agent-examples).
+
+:::
+
+## 🏗️ Phase I: Setup
+
+1. Select the XMTP SDK that matches your platform.
+
+   - Mobile development
+     - [React Native SDK](https://github.com/xmtp/xmtp-react-native)
+     - [Kotlin SDK](https://github.com/xmtp/xmtp-android)
+     - [Swift SDK](https://github.com/xmtp/xmtp-ios)
+
+   - Web development
+     - [Browser SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk) (for web apps)
+     - [Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk) (for servers)
+
+   Need an SDK for a different platform? Let us know in [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
+
+2. [Run a local XMTP node](https://github.com/xmtp/xmtp-local-node/tree/main) for development and testing.
+
+3. You can [use llms-full.txt](http://localhost:5173/intro/build-with-llms) to provide the full text of the XMTP developer documentation to an AI coding assistant.
+
+
+## 💬 Phase II: Build core messaging
+
+1. [Create an EOA or SCW signer](/inboxes/create-a-signer#create-a-eoa-or-scw-signer).
+
+2. [Create an XMTP client](/inboxes/create-a-client).
+
+3. [Check if an identity is reachable on XMTP](/inboxes/create-conversations#check-if-an-identity-is-reachable).
+
+4. Create a [group chat](/inboxes/create-conversations#create-a-new-group-chat) or [direct message](/inboxes/create-conversations#create-a-new-dm) (DM) conversation. 
+   
+   With XMTP, "conversation" refers to both group chat and DM conversations.
+
+5. [Send messages](/inboxes/send-messages) in a conversation.
+
+6. Manage group chat [permissions](/inboxes/group-permissions) and [metadata](/inboxes/group-metadata).
+
+7. [Manage identities, inboxes, and installations](/inboxes/manage-inboxes).
+
+## 📩 Phase III: Manage conversations and messages
+
+1. [List existing conversations](/inboxes/list-and-stream#list-existing-conversations) from local storage.
+
+2. [Stream new conversations](/inboxes/list-and-stream#stream-all-group-chats-and-dms) from the network.
+
+3. [Stream new messages](/inboxes/list-and-stream#stream-all-group-chat-and-dm-messages-and-preferences) from the network.
+
+4. [Sync new conversations](/inboxes/sync-and-syncall#sync-new-conversations) from the network.
+
+5. [Sync a specific conversation's messages and preference updates](/inboxes/sync-and-syncall#sync-a-specific-conversation) from the network.
+
+## 💅🏽 Phase IV: Enhance the user experience
+
+1. [Implement user consent](/inboxes/user-consent/support-user-consent), which provides a consent value of either **unknown**, **allowed** or **denied** to each of a user's contacts. You can use these consent values to filter conversations. For example:
+   
+   - Conversations with **allowed** contacts go to a user's main inbox
+   - Conversations with **unknown** contacts go to a possible spam tab
+   - Conversations with **denied** contacts are hidden from view.
+  
+2. Support rich [content types](/inboxes/content-types/content-types).
+   
+   - [Attachments](/inboxes/content-types/attachments)
+     - Single remote attachment
+     - Multiple remote attachments
+     - Attachments smaller than 1MB
+   - [Reactions](/inboxes/content-types/reactions)
+   - [Replies](/inboxes/content-types/replies)
+   - [Read receipts](/inboxes/content-types/read-receipts)
+   - [Onchain transaction references](/inboxes/content-types/transaction-refs)
+
+3. [Implement push notifications](/inboxes/push-notifs/understand-push-notifs).
+
+## 🧪 Phase V: Test and debug
+
+- [Stress and burn-in test](/inboxes/debug-your-app#xmtp-debug) your inbox app.
+
+- [Enable file logging](/inboxes/debug-your-app#file-logging).
+
+- [Capture network statistics](/inboxes/debug-your-app#network-statistics).
+
+- Found a bug or need support? Please file an issue in the relevant SDK repo:
+  
+  - [React Native SDK](https://github.com/xmtp/xmtp-react-native/issues)
+  - [Kotlin SDK](https://github.com/xmtp/xmtp-android/issues)
+  - [Swift SDK](https://github.com/xmtp/xmtp-ios/issues)
+  - [Browser SDK](https://github.com/xmtp/xmtp-js/issues)
+  - [Node SDK](https://github.com/xmtp/xmtp-js/issues)
+
+
+## pages/inboxes/sync-preferences.mdx
+# Sync preferences
+
+Preference sync enables you to sync the following preference-related information across multiple existing app installations:
+
+- Conversation [consent preferences](/inboxes/user-consent/user-consent#how-user-consent-preferences-are-set)
+- Conversation HMAC keys (for [push notifications](/inboxes/push-notifs/understand-push-notifs))
+
+## Databases used by preference sync
+
+Each xmtpd node contains:
+
+- A **welcomes database**: Keeps a ledger of all groups an inbox ID is a part of.
+- A **group messages database**: Keeps a ledger of all messages in the groups an inbox ID is a part of.
+
+<div>
+  <img alt="databases in each xmtpd node" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/xmtpd-dbs.png" width="300px" />
+</div>
+
+In the welcomes database, the groups are of these types:
+
+- **1:1 chat**: A group that handles conversations between an inbox ID and one other user.
+- **Group chat**: A group that handles conversations between an inbox ID and multiple other users.
+- **Preferences**: A group that handles syncing preferences between an inbox ID's existing app installations.
+
+One-to-one chat, group chat, and preferences groups in the welcome database are updated by apps as follows:
+
+- 1:1 chats
+    - `conversations.list`
+    - `syncAll`
+    - `streamAll`
+- Group chats
+    - `conversations.list`
+    - `syncAll`
+    - `streamAll`
+- Preferences
+    - `preferences.sync`
+    - `syncAll`
+    - `streamAll`
+
+<div>
+  <img alt="groups in the welcome database" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/welcomes-db.png" width="500px" />
+</div>
+
+## Preferences group
+
+To describe preference sync, let's first focus on how the preferences group works.
+
+1. A preferences group has one member, which is one inbox ID.
+   
+2. Let's say Inbox ID Alix has an Installation A of App A on their phone. At this time, Inbox ID Alix has a preferences group that looks like this:
+
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-1.png" width="300px" />
+   </div>
+
+3. Inbox ID Alix then logs in to an Installation B of App B on their phone. The next time Installation A runs `preferences.sync`, `syncAll`, or `streamAll`, it updates the preferences group as follows:
+    
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-2.png" width="300px" />
+   </div>
+    
+4. Then let's say Inbox ID Alix logs in to an Installation C of App A on their tablet. The next time Installation A or B runs `preferences.sync`, `syncAll`, or `streamAll`, it updates the preferences group as follows:
+    
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-3.png" width="300px" />
+   </div>
+    
+## Preferences sync worker
+
+Now, let's describe how the preferences sync worker helps keep user consent preferences in sync across existing app installations.
+
+1. Let's say Inbox ID Alix uses Installation A to block Inbox ID Bo.
+
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/a-block-bo.png" width="200px" />
+   </div>    
+    
+2. This sends a message to the preferences group in the group message database. This is not an actual chat message, but a serialized proto message that is not shown to app users.
+    
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/gm-pg.png" width="300px" />
+   </div>    
+    
+3. When Installation B calls `preferences.sync`, `syncAll`, or `streamAll`, it gets the message from the preferences group. The sync worker listens for these preferences group messages and processes the message to block Inbox ID Bo in Installation B.
+    
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/b-block-bo.png" width="200px" />
+   </div> 
+    
+4. Likewise, when Installation C calls `preferences.sync`, `syncAll`, or `streamAll`, it gets the message from the preferences group, and the sync worker ensures Inbox ID Bo is blocked there as well.
+    
+   <div>
+      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/c-block-bo.png" width="200px" />
+   </div>   
+
+Preferences sync handles syncing HMAC keys in the same way.
+
+For example, it will handle syncing an HMAC key shared by Installation B to other installations. When Installation A and C call `preferences.sync`, `syncAll`, or `streamAll`, the sync worker gets Installation B's HMAC key message from the preferences group and ensures that Installation A and C get the HMAC key for Installation B.
+
+## Sync preferences
+
+Use this call to sync preferences (consent preferences and HMAC keys) across app installations in a preferences group. This will also sync welcomes to ensure that you have all potential new installations before syncing.
+
+This is a lighter-weight alternative to syncing preferences using [`syncAll`](/inboxes/sync-and-syncall#sync-all-new-conversations-messages-and-preferences) or [`streamAll`](/inboxes/list-and-stream#stream-all-group-chat-and-dm-messages-and-preferences).
+
+:::code-group
+
+```js [Browser]
+await client.preferences.sync();
+```
+
+```js [Node]
+await client.preferences.sync();
+```
+
+```tsx [React Native]
+await client.preferences.sync()
+```
+
+```kotlin [Kotlin]
+client.preferences.sync()
+```
+
+```swift [Swift]
+try await client.preferences.sync()
+```
+
+:::
+
+
+## pages/inboxes/create-conversations.md
+# Create conversations
+
+## Check if an identity is reachable
+
+The first step to creating a conversation is to verify that participants’ identities are reachable on XMTP. The `canMessage` method checks each identity's compatibility, returning a response indicating whether each identity can receive messages.
+
+Once you have the verified identities, you can create a new conversation, whether it's a group chat or direct message (DM).
+
+:::code-group
+
+```js [Browser]
+import { Client } from "@xmtp/browser-sdk";
+
+// response is a Map of string (identity) => boolean (is reachable)
+const response = await Client.canMessage([bo.identity, caro.identity]);
+```
+
+```js [Node]
+import { Client } from "@xmtp/node-sdk";
+
+// response is a Map of string (identity) => boolean (is reachable)
+const response = await Client.canMessage([bo.identity, caro.identity]);
+```
+
+```tsx [React Native]
+// Request
+const canMessage = await client.canMessage([
+  boIdentity,
+  v2OnlyIdentity,
+  badIdentity,
+])
+
+// Response
+{
+  "0xboAddress": true,
+  "0xV2OnlyAddress": false,
+  "0xBadAddress": false,
+}
+```
+
+```kotlin [Kotlin]
+// Request
+val boIdentity = Identity(ETHEREUM, '0xboAddress')
+val v2Identity = Identity(ETHEREUM, '0xV2OnlyAddress')
+val badIdentity = Identity(ETHEREUM, '0xBadAddress')
+
+val canMessage = client.canMessage(listOf(boIdentity, v2Identity, badIdentity))
+
+// Response
+[
+  "0xboAddress": true,
+  "0xV2OnlyAddress": false,
+  "0xBadAddress": false,
+]
+```
+
+```swift [Swift]
+// Request
+let canMessage = try await client.canMessage([boIdentity, v2OnlyIdentity, badIdentity])
+
+// Response
+[
+  "0xboAddress": true,
+  "0xV2OnlyAddress": false,
+  "0xBadAddress": false,
+]
+```
+
+:::
+
+## Create a new group chat
+
+Once you have the verified identities, create a new group chat. The maximum group chat size is 220 members.
+
+:::tip
+If you want to provide faster and offline group creation, consider using [optimistic group chat creation](#optimistically-create-a-group-chat) instead. This approach enables instant group creation and message preparation before adding members and even when offline.
+:::
+
+:::code-group
+
+```js [Browser]
+const group = await client.conversations.newGroup(
+  [bo.inboxId, caro.inboxId],
+  createGroupOptions /* optional */
+);
+```
+
+```js [Node]
+const group = await client.conversations.newGroup(
+  [bo.inboxId, caro.inboxId],
+  createGroupOptions /* optional */
+);
+```
+
+```tsx [React Native]
+// New Group
+const group = await alix.conversations.newGroup([bo.inboxId, caro.inboxId]);
+
+// New Group with Metadata
+const group = await alix.conversations.newGroup([bo.inboxId, caro.inboxId], {
+  name: "The Group Name",
+  imageUrl: "www.groupImage.com",
+  description: "The description of the group",
+  permissionLevel: "admin_only", // 'all_members' | 'admin_only'
+});
+```
+
+```kotlin [Kotlin]
+// New Group
+val group = alix.conversations.newGroup(listOf(bo.inboxId, caro.inboxId))
+
+// New Group with Metadata
+val group = alix.conversations.newGroup(listOf(bo.inboxId, caro.inboxId),
+  permissionLevel = GroupPermissionPreconfiguration.ALL_MEMBERS, // ALL_MEMBERS | ADMIN_ONLY
+  name = "The Group Name",
+  imageUrl = "www.groupImage.com",
+  description = "The description of the group",
+)
+```
+
+```swift [Swift]
+// New Group
+let group = try await alix.conversations.newGroup([bo.inboxId, caro.inboxId])
+
+// New Group with Metadata
+let group = try await alix.conversations.newGroup([bo.inboxId, caro.inboxId],
+  permissionLevel: .admin_only, // .all_members | .admin_only
+  name: "The Group Name",
+  imageUrl: "www.groupImage.com",
+  description: "The description of the group",
+)
+```
+
+:::
+
+## Optimistically create a new group chat
+
+Optimistic group creation enables instant group chat creation and message preparation before adding members and even when offline. This approach prioritizes user experience by allowing immediate interaction with the group chat, while handling the network synchronization in the background when members are added.
+
+Use this method to optimistically create a group chat, which enables a user to create a group chat now and add members later.
+
+The group chat can be created with any number of [standard options](/inboxes/group-metadata#updatable-group-chat-metadata), or no options. The group chat is stored only in the local storage of the app installation used to create it. In other words, the group chat is visible only to the creator and in the app installation they used to create it.
+
+You can prepare messages for the optimistic group chat immediately using `prepareMessage()`. As with the group chat itself, these messages are stored locally only.
+
+When you want to add members, you use [`addMembers()`](/inboxes/group-permissions#add-members-by-inbox-id) with a list of inbox IDs.
+
+Adding a member will automatically sync the group chat to the network. Once synced, the group chat becomes visible to the added members and across other app installations.
+
+After adding members, you must explicitly call `publishMessages()` to send any prepared messages to the network.
+
+To learn more about optimistically sending messages using `prepareMessage()` and `publishMessages()`, see [Optimistically send messages](/inboxes/send-messages#optimistically-send-messages).
+
+:::code-group
+
+```tsx [Browser]
+// create optimistic group (stays local)
+const optimisticGroup = await alixClient.conversations.newGroupOptimistic();
+
+// send optimistic message (stays local)
+await optimisticGroup.sendOptimistic("gm");
+
+// later, sync the group by adding members
+await optimisticGroup.addMembers([boClient.inboxId]);
+// or publishing messages
+await optimisticGroup.publishMessages();
+```
+
+```ts [Node]
+// create optimistic group (stays local)
+const optimisticGroup = client.conversations.newGroupOptimistic();
+
+// send optimistic message (stays local)
+optimisticGroup.sendOptimistic("gm");
+
+// later, sync the group by adding members
+await optimisticGroup.addMembers([boClient.inboxId]);
+// or publishing messages
+await optimisticGroup.publishMessages();
+```
+
+```tsx [React Native]
+const optimisticGroup = await boClient.conversations.newGroupOptimistic();
+
+// Prepare a message (stays local)
+await optimisticGroup.prepareMessage("Hello group!");
+
+// Later, add members and sync
+await optimisticGroup.addMembers([alixClient.inboxId]); // also syncs group to the network
+await optimisticGroup.publishMessages(); // Publish prepared messages
+```
+
+```kotlin [Kotlin]
+// Create optimistic group (stays local)
+val optimisticGroup = boClient.conversations.newGroupOptimistic(groupName = "Testing")
+
+// Prepare a message (stays local)
+optimisticGroup.prepareMessage("Hello group!")
+
+// Later, add members and sync
+optimisticGroup.addMembers(listOf(alixClient.inboxId)) // also syncs group to the network
+optimisticGroup.publishMessages() // Publish prepared messages
+```
+
+```swift [Swift]
+// Create optimistic group (stays local)
+let optimisticGroup = try await boClient.conversations.newGroupOptimistic(groupName: "Testing")
+
+// Prepare a message (stays local)
+try await optimisticGroup.prepareMessage("Hello group!")
+
+// Later, add members and sync
+try await  optimisticGroup.addMembers([alixClient.inboxId]) // also syncs group to the network
+try await  optimisticGroup.publishMessages() // Publish prepared messages
+```
+
+:::
+
+## Create a new DM
+
+Once you have the verified identity, get its inbox ID and create a new DM:
+
+:::code-group
+
+```js [Browser]
+const group = await client.conversations.newDm(bo.inboxId);
+```
+
+```js [Node]
+const group = await client.conversations.newDm(bo.inboxId);
+```
+
+```tsx [React Native]
+const dm = await alix.conversations.findOrCreateDm(bo.inboxId);
+```
+
+```kotlin [Kotlin]
+val dm = alix.conversations.findOrCreateDm(bo.inboxId)
+
+// calls the above function under the hood but returns a type conversation instead of a dm
+val conversation = client.conversations.newConversation(inboxId)
+```
+
+```swift [Swift]
+let dm = try await alix.conversations.findOrCreateDm(with: bo.inboxId)
+
+// calls the above function under the hood but returns a type conversation instead of a dm
+let conversation = try await client.conversations.newConversation(inboxId)
+```
+
+:::
+
+## Conversation helper methods
+
+Use these helper methods to quickly locate and access specific conversations—whether by conversation ID, topic, group ID, or DM identity—returning the appropriate ConversationContainer, group, or DM object.
+
+:::code-group
+
+```js [Browser]
+// get a conversation by its ID
+const conversationById = await client.conversations.getConversationById(
+  conversationId
+);
+
+// get a message by its ID
+const messageById = await client.conversations.getMessageById(messageId);
+
+// get a 1:1 conversation by a peer's inbox ID
+const dmByInboxId = await client.conversations.getDmByInboxId(peerInboxId);
+```
+
+```js [Node]
+// get a conversation by its ID
+const conversationById = await client.conversations.getConversationById(
+  conversationId
+);
+
+// get a message by its ID
+const messageById = await client.conversations.getMessageById(messageId);
+
+// get a 1:1 conversation by a peer's inbox ID
+const dmByInboxId = await client.conversations.getDmByInboxId(peerInboxId);
+```
+
+```tsx [React Native]
+// Returns a ConversationContainer
+await alix.conversations.findConversation(conversation.id);
+await alix.conversations.findConversationByTopic(conversation.topic);
+// Returns a Group
+await alix.conversations.findGroup(group.id);
+// Returns a DM
+await alix.conversations.findDmByIdentity(bo.identity);
+```
+
+```kotlin [Kotlin]
+// Returns a ConversationContainer
+alix.conversations.findConversation(conversation.id)
+alix.conversations.findConversationByTopic(conversation.topic)
+// Returns a Group
+alix.conversations.findGroup(group.id)
+// Returns a DM
+alix.conversations.findDmbyInboxId(bo.inboxId);
+```
+
+```swift [Swift]
+// Returns a ConversationContainer
+try alix.conversations.findConversation(conversation.id)
+try alix.conversations.findConversationByTopic(conversation.topic)
+// Returns a Group
+try alix.conversations.findGroup(group.id)
+// Returns a DM
+try alix.conversations. findDmbyInboxId(bo.inboxId)
+```
+
+:::
+
+## Conversation union type
+
+Serves as a unified structure for managing both group chats and DMs. It provides a consistent set of properties and methods to seamlessly handle various conversation types.
+
+- React Native: [Conversation.ts](https://github.com/xmtp/xmtp-react-native/blob/main/src/lib/Conversation.ts)
+
+## Group class
+
+Represents a group chat conversation, providing methods to manage group-specific functionalities such as sending messages, synchronizing state, and handling group membership.
+
+- React Native: [Group.ts](https://github.com/xmtp/xmtp-react-native/blob/main/src/lib/Group.ts)
+
+## Dm class
+
+Represents a DM conversation, providing methods to manage one-on-one communications, such as sending messages, synchronizing state, and handling message streams.
+
+- React Native: [Dm.ts](https://github.com/xmtp/xmtp-react-native/blob/main/src/lib/Dm.ts)
+
+
+## pages/inboxes/pick-an-sdk.md
+# Pick an SDK
+
+Choose the appropriate XMTP SDK based on your app platform and development needs.
+
+## Web
+
+This SDK is designed for web-based apps, offering seamless integration with browser environments: [Browser SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk)
+
+## Server
+
+This SDK is designed for backend applications, offering seamless integration with server environments: [Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk)
+
+## Mobile
+
+These SDKs provide native support for mobile app development across different platforms and frameworks.
+
+- [React Native SDK](https://github.com/xmtp/xmtp-react-native) 
+
+- [Kotlin SDK](https://github.com/xmtp/xmtp-android)
+
+- [Swift SDK](https://github.com/xmtp/xmtp-ios)
+
+
+## pages/inboxes/push-notifs/pn-server.md
+# Run a push notification server for an app built with XMTP
+
+This guide supplements the [core instructions](https://github.com/xmtp/example-notification-server-go/blob/np/export-kotlin-proto-code/README.md#local-setup) provided in the `example-notification-server-go` repository. The guide aims to address some common setup misconceptions and issues. 
+
+This guide is for macOS users, but the steps should be similar for Linux users.
+
+## Useful resources
+
+- [Notification server example implementation](https://github.com/xmtp/example-notification-server-go)
+- [Notification server integration test suite](https://github.com/xmtp/example-notification-server-go/blob/main/integration/README.md)
+
+## Install Docker
+
+1. Install Docker Desktop:
+
+   - [Mac](https://docs.docker.com/docker-for-mac/install/)
+   - [Windows](https://docs.docker.com/docker-for-windows/install/)
+   - [Linux](https://docs.docker.com/desktop/install/linux-install/)
+
+2. You must also have Docker and Docker Compose installed on your system. You can install them using Homebrew:
+
+   ```bash [Bash]
+   brew install docker docker-compose docker-credential-desktop
+   ```
+
+3. Make sure Docker Desktop is running by searching for Docker in Spotlight and opening the application. You don't need to interact with the Docker UI. We're going to use terminal commands only.
+
+## Install Go
+
+If you need to upgrade Go on your system, you can do it via Homebrew:
+
+```bash [Bash]
+brew install go
+```
+
+If you encounter an error like `Error: go 1.17.2 is already installed`, you already have Go installed on your system. 
+
+You can check the version of Go installed on your system using:
+
+```bash [Bash]
+brew update
+brew upgrade go
+```
+
+After following these steps, you can update Homebrew and upgrade Go without issues.
+
+## Set up the server
+
+1. To start the XMTP service and database, navigate to the project terminal and run:
+
+   ```bash [Bash]
+   ./dev/up
+   ```
+
+   ![set up the server](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd1.png)
+
+   If you encounter an error like `error getting credentials - err: docker-credential-desktop resolves to executable in current directory (./docker-credential-desktop), out:`, it's likely because Docker is not running. Make sure Docker Desktop is running and try the command again.
+
+2. Build the server using:
+
+   ```bash [Bash]
+   ./dev/build
+   ```
+
+   During the build, if you encounter any Go-related errors like missing `go.sum` entries, use the suggested `go get` or `go mod download` commands in the error messages to resolve them. For example, if you see `missing go.sum entry; to add it: go mod download golang.org/x/sys`, run:
+
+   ```bash [Bash]
+   go mod download golang.org/x/sys
+   ```
+
+   If you encounter errors related to Go build comments like `//go:build comment without // +build comment`, you can ignore them as they are warnings about future deprecations and won't prevent your code from running.
+
+## Run the server
+
+Run the server using the `./dev/run` script with the `--xmtp-listener` and `--api` flags:
+
+```bash [Bash]
+./dev/up
+```
+
+![./dev/up in CLI](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd2.png)
+
+```bash [Bash]
+source .env
+./dev/run --xmtp-listener --api
+```
+
+This starts both the `worker` and `api` services. The `worker` listens for new messages on the XMTP network and sends push notifications. The `api` service handles HTTP/GRPC requests.
+
+![./dev/run --xmtp-listener --api in CLI](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd3.png)
+
+You can now send notifications to your device using an [XMTP push notification client](https://github.com/xmtp/example-notification-server-go/blob/main/docs/notifications-client-guide.md).
+
+![dev/run in CLI](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd4.png)
+
+## Troubleshooting
+
+- If Docker or Docker Compose commands aren't recognized, it might mean that they aren't installed or their executable paths aren't included in your system's PATH variable. Make sure Docker and Docker Compose are installed and their paths are included in your system's PATH.
+
+- If you encounter Go-related errors during the build, it's often due to missing packages or outdated versions. Make sure your Go is up to date and use the `go get` or `go mod download` commands to fetch the necessary dependencies.
+
+- If you encounter any error like `./dev/up: line 3: docker-compose: command not found`, it's because you don't have Docker Compose installed on your system. Use the above command to install it.
+
+- If you see warnings about `//go:build comment without // +build comment`, these are warnings about future deprecations in Go. They won't prevent your code from running and can be ignored.
+
+- If `brew update` gives errors, it might be due to changes in Homebrew's repository. Homebrew switched to using `main` as its default branch. The steps provided in the "Upgrading Go" section should help resolve this issue.
+
+- If you encounter any errors during `brew update`, such as `fatal: couldn't find remote ref refs/heads/master`, Homebrew is having trouble updating its repositories. To fix this, run:
+
+  ```bash [Bash]
+  cd $(brew --repository)
+  git checkout main
+  git reset --hard origin/main
+  ```
+- Here is a piece of code that points to the ports and network. Be sure to use TLS like this `./dev/run --xmtp-listener-tls --api`.
+
+   :::code-group
+
+   ```tsx [Browser]
+   export const ApiUrls = {
+   local: "http://localhost:5555",
+   dev: "https://dev.xmtp.network",
+   production: "https://production.xmtp.network",
+   } as const;
+
+   export const HistorySyncUrls = {
+   local: "http://localhost:5558",
+   dev: "https://message-history.dev.ephemera.network",
+   production: "https://message-history.production.ephemera.network",
+   } as const;
+   ```
+
+   ```tsx [Node]
+   export const ApiUrls = {
+   local: "http://localhost:5556",
+   dev: "https://grpc.dev.xmtp.network:443",
+   production: "https://grpc.production.xmtp.network:443",
+   } as const;
+   ```
+
+   ```tsx [React Native]
+   const ApiUrls = {
+   local: 'http://localhost:5556',
+   dev: 'https://grpc.dev.xmtp.network:443',
+   production: 'https://grpc.production.xmtp.network:443'
+   }
+   ```
+
+   ```kotlin [Kotlin]
+   enum ApiUrls {
+      static let local = "http://localhost:5556"
+      static let dev = "https://grpc.dev.xmtp.network:443"
+      static let production = "https://grpc.production.xmtp.network:443"
+   }
+   ```
+
+   ```swift [Swift]
+   object ApiUrls {
+      const val local = "http://localhost:5556"
+      const val dev = "https://grpc.dev.xmtp.network:443"
+      const val production = "https://grpc.production.xmtp.network:443"
+   }
+   ```
+
+   :::
+
+## pages/inboxes/push-notifs/ios-pn.md
+# Try push notifications with the iOS example XMTP app
+
+This guide describes how to set up push notifications for the [XMTP iOS example app](https://github.com/xmtp/xmtp-ios/tree/main/XMTPiOSExample) built with the [xmtp-ios SDK](https://github.com/xmtp/xmtp-ios) using Firebase Cloud Messaging (FCM) and a custom notification server.
+
+Perform this setup to understand how you can enable push notifications for your own app built with the `xmtp-ios` SDK.
+
+## Prerequisites
+
+- An iOS device for testing. Push notifications don't work on simulators
+- A Firebase account and a project set up in the Firebase console
+
+## Set up Firebase Cloud Messaging
+
+For this tutorial, we'll use [Firebase Cloud Messaging](https://console.firebase.google.com/) (FCM) as a convenient way to set up a messaging server.
+
+1. Create an FCM project  
+Go to the [Firebase Console](https://console.firebase.google.com/), create a new project, and follow the setup instructions.
+
+2. Add your app to the FCM project  
+Add your iOS app to the project by following the Firebase setup workflow. You'll need your app's bundle ID.
+
+3. Download `GoogleService-Info.plist`  
+At the end of the setup, download the `GoogleService-Info.plist` file and add it to your Xcode project.
+
+4. Generate FCM credentials  
+In the Firebase console, navigate to your project settings, select the **Cloud Messaging** tab, and note your server key and sender ID. You'll need these for your notification server.
+
+## Configure the iOS example app for push notifications
+
+1. Enable push notifications  
+In Xcode, go to your project's target capabilities and enable push notifications.
+
+2. Register for notifications  
+Modify the `AppDelegate` to register for remote notifications and handle the device token.
+
+3. Handle incoming notifications  
+Implement the necessary delegate methods to handle incoming notifications and foreground notification display.
+
+## Run the notification server
+
+1. Clone and configure the notification server  
+If you're using the example notification server, clone the repository and follow the setup instructions. Make sure to configure it with your FCM server key.
+
+2. Run the server  
+Start the server locally or deploy it to a hosting service.
+
+- Subscribe to push notifications in the app  
+  When initializing the XMTP client in your app, subscribe to push notifications using the device token obtained during registration.
+
+- Decode a notification envelope  
+When you receive a push notification, you may want to decode the notification envelope to display a message preview or other information.
 
 ## pages/inboxes/push-notifs/push-notifs.md
 # Support push notifications
@@ -4870,128 +4554,6 @@ Then you can:
 - [Try push notifications with the iOS example XMTP app](/inboxes/push-notifs/ios-pn)
 
 
-## pages/inboxes/push-notifs/android-pn.md
-# Try push notifications with the Android example XMTP app
-
-This guide describes how to set up push notifications for the [XMTP Android example app](https://github.com/xmtp/xmtp-android/tree/main/example) built with the [xmtp-android SDK](https://github.com/xmtp/xmtp-android) using Firebase Cloud Messaging (FCM) and a custom notification server.
-
-Perform this setup to understand how you can enable push notifications for your own app built with the `xmtp-android` SDK.
-
-## Set up a Firebase Cloud Messaging server
-
-For this tutorial, we'll use [Firebase Cloud Messaging](https://console.firebase.google.com/) (FCM) as a convenient way to set up a messaging server.
-
-1. Create an FCM project.
-
-2. Add the example app to the FCM project. This generates a `google-services.json` file that you need in subsequent steps.
-
-3. Add the `google-services.json` file to the example app's project as described in the FCM project creation process.
-
-4. Generate FCM credentials, which you need to run the example notification server. To do this, from the FCM dashboard, click the gear icon next to **Project Overview** and select **Project settings**. Select **Service accounts**. Select **Go** and click **Generate new private key**.
-
-## Run an example notification server
-
-Now that you have an FCM server set up, take a look at the `kotlin` folder in the `example-notifications-server-go` repo.
-
-These files can serve as the basis for what you might want to provide for your own notification server. This proto code from the example notification server has already been generated and added to the `xmtp-android` example app if you use the example notification server as-is.
-
-**To run an example notification server:**
-
-1. Clone the [example-notification-server-go](https://github.com/xmtp/example-notification-server-go) repo.
-
-2. Complete the steps in [Local Setup](https://github.com/xmtp/example-notification-server-go/blob/np/export-kotlin-proto-code/README.md#local-setup).
-
-3. Get the FCM project ID and the FCM credentials you created in step 4 of setting up FCM and run:
-
-   ```bash [Bash]
-   YOURFCMJSON=$(cat /path/to/FCMCredentials.json)
-   ```
-
-   ```bash [Bash]
-   dev/run \
-   --xmtp-listener-tls \
-   --xmtp-listener \
-   --api \
-   -x "grpc.production.xmtp.network:443" \
-   -d "postgres://postgres:xmtp@localhost:25432/postgres?sslmode=disable" \
-   --fcm-enabled \
-   --fcm-credentials-json=$YOURFCMJSON \
-   --fcm-project-id="YOURFCMPROJECTID"
-   ```
-
-4. You should now be able to see push notifications coming across the local network.
-
-## Update the example app to send push notifications
-
-1. Add your `google-services.json` file to the `example` folder, if you haven't already done it as a part of the FCM project creation process.
-
-2. Uncomment `id 'com.google.gms.google-services'` in the example app's `build.gradle` file.
-
-3. Uncomment the following code in the top level of the example app's `build.gradle` file:
-
-   ```groovy [Groovy]
-   buildscript {
-       repositories {
-           google()
-           mavenCentral()
-       }
-       dependencies {
-           classpath 'com.google.gms:google-services:4.3.15'
-       }
-   }
-   ```
-
-4. Sync the Gradle project.
-
-5. Add the example notification server address to the example app's `MainActivity`. In this case, it should be `PushNotificationTokenManager.init(this, "10.0.2.2:8080")`.
-
-6. Change the example app's environment to `XMTPEnvironment.PRODUCTION` in `ClientManager.kt`.
-
-7. Set up the example app to register the FCM token with the network and then subscribe each conversation to push notifications. For example:
-
-   ```kotlin [Kotlin]
-   XMTPPush(context, "10.0.2.2:8080").register(token)
-   ```
-
-   ```kotlin [Kotlin]
-   val hmacKeysResult = ClientManager.client.conversations.getHmacKeys()
-   val subscriptions = conversations.map {
-       val hmacKeys = hmacKeysResult.hmacKeysMap
-       val result = hmacKeys[it.topic]?.valuesList?.map { hmacKey ->
-           Service.Subscription.HmacKey.newBuilder().also { sub_key ->
-               sub_key.key = hmacKey.hmacKey
-               sub_key.thirtyDayPeriodsSinceEpoch = hmacKey.thirtyDayPeriodsSinceEpoch
-           }.build()
-       }
-
-       Service.Subscription.newBuilder().also { sub ->
-           sub.addAllHmacKeys(result)
-           sub.topic = it.topic
-           sub.isSilent = it.version == Conversation.Version.V1
-       }.build()
-   }
-
-   XMTPPush(context, "10.0.2.2:8080").subscribeWithMetadata(subscriptions)
-   ```
-
-   ```kotlin [Kotlin]
-   XMTPPush(context, "10.0.2.2:8080").unsubscribe(conversations.map { it.topic })
-   ```
-
-## Decode a notification envelope
-
-You can decode a single `Envelope` from XMTP using the `decode` method:
-
-```kotlin [Kotlin]
-val conversation =
-    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
-
-// Assume this function returns an Envelope that contains a message for the above conversation
-val envelope = getEnvelopeFromXMTP()
-
-val decodedMessage = conversation.decode(envelope)
-```
-
 ## pages/inboxes/push-notifs/understand-push-notifs.mdx
 # Understand push notifications with XMTP
 
@@ -5141,263 +4703,161 @@ For example, you must consider that with DM stitching, the conversation is movin
 Also, you must consider that a welcome message will be sent when a DM conversation is added to the stitched DMs, and you should not send a push for the welcome message because the user already has a conversation with the person. It is just a different DM conversation in the set of DM conversations that are stitched together. These welcome messages are filtered out of streams, but they are not filtered out for the XMTP push notification server, so you must handle these duplicate DM welcomes at the push notification service.
 
 
-## pages/inboxes/push-notifs/pn-server.md
-# Run a push notification server for an app built with XMTP
+## pages/inboxes/push-notifs/android-pn.md
+# Try push notifications with the Android example XMTP app
 
-This guide supplements the [core instructions](https://github.com/xmtp/example-notification-server-go/blob/np/export-kotlin-proto-code/README.md#local-setup) provided in the `example-notification-server-go` repository. The guide aims to address some common setup misconceptions and issues. 
+This guide describes how to set up push notifications for the [XMTP Android example app](https://github.com/xmtp/xmtp-android/tree/main/example) built with the [xmtp-android SDK](https://github.com/xmtp/xmtp-android) using Firebase Cloud Messaging (FCM) and a custom notification server.
 
-This guide is for macOS users, but the steps should be similar for Linux users.
+Perform this setup to understand how you can enable push notifications for your own app built with the `xmtp-android` SDK.
 
-## Useful resources
-
-- [Notification server example implementation](https://github.com/xmtp/example-notification-server-go)
-- [Notification server integration test suite](https://github.com/xmtp/example-notification-server-go/blob/main/integration/README.md)
-
-## Install Docker
-
-1. Install Docker Desktop:
-
-   - [Mac](https://docs.docker.com/docker-for-mac/install/)
-   - [Windows](https://docs.docker.com/docker-for-windows/install/)
-   - [Linux](https://docs.docker.com/desktop/install/linux-install/)
-
-2. You must also have Docker and Docker Compose installed on your system. You can install them using Homebrew:
-
-   ```bash [Bash]
-   brew install docker docker-compose docker-credential-desktop
-   ```
-
-3. Make sure Docker Desktop is running by searching for Docker in Spotlight and opening the application. You don't need to interact with the Docker UI. We're going to use terminal commands only.
-
-## Install Go
-
-If you need to upgrade Go on your system, you can do it via Homebrew:
-
-```bash [Bash]
-brew install go
-```
-
-If you encounter an error like `Error: go 1.17.2 is already installed`, you already have Go installed on your system. 
-
-You can check the version of Go installed on your system using:
-
-```bash [Bash]
-brew update
-brew upgrade go
-```
-
-After following these steps, you can update Homebrew and upgrade Go without issues.
-
-## Set up the server
-
-1. To start the XMTP service and database, navigate to the project terminal and run:
-
-   ```bash [Bash]
-   ./dev/up
-   ```
-
-   ![set up the server](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd1.png)
-
-   If you encounter an error like `error getting credentials - err: docker-credential-desktop resolves to executable in current directory (./docker-credential-desktop), out:`, it's likely because Docker is not running. Make sure Docker Desktop is running and try the command again.
-
-2. Build the server using:
-
-   ```bash [Bash]
-   ./dev/build
-   ```
-
-   During the build, if you encounter any Go-related errors like missing `go.sum` entries, use the suggested `go get` or `go mod download` commands in the error messages to resolve them. For example, if you see `missing go.sum entry; to add it: go mod download golang.org/x/sys`, run:
-
-   ```bash [Bash]
-   go mod download golang.org/x/sys
-   ```
-
-   If you encounter errors related to Go build comments like `//go:build comment without // +build comment`, you can ignore them as they are warnings about future deprecations and won't prevent your code from running.
-
-## Run the server
-
-Run the server using the `./dev/run` script with the `--xmtp-listener` and `--api` flags:
-
-```bash [Bash]
-./dev/up
-```
-
-![./dev/up in CLI](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd2.png)
-
-```bash [Bash]
-source .env
-./dev/run --xmtp-listener --api
-```
-
-This starts both the `worker` and `api` services. The `worker` listens for new messages on the XMTP network and sends push notifications. The `api` service handles HTTP/GRPC requests.
-
-![./dev/run --xmtp-listener --api in CLI](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd3.png)
-
-You can now send notifications to your device using an [XMTP push notification client](https://github.com/xmtp/example-notification-server-go/blob/main/docs/notifications-client-guide.md).
-
-![dev/run in CLI](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/cmd4.png)
-
-## Troubleshooting
-
-- If Docker or Docker Compose commands aren't recognized, it might mean that they aren't installed or their executable paths aren't included in your system's PATH variable. Make sure Docker and Docker Compose are installed and their paths are included in your system's PATH.
-
-- If you encounter Go-related errors during the build, it's often due to missing packages or outdated versions. Make sure your Go is up to date and use the `go get` or `go mod download` commands to fetch the necessary dependencies.
-
-- If you encounter any error like `./dev/up: line 3: docker-compose: command not found`, it's because you don't have Docker Compose installed on your system. Use the above command to install it.
-
-- If you see warnings about `//go:build comment without // +build comment`, these are warnings about future deprecations in Go. They won't prevent your code from running and can be ignored.
-
-- If `brew update` gives errors, it might be due to changes in Homebrew's repository. Homebrew switched to using `main` as its default branch. The steps provided in the "Upgrading Go" section should help resolve this issue.
-
-- If you encounter any errors during `brew update`, such as `fatal: couldn't find remote ref refs/heads/master`, Homebrew is having trouble updating its repositories. To fix this, run:
-
-  ```bash [Bash]
-  cd $(brew --repository)
-  git checkout main
-  git reset --hard origin/main
-  ```
-- Here is a piece of code that points to the ports and network. Be sure to use TLS like this `./dev/run --xmtp-listener-tls --api`.
-
-   :::code-group
-
-   ```tsx [Browser]
-   export const ApiUrls = {
-   local: "http://localhost:5555",
-   dev: "https://dev.xmtp.network",
-   production: "https://production.xmtp.network",
-   } as const;
-
-   export const HistorySyncUrls = {
-   local: "http://localhost:5558",
-   dev: "https://message-history.dev.ephemera.network",
-   production: "https://message-history.production.ephemera.network",
-   } as const;
-   ```
-
-   ```tsx [Node]
-   export const ApiUrls = {
-   local: "http://localhost:5556",
-   dev: "https://grpc.dev.xmtp.network:443",
-   production: "https://grpc.production.xmtp.network:443",
-   } as const;
-   ```
-
-   ```tsx [React Native]
-   const ApiUrls = {
-   local: 'http://localhost:5556',
-   dev: 'https://grpc.dev.xmtp.network:443',
-   production: 'https://grpc.production.xmtp.network:443'
-   }
-   ```
-
-   ```kotlin [Kotlin]
-   enum ApiUrls {
-      static let local = "http://localhost:5556"
-      static let dev = "https://grpc.dev.xmtp.network:443"
-      static let production = "https://grpc.production.xmtp.network:443"
-   }
-   ```
-
-   ```swift [Swift]
-   object ApiUrls {
-      const val local = "http://localhost:5556"
-      const val dev = "https://grpc.dev.xmtp.network:443"
-      const val production = "https://grpc.production.xmtp.network:443"
-   }
-   ```
-
-   :::
-
-## pages/inboxes/push-notifs/ios-pn.md
-# Try push notifications with the iOS example XMTP app
-
-This guide describes how to set up push notifications for the [XMTP iOS example app](https://github.com/xmtp/xmtp-ios/tree/main/XMTPiOSExample) built with the [xmtp-ios SDK](https://github.com/xmtp/xmtp-ios) using Firebase Cloud Messaging (FCM) and a custom notification server.
-
-Perform this setup to understand how you can enable push notifications for your own app built with the `xmtp-ios` SDK.
-
-## Prerequisites
-
-- An iOS device for testing. Push notifications don't work on simulators
-- A Firebase account and a project set up in the Firebase console
-
-## Set up Firebase Cloud Messaging
+## Set up a Firebase Cloud Messaging server
 
 For this tutorial, we'll use [Firebase Cloud Messaging](https://console.firebase.google.com/) (FCM) as a convenient way to set up a messaging server.
 
-1. Create an FCM project  
-Go to the [Firebase Console](https://console.firebase.google.com/), create a new project, and follow the setup instructions.
+1. Create an FCM project.
 
-2. Add your app to the FCM project  
-Add your iOS app to the project by following the Firebase setup workflow. You'll need your app's bundle ID.
+2. Add the example app to the FCM project. This generates a `google-services.json` file that you need in subsequent steps.
 
-3. Download `GoogleService-Info.plist`  
-At the end of the setup, download the `GoogleService-Info.plist` file and add it to your Xcode project.
+3. Add the `google-services.json` file to the example app's project as described in the FCM project creation process.
 
-4. Generate FCM credentials  
-In the Firebase console, navigate to your project settings, select the **Cloud Messaging** tab, and note your server key and sender ID. You'll need these for your notification server.
+4. Generate FCM credentials, which you need to run the example notification server. To do this, from the FCM dashboard, click the gear icon next to **Project Overview** and select **Project settings**. Select **Service accounts**. Select **Go** and click **Generate new private key**.
 
-## Configure the iOS example app for push notifications
+## Run an example notification server
 
-1. Enable push notifications  
-In Xcode, go to your project's target capabilities and enable push notifications.
+Now that you have an FCM server set up, take a look at the `kotlin` folder in the `example-notifications-server-go` repo.
 
-2. Register for notifications  
-Modify the `AppDelegate` to register for remote notifications and handle the device token.
+These files can serve as the basis for what you might want to provide for your own notification server. This proto code from the example notification server has already been generated and added to the `xmtp-android` example app if you use the example notification server as-is.
 
-3. Handle incoming notifications  
-Implement the necessary delegate methods to handle incoming notifications and foreground notification display.
+**To run an example notification server:**
 
-## Run the notification server
+1. Clone the [example-notification-server-go](https://github.com/xmtp/example-notification-server-go) repo.
 
-1. Clone and configure the notification server  
-If you're using the example notification server, clone the repository and follow the setup instructions. Make sure to configure it with your FCM server key.
+2. Complete the steps in [Local Setup](https://github.com/xmtp/example-notification-server-go/blob/np/export-kotlin-proto-code/README.md#local-setup).
 
-2. Run the server  
-Start the server locally or deploy it to a hosting service.
+3. Get the FCM project ID and the FCM credentials you created in step 4 of setting up FCM and run:
 
-- Subscribe to push notifications in the app  
-  When initializing the XMTP client in your app, subscribe to push notifications using the device token obtained during registration.
+   ```bash [Bash]
+   YOURFCMJSON=$(cat /path/to/FCMCredentials.json)
+   ```
 
-- Decode a notification envelope  
-When you receive a push notification, you may want to decode the notification envelope to display a message preview or other information.
+   ```bash [Bash]
+   dev/run \
+   --xmtp-listener-tls \
+   --xmtp-listener \
+   --api \
+   -x "grpc.production.xmtp.network:443" \
+   -d "postgres://postgres:xmtp@localhost:25432/postgres?sslmode=disable" \
+   --fcm-enabled \
+   --fcm-credentials-json=$YOURFCMJSON \
+   --fcm-project-id="YOURFCMPROJECTID"
+   ```
 
-## pages/inboxes/content-types/reactions.mdx
----
-description: Learn how to use the reaction content type to support reactions in your app built with XMTP
----
+4. You should now be able to see push notifications coming across the local network.
 
-# Support reactions in your app built with XMTP
+## Update the example app to send push notifications
 
-Use the reaction content type to support reactions in your app. A reaction is a quick and often emoji-based way to respond to a message. Reactions are usually limited to a predefined set of emojis or symbols provided by the messaging app.
+1. Add your `google-services.json` file to the `example` folder, if you haven't already done it as a part of the FCM project creation process.
 
-## Use a local database for performance
+2. Uncomment `id 'com.google.gms.google-services'` in the example app's `build.gradle` file.
 
-Use a local database to store reactions. This enables your app to performantly display a reaction with its [referenced message](#send-a-reaction) when rendering message lists.
+3. Uncomment the following code in the top level of the example app's `build.gradle` file:
 
-### Install the package
+   ```groovy [Groovy]
+   buildscript {
+       repositories {
+           google()
+           mavenCentral()
+       }
+       dependencies {
+           classpath 'com.google.gms:google-services:4.3.15'
+       }
+   }
+   ```
 
-```bash [Bash]
-npm i @xmtp/content-type-reaction
+4. Sync the Gradle project.
+
+5. Add the example notification server address to the example app's `MainActivity`. In this case, it should be `PushNotificationTokenManager.init(this, "10.0.2.2:8080")`.
+
+6. Change the example app's environment to `XMTPEnvironment.PRODUCTION` in `ClientManager.kt`.
+
+7. Set up the example app to register the FCM token with the network and then subscribe each conversation to push notifications. For example:
+
+   ```kotlin [Kotlin]
+   XMTPPush(context, "10.0.2.2:8080").register(token)
+   ```
+
+   ```kotlin [Kotlin]
+   val hmacKeysResult = ClientManager.client.conversations.getHmacKeys()
+   val subscriptions = conversations.map {
+       val hmacKeys = hmacKeysResult.hmacKeysMap
+       val result = hmacKeys[it.topic]?.valuesList?.map { hmacKey ->
+           Service.Subscription.HmacKey.newBuilder().also { sub_key ->
+               sub_key.key = hmacKey.hmacKey
+               sub_key.thirtyDayPeriodsSinceEpoch = hmacKey.thirtyDayPeriodsSinceEpoch
+           }.build()
+       }
+
+       Service.Subscription.newBuilder().also { sub ->
+           sub.addAllHmacKeys(result)
+           sub.topic = it.topic
+           sub.isSilent = it.version == Conversation.Version.V1
+       }.build()
+   }
+
+   XMTPPush(context, "10.0.2.2:8080").subscribeWithMetadata(subscriptions)
+   ```
+
+   ```kotlin [Kotlin]
+   XMTPPush(context, "10.0.2.2:8080").unsubscribe(conversations.map { it.topic })
+   ```
+
+## Decode a notification envelope
+
+You can decode a single `Envelope` from XMTP using the `decode` method:
+
+```kotlin [Kotlin]
+val conversation =
+    client.conversations.newConversation("0x3F11b27F323b62B159D2642964fa27C46C841897")
+
+// Assume this function returns an Envelope that contains a message for the above conversation
+val envelope = getEnvelopeFromXMTP()
+
+val decodedMessage = conversation.decode(envelope)
 ```
 
-> In some SDKs, the `ReactionCodec` is already included in the SDK. If not, you can install the package using the following command:
+## pages/inboxes/content-types/read-receipts.mdx
+---
+description: Learn how to use the read receipt content type to support read receipts in your app built with XMTP
+---
+
+# Support read receipts in your app built with XMTP
+
+Use the read receipt content type to support read receipts in your app. A read receipt is a `timestamp` that indicates when a message was read. It is sent as a message and can be used to calculate the time since the last message was read.
+
+## Provide an opt-out option
+
+While this is a per-app decision, the best practice is to provide users with the option to opt out of sending read receipts. If a user opts out, when they read a message, a read receipt will not be sent to the sender of the message.
+
+## Install the package
+
+```bash [Bash]
+npm i @xmtp/content-type-read-receipt
+```
 
 ## Configure the content type
-
-After importing the package, you can register the codec.
 
 :::code-group
 
 <div data-title="Browser">
 
-```jsx
+```tsx
 import {
-  ContentTypeReaction,
-  ReactionCodec,
-} from "@xmtp/content-type-reaction";
+  ContentTypeReadReceipt,
+  ReadReceiptCodec,
+} from "@xmtp/content-type-read-receipt";
 // Create the XMTP client
 const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new ReactionCodec());
+xmtp.registerCodec(new ReadReceiptCodec());
 ```
 
 </div>
@@ -5405,143 +4865,116 @@ xmtp.registerCodec(new ReactionCodec());
 ```jsx [React Native]
 const client = await Client.create(signer, {
   env: "production",
-  codecs: [new ReactionCodec()],
+  codecs: [new ReadReceiptCodec()],
 });
 ```
 
 ```kotlin [Kotlin]
-import org.xmtp.android.library.codecs.ReactionCodec
+import org.xmtp.android.library.Client
+import org.xmtp.android.library.codecs.ReadReceiptCodec
 
-Client.register(codec = ReactionCodec())
+Client.register(codec = ReadReceiptCodec())
 ```
 
 ```swift [Swift]
-Client.register(ReactionCodec());
+ Client.register(codec: ReadReceiptCodec())
 ```
 
 :::
 
-## Send a reaction
-
-With XMTP, reactions are represented as objects with the following keys:
-
-- `reference`: ID of the message being reacted to
-
-- `action`: Action of the reaction (added or removed)
-
-- `content`: String representation of the reaction (smile, for example) to be interpreted by clients
-
-- `schema`: Schema of the reaction (Unicode, shortcode, or custom)
+## Send a read receipt
 
 :::code-group
 
-```tsx [Browser]
-const reaction = {
-  reference: someMessageID,
-  action: "added",
-  content: "smile",
-};
+```jsx [Browser]
+// The content of a read receipt message must be an empty object.
 
-await conversation.send(reaction, {
-  contentType: ContentTypeReaction,
-});
+await conversation.messages.send({}, ContentTypeReadReceipt);
 ```
 
 ```jsx [React Native]
-// Assuming you have a conversation object and the ID of the message you're reacting to
-const reactionContent = {
-  reaction: {
-    reference: messageId, // ID of the message you're reacting to
-    action: "added", // Action can be 'added' or 'removed'
-    schema: "unicode", // Schema can be 'unicode', 'shortcode', or 'custom'
-    content: "👍", // Content of the reaction
-  },
-};
-
-await conversation.send(reactionContent);
+await bobConversation.send({ readReceipt: {} });
 ```
 
 ```kotlin [Kotlin]
-import org.xmtp.android.library.codecs.Reaction
-import org.xmtp.android.library.codecs.ReactionAction
-import org.xmtp.android.library.codecs.ReactionSchema
-import org.xmtp.android.library.codecs.ContentTypeReaction
-import org.xmtp.android.library.SendOptions
+import org.xmtp.android.library.Client
+import org.xmtp.android.library.codecs.ReadReceipt
+import org.xmtp.android.library.codecs.ContentTypeReadReceipt
+import org.xmtp.android.library.messages.SendOptions
 
-val reaction = Reaction(
-    reference = messageToReact.id, // the ID of the message you're reacting to
-    action = ReactionAction.Added, // the action of the reaction
-    content = "U+1F603", // the content of the reaction
-    schema = ReactionSchema.Unicode // the schema of the reaction
-)
-conversation.send(
-    content = reaction,
-    options = SendOptions(contentType = ContentTypeReaction)
-)
+// Create a ReadReceipt instance
+val readReceipt = ReadReceipt
 
+// Send the read receipt
+aliceConversation.send(
+    content = readReceipt,
+    options = SendOptions(contentType = ContentTypeReadReceipt),
+)
 ```
 
 ```swift [Swift]
-let reaction = Reaction(
-    reference: messageToReact.id,
-    action: .added,
-    content: "U+1F603",
-    schema: .unicode
-)
+let read = ReadReceipt(timestamp: "2019-09-26T07:58:30.996+0200")
 
 try await conversation.send(
-    content: reaction,
-    options: .init(contentType: ContentTypeReaction)
+    content: read,
+    options: .init(contentType: ContentTypeReadReceipt)
 )
 ```
 
 :::
 
-## Receive a reaction
+## Receive a read receipt
 
-Now that you can send a reaction, you need a way to receive a reaction. For example:
+Here's how you can receive a read receipt:
 
 :::code-group
 
 ```tsx [Browser]
-if (message.contentType.sameAs(ContentTypeReaction)) {
-  // We've got a reaction.
-  const reaction: Reaction = message.content;
+if (message.contentType.sameAs(ContentTypeReadReceipt)) {
+  // The message is a read receipt
+  const timestamp = message.sent;
 }
 ```
 
 ```jsx [React Native]
-if (message.contentTypeId === "xmtp.org/reaction:1.0") {
-  const reaction = message.content();
-  return reaction;
-  //reaction.reference = id of the message being reacted to,
-  //reaction.action = 'added',
-  //reaction.schema =  'unicode',
-  //reaction.content = '💖',
+if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
+  return message.sent; //Date received
 }
 ```
 
 ```kotlin [Kotlin]
-if (message.contentType == ContentTypeReaction) {
-    // The message is a reaction
-    val reactionCodec = ReactionCodec()
-    val reaction: Reaction = reactionCodec.decode(message.content)
+val message: DecodedMessage = conversation.messages().first()
+if (message.encodedContent.type == ContentTypeReadReceipt) {
+    // The message is a ReadReceipt
+    val readReceipt: ReadReceipt? = message.content()
+    if (readReceipt != null) {
+      println("Message read at: ${message.sent}")
+    }
 }
 ```
 
 ```swift [Swift]
-let content: Reaction = try message.content()
+let content: ReadReceipt = try message.content()
+content.timestamp // "2019-09-26T07:58:30.996+0200"
 ```
 
-To handle unsupported content types, refer to the [fallback](/inboxes/list-and-stream/#handle-unsupported-content-types) section.
+:::
 
-## Display the reaction
+## Display a read receipt
 
-Generally, reactions should be interpreted as emoji. So, "smile" would translate to 😄 in UI clients. That being said, how you ultimately choose to render a reaction in your app is up to you.
+`ReadReceipts` have an `undefined` or `nil` fallback, indicating the message is not expected to be displayed. To learn more, see [Handle unsupported content types](/inboxes/list-and-stream/#handle-unsupported-content-types) section.
 
-## Notifications and reactions
+## Notifications and read receipts
 
-Reactions have `shouldPush` set to `false`, which means that reactions do not trigger push notifications as long as the notification server respects this flag.
+Read receipts have `shouldPush` set to `false`, which means that read receipts do not trigger push notifications as long as the notification server respects this flag.
+
+## Use a read receipt
+
+Generally, a read receipt indicator should be displayed under the message it's associated with. The indicator can include a timestamp. Ultimately, how you choose to display a read receipt indicator is completely up to you.
+
+The read receipt is provided as an **empty message** whose timestamp provides the data needed for the indicators. **Be sure to filter out read receipt empty messages and not display them to users.**
+
+You can use a read receipt timestamp to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the timestamp is lower.
 
 ## pages/inboxes/content-types/replies.mdx
 ---
@@ -5716,6 +5149,71 @@ For example, in Discord, users can reply to individual messages, and the reply p
 
 Note that the user experience of replies in iMessage and Slack follows more of a threaded pattern, where messages display in logical groupings, or threads. This reply content type doesn't support the threaded pattern. If you'd like to request support for a threaded reply pattern, [post an XIP idea](https://community.xmtp.org/c/development/ideas/54).
 
+## pages/inboxes/content-types/content-types.md
+# Understand content types with XMTP
+
+When you build an app with XMTP, all messages are encoded with a content type to ensure that an XMTP client knows how to encode and decode messages, ensuring interoperability and consistent display of messages across apps.
+
+In addition, message payloads are transported as a set of bytes. This means that payloads can carry any content type that a client supports, such as plain text, JSON, or even non-text binary or media content.
+
+At a high level, there are three categories of content types with XMTP:
+
+- Standard
+- Standards-track
+- Custom
+
+## Standard content types
+
+A standard content type is one that has undergone the XMTP Request for Comment (XRC) process and has been adopted as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs#readme) (XIP).
+
+Once adopted, a standard content type is bundled in XMTP client SDKs. A developer can then import the standard content type from an SDK for use in their app.
+
+Here is the current standard content type:
+
+### Text content type
+
+An app built with XMTP uses the `TextCodec` (plain text) standard content type by default. This means that if your app is sending plain text messages only, you don’t need to perform any additional steps related to content types.
+
+:::code-group
+
+```jsx [Browser]
+await conversation.send("gm");
+```
+
+```jsx [React Native]
+await conversation.send("gm");
+```
+
+```kotlin [Kotlin]
+conversation.send(text = "gm")
+```
+
+```swift [Swift]
+try await conversation.send(content: "gm")
+```
+
+:::
+
+## Standards-track content types
+
+A standards-track content type is one that's being actively reviewed for adoption as a standard content type through the XIP process.
+
+Here are standards-track content types that you can review, test, and adopt in your app today:
+
+- [Attachment content type](/inboxes/content-types/attachments/#support-attachments-smaller-than-1mb): Use to send attachments smaller than 1MB.
+- [Remote attachment content type](/inboxes/content-types/attachments#support-remote-attachments-of-any-size): Use to send attachments of any size.
+- [Multiple remote attachments content type](/inboxes/content-types/attachments#support-multiple-remote-attachments-of-any-size): Use to send attachments of any size.
+- [Read receipt content type](/inboxes/content-types/read-receipts): Use to send a read receipt, which is a `timestamp` that indicates when a message was read. 
+- [Reaction content type](/inboxes/content-types/reactions): Use a reaction to send a quick and often emoji-based way to respond to a message. 
+- [Reply content type](/inboxes/content-types/replies): Use a reply to send a direct response to a specific message in a conversation. Users can select and reply to a particular message instead of sending a new one.
+- [On-chain transaction reference content type](/inboxes/content-types/transaction-refs): Use to send references to on-chain transactions, such as crypto payments.
+
+## Create a custom content type
+
+Any developer building with XMTP can create a custom content type and immediately start using it in their app. Unlike a standard content type, use of a custom content type doesn't require prerequisite formal adoption through the XRC and XIP processes.
+
+To learn more, see [Build custom content types](/inboxes/content-types/custom).
+
 ## pages/inboxes/content-types/transaction-refs.mdx
 ---
 description: Learn how to implement an onchain transaction reference content type
@@ -5812,99 +5310,6 @@ const transactionRef: TransactionReference = message.content;
 ## Display the transaction reference
 
 Displaying a transaction reference typically involves rendering details such as the transaction hash, network ID, and any relevant metadata. Because the exact UI representation can vary based on your app's design, you might want to fetch on-chain data before showing it to the user.
-
-## pages/inboxes/content-types/content-types.md
-# Understand content types with XMTP
-
-When you build an app with XMTP, all messages are encoded with a content type to ensure that an XMTP client knows how to encode and decode messages, ensuring interoperability and consistent display of messages across apps.
-
-In addition, message payloads are transported as a set of bytes. This means that payloads can carry any content type that a client supports, such as plain text, JSON, or even non-text binary or media content.
-
-At a high level, there are three categories of content types with XMTP:
-
-- Standard
-- Standards-track
-- Custom
-
-## Standard content types
-
-A standard content type is one that has undergone the XMTP Request for Comment (XRC) process and has been adopted as an [XMTP Improvement Proposal](https://github.com/xmtp/XIPs#readme) (XIP).
-
-Once adopted, a standard content type is bundled in XMTP client SDKs. A developer can then import the standard content type from an SDK for use in their app.
-
-Here is the current standard content type:
-
-### Text content type
-
-An app built with XMTP uses the `TextCodec` (plain text) standard content type by default. This means that if your app is sending plain text messages only, you don’t need to perform any additional steps related to content types.
-
-:::code-group
-
-```jsx [Browser]
-await conversation.send("gm");
-```
-
-```jsx [React Native]
-await conversation.send("gm");
-```
-
-```kotlin [Kotlin]
-conversation.send(text = "gm")
-```
-
-```swift [Swift]
-try await conversation.send(content: "gm")
-```
-
-:::
-
-## Standards-track content types
-
-A standards-track content type is one that's being actively reviewed for adoption as a standard content type through the XIP process.
-
-Here are standards-track content types that you can review, test, and adopt in your app today:
-
-- [Attachment content type](/inboxes/content-types/attachments/#support-attachments-smaller-than-1mb): Use to send attachments smaller than 1MB.
-- [Remote attachment content type](/inboxes/content-types/attachments#support-remote-attachments-of-any-size): Use to send attachments of any size.
-- [Multiple remote attachments content type](/inboxes/content-types/attachments#support-multiple-remote-attachments-of-any-size): Use to send attachments of any size.
-- [Read receipt content type](/inboxes/content-types/read-receipts): Use to send a read receipt, which is a `timestamp` that indicates when a message was read. 
-- [Reaction content type](/inboxes/content-types/reactions): Use a reaction to send a quick and often emoji-based way to respond to a message. 
-- [Reply content type](/inboxes/content-types/replies): Use a reply to send a direct response to a specific message in a conversation. Users can select and reply to a particular message instead of sending a new one.
-- [On-chain transaction reference content type](/inboxes/content-types/transaction-refs): Use to send references to on-chain transactions, such as crypto payments.
-
-## Create a custom content type
-
-Any developer building with XMTP can create a custom content type and immediately start using it in their app. Unlike a standard content type, use of a custom content type doesn't require prerequisite formal adoption through the XRC and XIP processes.
-
-To learn more, see [Build custom content types](/inboxes/content-types/custom).
-
-## pages/inboxes/content-types/custom.md
----
-description: Learn how to build custom content types
----
-
-# Build custom content types
-
-Any developer building with XMTP can create a custom content type and immediately start using it in their app. Unlike a standard content type, use of a custom content type doesn't require prerequisite formal adoption through the XRC and XIP processes.
-
-Building a custom content type enables you to manage data in a way that's more personalized or specialized to the needs of your app.
-
-For example, if you need a content type that isn't covered by a [standard](/inboxes/content-types/content-types#standard-content-types) or [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content type, you can create a custom content type and begin using it immediately in your app.
-
-:::warning[warning]
-
-Be aware that your custom content type may not be automatically recognized or supported by other apps, which could result in the other apps overlooking or only displaying the fallback text for your custom content type.
-
-:::
-
-Fallback plain text is "alt text"-like description text that you can associate with a custom content type if you are concerned that a receiving app might not be able to handle the content. If the receiving app is unable to handle the custom content, it displays the fallback plain text instead.
-
-If another app wants to display your custom content type, they must implement your custom content type in their code exactly as it's defined in your code.
-
-For more common content types, you can usually find a [standard](/inboxes/content-types/content-types#standard-content-types) or [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content type to serve your needs.
-
-If your custom content type generates interest within the developer community, consider proposing it as a standard content type through the [XIP process](/intro/xips).
-
 
 ## pages/inboxes/content-types/attachments.mdx
 ---
@@ -6724,39 +6129,71 @@ if (message.contentType.sameAs(ContentTypeAttachment)) {
 ```
 
 
-## pages/inboxes/content-types/read-receipts.mdx
+## pages/inboxes/content-types/custom.md
 ---
-description: Learn how to use the read receipt content type to support read receipts in your app built with XMTP
+description: Learn how to build custom content types
 ---
 
-# Support read receipts in your app built with XMTP
+# Build custom content types
 
-Use the read receipt content type to support read receipts in your app. A read receipt is a `timestamp` that indicates when a message was read. It is sent as a message and can be used to calculate the time since the last message was read.
+Any developer building with XMTP can create a custom content type and immediately start using it in their app. Unlike a standard content type, use of a custom content type doesn't require prerequisite formal adoption through the XRC and XIP processes.
 
-## Provide an opt-out option
+Building a custom content type enables you to manage data in a way that's more personalized or specialized to the needs of your app.
 
-While this is a per-app decision, the best practice is to provide users with the option to opt out of sending read receipts. If a user opts out, when they read a message, a read receipt will not be sent to the sender of the message.
+For example, if you need a content type that isn't covered by a [standard](/inboxes/content-types/content-types#standard-content-types) or [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content type, you can create a custom content type and begin using it immediately in your app.
 
-## Install the package
+:::warning[warning]
+
+Be aware that your custom content type may not be automatically recognized or supported by other apps, which could result in the other apps overlooking or only displaying the fallback text for your custom content type.
+
+:::
+
+Fallback plain text is "alt text"-like description text that you can associate with a custom content type if you are concerned that a receiving app might not be able to handle the content. If the receiving app is unable to handle the custom content, it displays the fallback plain text instead.
+
+If another app wants to display your custom content type, they must implement your custom content type in their code exactly as it's defined in your code.
+
+For more common content types, you can usually find a [standard](/inboxes/content-types/content-types#standard-content-types) or [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content type to serve your needs.
+
+If your custom content type generates interest within the developer community, consider proposing it as a standard content type through the [XIP process](/intro/xips).
+
+
+## pages/inboxes/content-types/reactions.mdx
+---
+description: Learn how to use the reaction content type to support reactions in your app built with XMTP
+---
+
+# Support reactions in your app built with XMTP
+
+Use the reaction content type to support reactions in your app. A reaction is a quick and often emoji-based way to respond to a message. Reactions are usually limited to a predefined set of emojis or symbols provided by the messaging app.
+
+## Use a local database for performance
+
+Use a local database to store reactions. This enables your app to performantly display a reaction with its [referenced message](#send-a-reaction) when rendering message lists.
+
+### Install the package
 
 ```bash [Bash]
-npm i @xmtp/content-type-read-receipt
+npm i @xmtp/content-type-reaction
 ```
 
+> In some SDKs, the `ReactionCodec` is already included in the SDK. If not, you can install the package using the following command:
+
 ## Configure the content type
+
+After importing the package, you can register the codec.
 
 :::code-group
 
 <div data-title="Browser">
 
-```tsx
+```jsx
 import {
-  ContentTypeReadReceipt,
-  ReadReceiptCodec,
-} from "@xmtp/content-type-read-receipt";
+  ContentTypeReaction,
+  ReactionCodec,
+} from "@xmtp/content-type-reaction";
 // Create the XMTP client
 const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new ReadReceiptCodec());
+xmtp.registerCodec(new ReactionCodec());
 ```
 
 </div>
@@ -6764,116 +6201,143 @@ xmtp.registerCodec(new ReadReceiptCodec());
 ```jsx [React Native]
 const client = await Client.create(signer, {
   env: "production",
-  codecs: [new ReadReceiptCodec()],
+  codecs: [new ReactionCodec()],
 });
 ```
 
 ```kotlin [Kotlin]
-import org.xmtp.android.library.Client
-import org.xmtp.android.library.codecs.ReadReceiptCodec
+import org.xmtp.android.library.codecs.ReactionCodec
 
-Client.register(codec = ReadReceiptCodec())
+Client.register(codec = ReactionCodec())
 ```
 
 ```swift [Swift]
- Client.register(codec: ReadReceiptCodec())
+Client.register(ReactionCodec());
 ```
 
 :::
 
-## Send a read receipt
+## Send a reaction
 
-:::code-group
+With XMTP, reactions are represented as objects with the following keys:
 
-```jsx [Browser]
-// The content of a read receipt message must be an empty object.
+- `reference`: ID of the message being reacted to
 
-await conversation.messages.send({}, ContentTypeReadReceipt);
-```
+- `action`: Action of the reaction (added or removed)
 
-```jsx [React Native]
-await bobConversation.send({ readReceipt: {} });
-```
+- `content`: String representation of the reaction (smile, for example) to be interpreted by clients
 
-```kotlin [Kotlin]
-import org.xmtp.android.library.Client
-import org.xmtp.android.library.codecs.ReadReceipt
-import org.xmtp.android.library.codecs.ContentTypeReadReceipt
-import org.xmtp.android.library.messages.SendOptions
-
-// Create a ReadReceipt instance
-val readReceipt = ReadReceipt
-
-// Send the read receipt
-aliceConversation.send(
-    content = readReceipt,
-    options = SendOptions(contentType = ContentTypeReadReceipt),
-)
-```
-
-```swift [Swift]
-let read = ReadReceipt(timestamp: "2019-09-26T07:58:30.996+0200")
-
-try await conversation.send(
-    content: read,
-    options: .init(contentType: ContentTypeReadReceipt)
-)
-```
-
-:::
-
-## Receive a read receipt
-
-Here's how you can receive a read receipt:
+- `schema`: Schema of the reaction (Unicode, shortcode, or custom)
 
 :::code-group
 
 ```tsx [Browser]
-if (message.contentType.sameAs(ContentTypeReadReceipt)) {
-  // The message is a read receipt
-  const timestamp = message.sent;
-}
+const reaction = {
+  reference: someMessageID,
+  action: "added",
+  content: "smile",
+};
+
+await conversation.send(reaction, {
+  contentType: ContentTypeReaction,
+});
 ```
 
 ```jsx [React Native]
-if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
-  return message.sent; //Date received
-}
+// Assuming you have a conversation object and the ID of the message you're reacting to
+const reactionContent = {
+  reaction: {
+    reference: messageId, // ID of the message you're reacting to
+    action: "added", // Action can be 'added' or 'removed'
+    schema: "unicode", // Schema can be 'unicode', 'shortcode', or 'custom'
+    content: "👍", // Content of the reaction
+  },
+};
+
+await conversation.send(reactionContent);
 ```
 
 ```kotlin [Kotlin]
-val message: DecodedMessage = conversation.messages().first()
-if (message.encodedContent.type == ContentTypeReadReceipt) {
-    // The message is a ReadReceipt
-    val readReceipt: ReadReceipt? = message.content()
-    if (readReceipt != null) {
-      println("Message read at: ${message.sent}")
-    }
-}
+import org.xmtp.android.library.codecs.Reaction
+import org.xmtp.android.library.codecs.ReactionAction
+import org.xmtp.android.library.codecs.ReactionSchema
+import org.xmtp.android.library.codecs.ContentTypeReaction
+import org.xmtp.android.library.SendOptions
+
+val reaction = Reaction(
+    reference = messageToReact.id, // the ID of the message you're reacting to
+    action = ReactionAction.Added, // the action of the reaction
+    content = "U+1F603", // the content of the reaction
+    schema = ReactionSchema.Unicode // the schema of the reaction
+)
+conversation.send(
+    content = reaction,
+    options = SendOptions(contentType = ContentTypeReaction)
+)
+
 ```
 
 ```swift [Swift]
-let content: ReadReceipt = try message.content()
-content.timestamp // "2019-09-26T07:58:30.996+0200"
+let reaction = Reaction(
+    reference: messageToReact.id,
+    action: .added,
+    content: "U+1F603",
+    schema: .unicode
+)
+
+try await conversation.send(
+    content: reaction,
+    options: .init(contentType: ContentTypeReaction)
+)
 ```
 
 :::
 
-## Display a read receipt
+## Receive a reaction
 
-`ReadReceipts` have an `undefined` or `nil` fallback, indicating the message is not expected to be displayed. To learn more, see [Handle unsupported content types](/inboxes/list-and-stream/#handle-unsupported-content-types) section.
+Now that you can send a reaction, you need a way to receive a reaction. For example:
 
-## Notifications and read receipts
+:::code-group
 
-Read receipts have `shouldPush` set to `false`, which means that read receipts do not trigger push notifications as long as the notification server respects this flag.
+```tsx [Browser]
+if (message.contentType.sameAs(ContentTypeReaction)) {
+  // We've got a reaction.
+  const reaction: Reaction = message.content;
+}
+```
 
-## Use a read receipt
+```jsx [React Native]
+if (message.contentTypeId === "xmtp.org/reaction:1.0") {
+  const reaction = message.content();
+  return reaction;
+  //reaction.reference = id of the message being reacted to,
+  //reaction.action = 'added',
+  //reaction.schema =  'unicode',
+  //reaction.content = '💖',
+}
+```
 
-Generally, a read receipt indicator should be displayed under the message it's associated with. The indicator can include a timestamp. Ultimately, how you choose to display a read receipt indicator is completely up to you.
+```kotlin [Kotlin]
+if (message.contentType == ContentTypeReaction) {
+    // The message is a reaction
+    val reactionCodec = ReactionCodec()
+    val reaction: Reaction = reactionCodec.decode(message.content)
+}
+```
 
-The read receipt is provided as an **empty message** whose timestamp provides the data needed for the indicators. **Be sure to filter out read receipt empty messages and not display them to users.**
+```swift [Swift]
+let content: Reaction = try message.content()
+```
 
-You can use a read receipt timestamp to calculate the time since the last message was read. While iterating through messages, you can be sure that the last message was read at the timestamp of the read receipt if the string of the timestamp is lower.
+To handle unsupported content types, refer to the [fallback](/inboxes/list-and-stream/#handle-unsupported-content-types) section.
+
+## Display the reaction
+
+Generally, reactions should be interpreted as emoji. So, "smile" would translate to 😄 in UI clients. That being said, how you ultimately choose to render a reaction in your app is up to you.
+
+## Notifications and reactions
+
+Reactions have `shouldPush` set to `false`, which means that reactions do not trigger push notifications as long as the notification server respects this flag.
 
 ## pages/inboxes/user-consent/support-user-consent.md
 # Support user consent preferences to provide spam-free inboxes
@@ -7350,6 +6814,556 @@ Conversation created in an app on an SDK version **without** user consent suppor
 - There are no scenarios in which a user consent preference will be set to `denied`.
 
 
+## pages/protocol/signatures.md
+---
+description: "Learn about wallet signature types when using XMTP"
+---
+
+# Wallet signatures with XMTP
+
+Learn about the types of wallet address signatures you might be prompted to provide when using apps built with XMTP. These signatures are always made with a specific wallet address controlled by your wallet.
+
+## First-time app installation use
+
+The first time you use an installation of an app built with XMTP, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. For example:
+
+```text
+XMTP : Authenticate to inbox
+
+Inbox ID: ${INBOX_ID}
+Current time: ${YYYY-MM-DD HH:MM:SS UTC}
+```
+
+More specifically, the message will request that you sign:
+
+- A **Grant messaging access to app** message to grant the app installation access to messaging owned by your signing wallet address. For example:
+
+  ```text
+  - Grant messaging access to app
+    (ID: ${hex(INSTALLATION_PUBLIC_KEY)})
+  ```
+
+- A **Create inbox** message to create an XMTP inbox owned by your signing address, but only if you have never used an app installation built with XMTP v3 before. For example:
+
+  ```text
+  - Create inbox
+    (Owner: ${INITIAL_ADDRESS})
+  ```
+
+Sign the **XMTP : Authenticate to inbox** message with your wallet address to consent to the message requests.
+
+<img width="400" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/authen-to-inbox.PNG" alt="MetaMask wallet browser extension Sign this message? window showing an XMTP: Authenticate to inbox message" />
+
+## Sign to add another address to your inbox
+
+You can add another wallet address to your inbox at any time. For example, you might have started using an app with one wallet address and now want to use the app with an additional wallet address.
+
+If you decide to add another wallet address to your inbox, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign a **Link address to inbox** message. For example:
+
+```text
+- Link address to inbox
+  (Address: ${ASSOCIATED_ADDRESS})
+```
+
+Sign with the wallet address you want to add to grant it access to the inbox. You can now use your inbox to exchange messages using the wallet address you just added.
+
+## Sign to remove address from your inbox
+
+You can remove a wallet address from your inbox at any time.
+
+If you decide to remove a wallet address from your inbox, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign an **Unlink address from inbox** message. For example:
+
+```text
+- Unlink address from inbox
+  (Address: ${ASSOCIATED_ADDRESS})
+```
+
+Sign with the wallet address you want to remove to unlink it from your inbox. You can no longer access your inbox using the wallet address you removed.
+
+## Sign to change inbox recovery address
+
+The first time you used an app installation built with XMTP v3, the wallet address you used to create an inbox is automatically set as the inbox recovery address. You can change the recovery address to a different wallet address at any time.
+
+If you decide to change the recovery address, a **Sign this message?** window displays to request that you sign an **XMTP : Authenticate to inbox** message. Specifically, the message requests that you sign a **Change inbox recovery address** message. For example:
+
+```text
+- Change inbox recovery address
+  (Address: ${NEW_RECOVERY_ADDRESS})
+```
+
+Sign with the wallet address you want to set as the recovery address to change the recovery address.
+
+## Sign to consent to receive broadcast messages
+
+When you click a **Subscribe** button built with XMTP’s consent standards, you're prompted to sign an **XMTP : Grant inbox consent to sender** message.
+
+For example, here’s the MetaMask **Signature request** window that displays when clicking the **Subscribe** button on this [example subscription page](https://subscribe-broadcast.vercel.app/subscribe/button) connected to the XMTP `dev` network. You typically see **Subscribe** buttons like this on a web page or in a dapp.
+
+![MetaMask wallet browser extension Signature request window showing an "XMTP: Grant inbox consent to sender" message](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/consent-proof-sign.png)
+
+When you click **Sign**, you're consenting to receive broadcast messages from the publisher at your connected wallet address. You can see the publisher's sending address in the **Signature request** window.
+
+When you provide consent, you're adding the publisher's address to your personal XMTP allowed contacts list. This enables messages from the publisher to be displayed in your main inbox instead of being treated as a message from an unknown sender and placed in a secondary view.
+
+To learn about XMTP's consent standards, see [Understand how user consent preferences support spam-free inboxes](/inboxes/user-consent/user-consent).
+
+
+## pages/protocol/security.mdx
+# Messaging security properties with XMTP 
+
+XMTP delivers end-to-end encrypted 1:1 and group chat using the following resources:
+
+- Advanced cryptographic techniques
+- Secure key management practices
+- MLS ([Messaging Layer Security](https://www.rfc-editor.org/rfc/rfc9420.html))
+
+Specifically, XMTP messaging provides the comprehensive security properties covered in the following sections. In these sections, **group** refers to the MLS concept of a group, which includes both 1:1 and group conversations.
+
+🎥 **walkthrough: XMTP and MLS**
+
+This video provides a walkthrough of XMTP's implementation of MLS.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/g6I9qXOkDMo?si=o5pD2xwa_yynoP5s" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+
+To dive deeper into how XMTP implements MLS, see the [XMTP MLS protocol specification](https://github.com/xmtp/libxmtp/tree/main/xmtp_mls).
+
+## A deep dive into messaging security properties
+
+### Message confidentiality
+
+Ensures that the contents of messages in transit can't be read without the corresponding encryption keys.
+
+Message confidentiality is achieved through symmetric encryption, ensuring that only intended recipients can read the message content. [AEAD](#cryptographic-tools-in-use) (Authenticated Encryption with Associated Data) is used to encrypt the message content, providing robust protection against unauthorized access.
+
+## Forward secrecy
+
+Ensures that even if current session keys are compromised, past messages remain secure. 
+
+MLS achieves this by using the ratcheting mechanism, where the keys used to encrypt application messages are ratcheted forward every time a message is sent. When the old key is deleted, old messages can't be decrypted, even if the newer keys are known. This property is supported by using ephemeral keys during the key encapsulation process.
+
+## Post-compromise security
+
+Ensures that future messages remain secure even if current encryption keys are compromised.
+
+XMTP uses regular key rotation achieved through a commit mechanism with a specific update path in MLS, meaning a new group secret is encrypted to all other members. This essentially resets the key and an attacker with the old state can't derive the new secret, as long as the private key from the leaf node in the ratchet tree construction hasn't been compromised. This ensures forward secrecy and protection against future compromises.
+
+## Message authentication
+
+Validates the identity of the participants in the conversation, preventing impersonation.
+
+XMTP uses digital signatures to strongly guarantee message authenticity. These signatures ensure that each message is cryptographically signed by the sender, verifying the sender’s identity without revealing it to unauthorized parties. This prevents attackers from impersonating conversation participants.
+
+## Message integrity
+
+Ensures that messages can't be tampered with during transit and that messages are genuine and unaltered. 
+
+XMTP achieves this through the use of MLS. The combination of digital signatures and [AEAD](#cryptographic-tools-in-use) enables XMTP to detect changes to message content.
+
+## User anonymity
+
+Ensures that outsiders can't deduce the participants of a group, users who have interacted with each other, or the sender or recipient of individual messages.
+
+User anonymity is achieved through a combination of the following functions:
+
+- MLS Welcome messages encrypt the sender metadata and group ID, protecting the social graph.
+
+- XMTP adds a layer of encryption to MLS Welcome messages using [HPKE](#cryptographic-tools-in-use) (Hybrid Public Key Encryption). This prevents multiple recipients of the same Welcome message from being correlated to the same group.
+
+- XMTP uses MLS [PrivateMessage](https://www.rfc-editor.org/rfc/rfc9420.html#name-confidentiality-of-sender-d) framing to hide the sender and content of group messages.
+
+- XMTP’s backend doesn't authenticate reads or writes and only implements per-IP rate limits. Aside from Welcome messages, all payloads for a given group are stored under a single group ID, and any client may anonymously query or write to any group ID. Only legitimate members possess the correct encryption keys for a given group.
+
+It's technically possible for XMTP network node operators to analyze query patterns per IP address. However, clients may choose to obfuscate this information using proxying/onion routing.
+
+XMTP currently hides the sender of Welcome messages (used to add users to a group) but doesn't hide the Welcome message recipients. This makes it possible to determine how many groups a user was invited to but not whether the user did anything about the invitations.
+
+## Cryptographic tools in use
+
+XMTP messaging uses the ciphersuite _MLS_128_HPKEX25519_CHACHA20POLY1305_SHA256_Ed25519_.
+
+Here is a summary of individual cryptographic tools used to collectively ensure that XMTP messaging is secure, authenticated, and tamper-proof:
+
+- [HPKE](https://www.rfc-editor.org/rfc/rfc9180.html)
+
+    Used to encrypt Welcome messages, protect the identities of group invitees, and maintain the confidentiality of group membership. We use the ciphersuite HPKEX25519.
+
+- [AEAD](https://developers.google.com/tink/aead)
+
+    Used to ensure both confidentiality and integrity of messages. In particular, we use the ciphersuite CHACHA20POLY1305.
+
+- [SHA3_256 and SHA2_256](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)
+
+    XMTP uses two cryptographic hash functions to ensure data integrity and provide strong cryptographic binding. SHA3_256 is used in the multi-wallet identity structure. SHA2_256 is used in MLS. The ciphersuite is SHA256.
+
+- [Ed25519](https://ed25519.cr.yp.to/ed25519-20110926.pdf)
+
+    Used for digital signatures to provide secure, high-performance signing and verification of messages. The ciphersuite is Ed25519.
+
+
+## pages/intro/faq.mdx
+# FAQ about XMTP
+
+Get answers to the most frequently asked questions about XMTP.
+
+## What works with XMTP?
+
+In the spirit of web3 composability, here are **just a few** of the building blocks that work well with XMTP. Building your app with these tools can help you deliver and distribute an app—faster and with quality.
+
+:::tip
+This list is not exhaustive and is just a starting point. A highly extensible protocol like XMTP can work with more tools than those listed in each section.
+:::
+
+### Wallet connectors
+
+Here are some options for connecting wallets to your app built with XMTP:
+
+- [RainbowKit](https://www.rainbowkit.com/)  
+  Support for WalletConnect v2 is now standard in RainbowKit. To learn how to upgrade, see [Migrating to WalletConnect v2](https://www.rainbowkit.com/guides/walletconnect-v2).
+- [Thirdweb](https://thirdweb.com/)
+- [wagmi](https://wagmi.sh/)
+
+### Message payload storage
+
+Here are some options for storing encrypted message payload content:
+
+- [IPFS](https://ipfs.io/)
+- [ThirdwebStorage](https://portal.thirdweb.com/infrastructure/storage/how-storage-works)
+- [web3.storage](https://web3.storage/)
+
+### Wallet apps
+
+XMTP can be used with EVM-compatible wallet apps that support ECDSA signing on the secp256k1 elliptic curve. These include common wallet apps such as:
+
+- [Coinbase Wallet](https://www.coinbase.com/wallet)
+- [MetaMask](https://metamask.io/)
+- [Rainbow Wallet](https://rainbow.me/)
+- Most wallets in the [WalletConnect network](https://explorer.walletconnect.com/?type=wallet)
+
+The XMTP SDK **does not** include a wallet app abstraction, as XMTP assumes that developers have a way to obtain a wallet app connection.
+
+### Chains 
+
+XMTP can work with signatures from any private public key pair and currently supports EOAs and SCWs on Ethereum and Ethereum side-chains and L2s. 
+
+Because all Ethereum Virtual Machine (EVM) chains share the same Ethereum wallet and address format and XMTP messages are stored off-chain, XMTP is interoperable across EVM chains, including testnets. (XMTP itself does not use EVMs.) 
+
+For example, whether a user has their wallet app connected to Ethereum or an Ethereum side-chain or L2, their private key can generate and retrieve their XMTP key pair to give them access to XMTP. 
+
+XMTP is also chain-agnostic, so multi-chain support is possible.
+
+Here are just a few chains that work with XMTP:
+
+- [Arbitrum](https://arbitrum.foundation/)
+- [Avalanche](https://www.avax.com/)
+- [Base](https://base.org/)
+- [(BNB) Chain](https://www.bnbchain.org/)
+- [Ethereum](https://ethereum.org/)
+- [zk-EVM](https://linea.build/)
+- [Optimism](https://www.optimism.io/)
+- [Polygon](https://polygon.technology/)
+- [Scroll](https://www.scroll.io/)
+
+## Build with XMTP
+
+### Which languages does the XMTP SDK support?
+
+XMTP SDKs are [available for multiple languages](/inboxes/pick-an-sdk).
+
+### Which web3 libraries does the XMTP SDK require?
+
+The XMTP SDK currently requires you to use [ethers](https://ethers.org/) or another web3 library capable of supplying an [ethers Signer](https://docs.ethers.io/v5/api/signer/), such as [wagmi](https://wagmi.sh/).
+
+### What is the invalid key package error?
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hNlby-SfPzw?si=V7LqaBxk-i4xhbNC" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+
+### Where can I get official XMTP brand assets?
+
+See the [XMTP brand guidelines](https://github.com/xmtp/brand) GitHub repo.
+
+## Network
+
+See [Network FAQ](/network/run-a-node/#faq-about-the-xmtp-network).
+
+## Fees
+
+### Does XMTP have fees?
+
+XMTP core developers and researchers are working on a specific fee model for XMTP, with the following guiding principles in mind:
+
+- Fees will be dynamic to protect the network from Denial of Service (DoS) attacks.
+- Infrastructure costs for the network must remain low even when decentralized, and comparable to the costs for an equivalent centralized messaging service.
+- There must be a low "take rate": the biggest driver of cost must be infrastructure costs, with any remaining cost returned to the network.
+
+Have questions or feedback about the fee model for XMTP? See [XIP-57: Messaging fee collection](https://community.xmtp.org/t/xip-57-messaging-fee-collection/876) in the XMTP Community Forums.
+
+## Security
+
+### Has XMTP undergone a security audit?
+
+A security assessment of [LibXMTP](https://github.com/xmtp/libxmtp) and its use of Messaging Layer Security (MLS) was completed by [NCC Group](https://www.nccgroup.com/) in Dec 2024. 
+
+See [Public Report: XMTP MLS Implementation Review](https://www.nccgroup.com/us/research-blog/public-report-xmtp-mls-implementation-review/).
+
+## Storage
+
+### Where are XMTP messages stored?
+
+XMTP stores messages in the XMTP network before and after retrieval. App-specific message storage policies may vary.
+
+### What are the XMTP message retention policies?
+
+#### For XMTP’s blockchain and node databases:
+
+Currently, encrypted payloads are stored indefinitely.
+
+In the coming year, a retention policy will be added. 
+
+This retention policy would represent a minimum retention period, not a maximum.
+
+For example, a retention policy may look something like the following, though specifics are subject to change:
+  - One year for messages
+  - Indefinite storage for account information and personal preferences  
+
+The team is researching a way to provide this indefinite storage and have it scale forever. 
+- If research shows that it's possible, we'll share a plan for how it will be achieved. 
+- If research shows that it isn't possible, we'll share a plan that shows how retention periods will provide a permanent solution to storage scaling.
+
+Have questions or feedback regarding message storage and retention? Post to the [XMTP Community Forums](https://community.xmtp.org/c/development/ideas/54).
+
+#### For the on-device database managed by the XMTP SDK:
+
+Messages are stored for as long as the user decides to keep them. However, encryption keys are regularly rotated.
+
+### What are XMTP message storage and retrieval costs?
+
+Messages are stored off-chain on the XMTP network, with all nodes currently hosted by Ephemera. Ephemera currently absorbs all message storage and retrieval costs.
+
+Today, there are no message storage and retrieval-related fees incurred by developers for building with the XMTP SDK.
+
+## Messages
+
+### Which message formats does XMTP support?
+
+XMTP transports a message payload as a set of bytes that can represent any format that a developer wants to support, such as plain text, JSON, or non-text binary or media content.
+
+With XMTP, these message formats are called content types. Currently, there are two basic content types available. These content types aim to establish broad compatibility among apps built with XMTP.
+
+The XMTP community can propose and adopt standards for other content types, either informally or through a governance process.
+
+To learn more about content types, see [Content types](/inboxes/content-types/content-types).
+
+To learn more about the XMTP improvement proposals governance process, see [What is an XIP?](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md)
+ 
+### Does XMTP have a maximum message size?
+
+Yes. Messages sent on the XMTP network are limited to just short of 1MB (1048214 bytes).
+
+For this reason, XMTP supports [remote attachments](/inboxes/content-types/attachments).
+
+### Does XMTP support message deletion and editing?
+
+Not currently. However, Ephemera is exploring ways to support message deletion and editing.
+
+Have ideas about message deletion and editing? Post to the [XMTP Community Forums](https://community.xmtp.org/c/development/ideas/54).
+
+### Is XMTP more like email or chat?
+
+XMTP enables developers to implement messaging features and UX paradigms that best fit their needs. As a result, messages sent using apps built with XMTP might resemble many typical forms of communication, such as email, direct and group messaging, broadcasts, text messaging, push notifications, and more.
+
+## What is Ephemera?
+
+Ephemera is a web3 software company that contributes to XMTP, an open network, protocol, and standards for secure messaging between blockchain accounts.
+
+Ephemera employees work alongside other XMTP community members to build with and extend XMTP. Community [contributions and participation](https://community.xmtp.org/) are critical to the development and adoption of XMTP.
+
+Ephemera focuses on serving developers. We build [SDKs](/inboxes/pick-an-sdk), developer tools, and example apps that help developers build great experiences with XMTP.
+
+Ephemera [acquired Converse](https://paragraph.xyz/@ephemera/converse) in June 2024. Converse is now [Convos](https://github.com/ephemeraHQ/convos-app), open-sourced for the entire XMTP network.
+
+
+## pages/intro/build-with-llms.md
+# Use XMTP documentation with AI coding assistants
+
+To make it easier to use AI coding agents to build with XMTP, you can find an `llms-full.txt` file at [https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-full.txt](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-full.txt).
+
+This `llms-full.txt` file includes all XMTP documentation in a single plain text file for easy parsing by AI agents.
+
+If you’re using an LLM tool that allows custom context, you can upload or point to `llms-full.txt` to enhance your AI coding experience with XMTP.
+
+
+## pages/intro/dev-support.md
+# Get dev support for building with XMTP
+
+Building with XMTP and need help or think you've found a bug?
+
+Please open an issue in the relevant repo:
+
+- [Browser SDK](https://github.com/xmtp/xmtp-js/issues)
+- [Node SDK](https://github.com/xmtp/xmtp-js/issues)
+- [React Native SDK](https://github.com/xmtp/xmtp-react-native/issues)
+- [Android SDK](https://github.com/xmtp/xmtp-android/issues)
+- [iOS SDK](https://github.com/xmtp/xmtp-ios/issues)
+
+
+## pages/intro/xips.md
+# XMTP Improvement Proposals (XIPs)
+
+An XIP is a design document that proposes a new feature or improvement for XMTP or its processes or environment.
+
+XIPs intend to be the primary mechanisms for:
+
+- Proposing new features
+- Collecting community technical input on an issue
+- Documenting the design decisions that have gone into XMTP
+
+For these reasons, XIPs are a great way to learn about XMTP's newest features and participate in shaping the evolution of the protocol.
+
+To review the latest XIPs, see [Improvement Proposals](https://community.xmtp.org/c/xips/xip-drafts/53).
+
+To learn more about XIPs and how to participate in the process, including authoring an XIP of your own, see [XIP purpose, process, and guidelines](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-0-purpose-process.md).
+
+
+## pages/intro/intro.md
+# What is XMTP?
+
+XMTP (Extensible Message Transport Protocol) is the largest and most secure decentralized messaging network
+
+XMTP is open and permissionless, empowering any developer to build end-to-end encrypted 1:1, group, and agent messaging experiences, and more.
+
+## Why should I build with XMTP?
+
+Build with XMTP to:
+
+- **Deliver secure and private messaging**
+
+    Using the [Messaging Layer Security](/protocol/security) (MLS) standard, a ratified [IETF](https://www.ietf.org/about/introduction/) standard, XMTP provides end-to-end encrypted messaging with forward secrecy and post-compromise security.
+
+- **Provide spam-free inboxes**
+
+    In any open and permissionless messaging ecosystem, spam is an inevitable reality, and XMTP is no exception. However, with XMTP [user consent preferences](/inboxes/user-consent/user-consent), developers can give their users spam-free inboxes displaying conversations with chosen contacts only.
+
+- **Build on native crypto rails**
+    
+    Build with XMTP to tap into the capabilities of crypto and web3. Support decentralized identities, crypto transactions, and more, directly in a messaging experience.
+
+- **Empower users to own and control their communications**
+
+    With apps built with XMTP, users own their conversations, data, and identity. Combined with the interoperability that comes with protocols, this means users can access their end-to-end encrypted communications using any app built with XMTP.
+    
+- **Create with confidence**
+
+    Developers are free to create the messaging experiences their users want—on a censorship-resistant protocol architected to last forever. Because XMTP isn't a closed proprietary platform, developers can build confidently, knowing their access and functionality can't be revoked by a central authority.
+
+## Try an app built with XMTP
+
+One of the best ways to understand XMTP is to use an app built with XMTP.
+
+- Try [xmtp.chat](https://xmtp.chat/), an app made for devs to learn to build with XMTP—using an app built with XMTP.
+
+- Try the [Convos](https://www.convos.org/) messaging app. Convos is open source courtesy of [Ephemera](https://ephemerahq.com/), the company stewarding the development and adoption of XMTP.
+
+## Join the XMTP community
+
+- **XMTP builds in the open**
+
+    - Explore the documentation on this site
+    - Explore the open [XMTP GitHub org](https://github.com/xmtp), which contains code for LibXMTP, XMTP SDKs, and xmtpd, node software powering the XMTP testnet.
+    - Explore the open source code for [xmtp.chat](https://github.com/xmtp/xmtp-js/tree/main/apps/xmtp.chat), an app made for devs to learn to build with XMTP—using an app built with XMTP.
+
+- **XMTP is for everyone**
+
+    - [Join the conversation](https://community.xmtp.org/) and become part of the movement to redefine digital communications.
+
+
+## pages/network/network-nodes.mdx
+# XMTP testnet nodes
+
+For real-time statuses of nodes in the XMTP testnet, see [XMTP Node Status](https://status.testnet.xmtp-partners.xyz/).
+The following table lists the nodes currently registered to power the XMTP testnet.
+
+|  | Node operator | Node address |
+|-----|---------------|--------------|
+| 1 | Artifact Capital | xmtp.artifact.systems:443 |
+| 2 | Crystal One | xmtp.node-op.com:443 |
+| 3 | Emerald Onion | xmtp.disobey.net:443 |
+| 4 | Encapsulate | lb.validator.xmtp.testnet.encapsulate.xyz:443 |
+| 5 | Ethereum Name Service (ENS) | grpc.ens-xmtp.com:443 |
+| 6 | Laminated Labs | xmtp.validators.laminatedlabs.net:443 |
+| 7 | Next.id | xmtp.nextnext.id:443 |
+| 8 | Nodle | xmtpd.nodleprotocol.io:443 |
+| 9 | Ephemera | grpc.testnet.xmtp.network:443 |
+| 10 | Ephemera | grpc2.testnet.xmtp.network:443 |
+
+Here is a map of node locations:
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden" }}>
+  <iframe
+    src="https://www.google.com/maps/d/embed?mid=18y4nFTXQKdgiSJCQbEGl5dojPoHL3LQ&ehbc=2E312F&noprof=1"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allowFullScreen=""
+    loading="lazy"
+  ></iframe>
+</div>
+
+A purple pin indicates that the node is operated by a non-profit organization.
+
+## pages/network/run-a-node.mdx
+# Run an XMTP network node
+
+A [testnet of the decentralized XMTP network](/network/network-nodes) was launched in early December 2024. The XMTP testnet is powered by registered node operators running [xmtpd](https://github.com/xmtp/xmtpd), XMTP daemon software. xmtpd will also power mainnet.
+
+To learn more about the decentralized network, see [Decentralizing XMTP](https://xmtp.org/decentralizing-xmtp).
+
+## Interested in becoming a registered XMTP node operator?
+
+1. Review [XIP-54: XMTP network node operator qualification criteria](https://community.xmtp.org/t/xip-54-xmtp-network-node-operator-qualification-criteria/868).
+2. [Submit an application](https://docs.google.com/forms/d/e/1FAIpQLScBpJ0i962xBPpZZeI6q7-UMo5Bc2JkhvHR_v2rliLDoBkzXQ/viewform?usp=sharing) to become a registered node operator.
+
+## Already a registered node operator?
+
+To get started, see the [xmtpd-infrastructure](https://github.com/xmtp/xmtpd-infrastructure) repository, which provides infrastructure-as-code examples and tooling to help node operators deploy and manage xmtpd nodes.
+
+## FAQ about the XMTP network
+
+To follow and provide feedback on the engineering work covered in this FAQ, see the [Replication tracking task](https://github.com/xmtp/xmtpd/issues/118) in the [xmtpd repo](https://github.com/xmtp/xmtpd).
+
+### Is the XMTP network decentralized?
+
+A testnet of the decentralized XMTP network was launched in early December 2024.
+
+All of the nodes in the `dev` and `production` XMTP network environments are still operated by [Ephemera](https://ephemerahq.com/) (the company) and powered by [xmtp-node-go](https://github.com/xmtp/xmtp-node-go).
+
+These nodes in the `dev` and `production` XMTP network environments operate in US jurisdiction in compliance with Office of Foreign Assets Control (OFAC) sanctions and Committee on Foreign Investment in the United States (CFIUS) export compliance regulations. Accordingly, IP-based geoblocking is in place for the following countries/territories:
+
+- Cuba
+- Iran
+- North Korea 
+- Syria
+- The Crimea, Donetsk People’s Republic, and Luhansk People’s Republic regions of Ukraine
+
+### Is XMTP a blockchain?
+
+The testnet of the decentralized XMTP network includes two distributed systems:
+
+- The XMTP broadcast network
+- The XMTP appchain, which is an L3 blockchain securing all metadata that require strict ordering.
+
+To learn more, see [Decentralizing XMTP](https://xmtp.org/decentralizing-xmtp).
+
+The `dev` and `production` XMTP network environments do not use a blockchain. Nodes in these networks run software to store and transfer messages between blockchain accounts. For secure and reliable delivery of messages, the nodes participate in a consensus mechanism.
+
+### Will I be able to run my own XMTP node?
+
+At this time, not everyone will be able to run an XMTP node in the production decentralized XMTP network. 
+
+To learn more, see [XIP-54: XMTP network node operator qualification criteria](https://community.xmtp.org/t/xip-54-xmtp-network-node-operator-qualification-criteria/868).
+
+### Does XMTP have a token?
+
+XMTP does not currently have a token. Disregard any information regarding airdrops or token sales. If and when an official token is introduced, announcements will be made exclusively through XMTP's official channels.
+
+
 # Summary
 
-This documentation contains 44 files.
+This documentation contains 45 files.

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -177,6 +177,10 @@ export default defineConfig({
               link: "/inboxes/content-types/read-receipts",
             },
             {
+              text: "Onchain transactions",
+              link: "/inboxes/content-types/transactions",
+            },
+            {
               text: "Onchain transaction references",
               link: "/inboxes/content-types/transaction-refs",
             },

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -161,6 +161,14 @@ export default defineConfig({
               link: "/inboxes/content-types/attachments",
             },
             {
+              text: "Onchain transactions",
+              link: "/inboxes/content-types/transactions",
+            },
+            {
+              text: "Onchain transaction references",
+              link: "/inboxes/content-types/transaction-refs",
+            },
+            {
               text: "Reactions",
               link: "/inboxes/content-types/reactions",
             },
@@ -171,14 +179,6 @@ export default defineConfig({
             {
               text: "Read receipts",
               link: "/inboxes/content-types/read-receipts",
-            },
-            {
-              text: "Onchain transactions",
-              link: "/inboxes/content-types/transactions",
-            },
-            {
-              text: "Onchain transaction references",
-              link: "/inboxes/content-types/transaction-refs",
             },
             {
               text: "Custom content",

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -28,7 +28,7 @@ export default defineConfig({
   },
   iconUrl: "/x-mark-blue.png",
   topNav: [
-    { text: "XMTP status", link: "https://xmtp.chat/" },
+    { text: "XMTP status", link: "https://status.xmtp.org/" },
     { text: "XMTP.chat", link: "https://xmtp.chat/" },
     { text: "XMTP.org", link: "https://xmtp.org/" },
   ],


### PR DESCRIPTION
### Add documentation for the onchain transaction content type to support transaction execution in XMTP applications
Creates comprehensive documentation for the onchain transaction content type that enables XMTP applications to send transactions to wallets for execution. The changes include:

- Creates new documentation file [transactions.md](https://github.com/xmtp/docs-xmtp-org/pull/236/files#diff-a7f5e8afb1cfdc2de835448746a5ca97fbaebf0902da98b4997a92f5c9a6810b) with installation instructions, SDK compatibility information, and code examples for the `@xmtp/content-type-wallet-send-calls` package
- Updates quickstart guide [quickstart.md](https://github.com/xmtp/docs-xmtp-org/pull/236/files#diff-ecf4d7a28c47a3d6324bab66423d10493f277d828873425ea98e0707b8150ea6) to reference the new onchain transactions documentation
- Modifies navigation configuration in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/236/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) to add sidebar entry for onchain transactions and reorder transaction-related documentation items

#### 📍Where to Start
Start with the new documentation file [transactions.md](https://github.com/xmtp/docs-xmtp-org/pull/236/files#diff-a7f5e8afb1cfdc2de835448746a5ca97fbaebf0902da98b4997a92f5c9a6810b) to understand the onchain transaction content type functionality and implementation examples.



#### Changes since #236 opened

- Added documentation section for onchain transaction support in agents [afe5083]
----

_[Macroscope](https://app.macroscope.com) summarized afe5083._