### PR TITLE
Document static installation revocation

### DIFF
--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -59,7 +59,7 @@ To help users make informed decisions when managing and revoking their installat
 - Last date logged in
 - Device make and model
 
-Installation IDs that don't have this additional information can be treated as unknown installations, which can also provides helpful signals to users.
+Installation IDs that don't have this additional information can be treated as unknown installations, which can also provide helpful signals to users.
 
 
 Revoking convos

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -28,67 +28,43 @@ You can enable a user to add multiple identities to their inbox. Added identitie
 
 You can enable a user to remove an identity from their inbox. You cannot remove the recovery identity.
 
-## Add an identity to an inbox
+## Inbox update and installation limits
 
-:::warning[Warning]
+An inbox ID is limited to 256 inbox updates. Inbox updates include actions like:
 
-This function is delicate and should be used with caution. Adding an identity to an inbox ID B when it's already associated with an inbox ID A will cause the identity to lose access to inbox ID A.
+- Add a wallet
+- Remove a wallet
+- Add an installation
+- Revoke an installation
 
-:::
+This means that one inbox ID can have 256 installations. When you add an inbox ID to a group, you are adding every installation as a member of the group. This means a group with an inbox that has 200+ installations can very quickly make a group size very large, which can have downstream performance implications.
 
-:::code-group
+If an inbox is allowed to reach its limit of 256 inbox updates, the user will need to [rotate their inbox](#rotate-an-inbox-id) to continue using their identity with XMTP. Rotating their inbox will cause the user to lose of their existing conversations, but will enable them to continue using their identity with new XMTP conversations.
 
-```tsx [Browser]
-await client.unsafe_addAccount(signer, true)
-```
+To avoid this scenario altogether, inboxes are limited to having only 5 active installations. When an inbox has 5 active installations, the user must revoke 1 installation before they are able to add another. This helps keep groups to a reasonable size and also helps keep users from accidentally reaching the 256 limit. However, note that revoking a installation counts toward the 256 inbox update limit, so frequently revoking installations and adding new ones can still cause a user to quickly reach the inbox update limit.
 
-```tsx [Node]
-await client.unsafe_addAccount(signer, true)
-```
+### Rotate an inbox ID
 
-```jsx [React Native]
-await client.addAccount(identityToAdd)
-```
+When you create an inbox ID, there is nonce on it that is used to create the ID. If an inbox reaches its inbox updates limit, you can increment the nonce and it will create a new inbox ID associated with the user's information.
 
-```kotlin [Kotlin]
-client.addAccount(identityToAdd)
-```
+## Help users manage installations
 
-```swift [Swift]
-try await client.addAccount(newAccount: identityToAdd)
-```
+By default, your app stores the following information about installations:
 
-:::
+- `id` (random byte array)
+- `createdAt` (date)
 
-## Remove an identity from an inbox
+To help users make informed decisions when managing and revoking their installations, you should aim to store additional useful information about installations, such as:
 
-:::tip[Note]
- A recovery identity cannot be removed. For example, if an inbox has only one associated identity, that identity serves as the recovery identity and cannot be removed.
-:::
+- Last date logged in
+- Device make and model
 
-:::code-group
+Installation IDs that don't have this additional information can be treated as unknown installations, which can also provides helpful signals to users.
 
-```tsx [Browser]
-await client.removeAccount(identifier)
-```
 
-```tsx [Node]
-await client.removeAccount(identifier)
-```
-
-```jsx [React Native]
-await client.removeAccount(recoveryIdentity, identityToRemove)
-```
-
-```kotlin [Kotlin]
-client.removeAccount(recoveryIdentity, identityToRemove)
-```
-
-```swift [Swift]
-try await client.removeAccount(recoveryIdentity: recoveryIdentity, identityToRemove: identityToRemove)
-```
-
-:::
+Revoking convos
+- 5 inboxUpdates + 1 = 6
+- 5 installations - 1 = 4
 
 ## Revoke installations
 
@@ -182,64 +158,21 @@ try await client.revokeAllOtherInstallations(signingKey)
 
 Static installation revocation enables users to revoke installations without needing to log in or have access to their installations. 
 
-This feature is especially useful in a scenario where a user has reached the 5-installation limit and can't log in, but needs to revoke installations to make room for a new installation.
+This feature is especially useful in the following scenarios:
 
-Static revocation enables users to revoke installations using only their recovery address signer. For example:
+- A user has reached the 5-installation limit and can't log in to revoke installations to make room for a new installation.
+- A user logs out of an app installation and chooses the option to delete their local database. Choosing this option will cause them to permanently lose access to the installation. For this reason, you should revoke the installation.
 
-1. **Identify installations to revoke**: Determine which installation IDs to revoke
-2. **Create signature request**: Generate a signature request for the revocation
-3. **Sign with recovery address**: Use the recovery address signer to authorize the revocation
-4. **Apply revocation**: Submit the signed request to revoke the specified installations
+In both scenarios, static revocation enables logged out users to revoke installations using only their recovery address signer. 
+
+Here is how static installation revocation works behind the scenes:
+
+1. Determines which installation IDs to revoke
+2. Generates a signature request for the revocation
+3. Uses the recovery address signer to authorize the revocation
+4. Submits the signed request to revoke the specified installations
 
 :::code-group
-
-```tsx [Browser]
-import { Client, type Signer } from "@xmtp/browser-sdk";
-
-// Recovery address signer (the address that created the inbox)
-const recoveryAddressSigner: Signer = {
-  // Your recovery address signer implementation
-};
-
-// Installation IDs to revoke
-const installationIdsToRevoke = [
-  "installation_id_1",
-  "installation_id_2"
-];
-
-async function revokeInstallationsStatically() {
-  try {
-    // Create a signature request for revoking installations
-    const signatureRequest = await createRevocationSignatureRequest(
-      recoveryAddressSigner.getIdentifier().identifier,
-      installationIdsToRevoke
-    );
-    
-    // Sign the revocation request with the recovery address
-    const signature = await recoveryAddressSigner.signMessage(
-      signatureRequest.signatureText
-    );
-    
-    // Apply the signed revocation
-    await applyRevocationSignature({
-      signatureRequest,
-      signature,
-      recoveryAddress: recoveryAddressSigner.getIdentifier().identifier
-    });
-    
-    console.log("Successfully revoked installations:", installationIdsToRevoke);
-  } catch (error) {
-    console.error("Failed to revoke installations:", error);
-  }
-}
-
-// Apply the revocation
-revokeInstallationsStatically();
-```
-
-```tsx [Node]
-
-```
 
 ```jsx [React Native]
 
@@ -340,6 +273,68 @@ InboxState
   "inboxId": "string"
 }
 ```
+
+## Add an identity to an inbox
+
+:::warning[Warning]
+
+This function is delicate and should be used with caution. Adding an identity to an inbox ID B when it's already associated with an inbox ID A will cause the identity to lose access to inbox ID A.
+
+:::
+
+:::code-group
+
+```tsx [Browser]
+await client.unsafe_addAccount(signer, true)
+```
+
+```tsx [Node]
+await client.unsafe_addAccount(signer, true)
+```
+
+```jsx [React Native]
+await client.addAccount(identityToAdd)
+```
+
+```kotlin [Kotlin]
+client.addAccount(identityToAdd)
+```
+
+```swift [Swift]
+try await client.addAccount(newAccount: identityToAdd)
+```
+
+:::
+
+## Remove an identity from an inbox
+
+:::tip[Note]
+ A recovery identity cannot be removed. For example, if an inbox has only one associated identity, that identity serves as the recovery identity and cannot be removed.
+:::
+
+:::code-group
+
+```tsx [Browser]
+await client.removeAccount(identifier)
+```
+
+```tsx [Node]
+await client.removeAccount(identifier)
+```
+
+```jsx [React Native]
+await client.removeAccount(recoveryIdentity, identityToRemove)
+```
+
+```kotlin [Kotlin]
+client.removeAccount(recoveryIdentity, identityToRemove)
+```
+
+```swift [Swift]
+try await client.removeAccount(recoveryIdentity: recoveryIdentity, identityToRemove: identityToRemove)
+```
+
+:::
 
 ## FAQ
 

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -178,6 +178,77 @@ try await client.revokeAllOtherInstallations(signingKey)
 
 :::
 
+## Revoke installations without a client present
+
+Use this static installation revocation when you need to revoke an installation but can't create a client first.
+
+For example, this scenario might arise when a user uninstalls their app, tries to re-install it, and finds the re-install is blocked because they've reached the maximum number of installations for their inbox ID (5 installations). In this state, the app will be unable to create a client.
+
+You can use this function to enable a user to revoke installations without a client. Instead, you'll use their wallet and information available in their static local database to enable them to revoke one or more installations to free up slots so their reinstall can succeed.
+
+:::code-group
+
+```tsx [Browser]
+// ────────────────────────────────────────────────
+// 0. Inputs
+// ────────────────────────────────────────────────
+const DB_PATH = "/data/app/inbox.db";
+const ENC_KEY: Uint8Array | undefined = loadEncKey();
+const inboxId: string            = "ab12…ef";          // hex InboxId
+const wallet:  Wallet            = loadWallet();       // wallet used for XMTP
+const installationsToRevoke: Uint8Array[] = [
+  hexToBytes("deadbeef…01"),
+  // hexToBytes("cafebabe…02"),  // uncomment to drop multiple
+];
+
+// ────────────────────────────────────────────────
+// 1. Build an unsigned SignatureRequest
+// ────────────────────────────────────────────────
+const sigReq: SignatureRequest = await staticRevokeInstallations(
+  api,
+  DB_PATH,
+  ENC_KEY,
+  inboxId,
+  installationsToRevoke,
+);
+
+// ────────────────────────────────────────────────
+// 2. Sign with the inbox-owning wallet
+// ────────────────────────────────────────────────
+await sigReq.addWalletSignature(wallet);
+
+// ────────────────────────────────────────────────
+// 3. Publish the signed update
+// ────────────────────────────────────────────────
+await staticApplySignatureRequest(api, DB_PATH, ENC_KEY, sigReq);
+
+// ────────────────────────────────────────────────
+// 4. Retry client registration (slot is now free)
+// ────────────────────────────────────────────────
+const client = await Client.create(wallet, {
+  dbPath: DB_PATH,
+  encryptionKey: ENC_KEY,
+});
+```
+
+```tsx [Node]
+
+```
+
+```jsx [React Native]
+
+```
+
+```kotlin [Kotlin]
+
+```
+
+```swift [Swift]
+
+```
+
+:::
+
 ## View the inbox state
 
 Find an `inboxId` for an identity:

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -172,15 +172,42 @@ Here is how static installation revocation works behind the scenes:
 :::code-group
 
 ```jsx [React Native]
+  const states = await Client.inboxStatesForInboxIds('production', [inboxId])
 
+  const toRevokeIds = states[0].installations.map((i) => i.id)
+
+  await Client.revokeInstallations(
+    'production',
+    recoveryWallet,
+    inboxId,
+    toRevokeIds as InstallationId[]
+  )
 ```
 
 ```kotlin [Kotlin]
+        val states = Client.inboxStatesForInboxIds( listOf(inboxId), api)
+		
+	val toRevokeIds = states.first().installations.map { it.id }
 
+	Client.revokeInstallations(
+		api,
+		recoveryWallet,
+		inboxId,
+		toRevokeIds
+	)
 ```
 
 ```swift [Swift]
+        let states = try await Client.inboxStatesForInboxIds(inboxIds: [inboxId], api)
+		
+	let toRevokeIds = states.first.installations.map { $0.id }
 
+	try await Client.revokeInstallations(
+		api: api,
+		signingKey: recoveryWallet,
+		inboxId: inboxId,
+		installationIds: toRevokeIds
+	)
 ```
 
 :::

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -62,9 +62,6 @@ To help users make informed decisions when managing and revoking their installat
 Installation IDs that don't have this additional information can be treated as unknown installations, which can also provide helpful signals to users.
 
 
-Revoking convos
-- 5 inboxUpdates + 1 = 6
-- 5 installations - 1 = 4
 
 ## Revoke installations
 

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -178,57 +178,63 @@ try await client.revokeAllOtherInstallations(signingKey)
 
 :::
 
-## Revoke installations without a client present
+## Revoke installations for a user who can't log in
 
-Use this static installation revocation when you need to revoke an installation but can't create a client first.
+Static installation revocation enables users to revoke installations without needing to log in or have access to their installations. 
 
-For example, this scenario might arise when a user uninstalls their app, tries to re-install it, and finds the re-install is blocked because they've reached the maximum number of installations for their inbox ID (5 installations). In this state, the app will be unable to create a client.
+This feature is especially useful in a scenario where a user has reached the 5-installation limit and can't log in, but needs to revoke installations to make room for a new installation.
 
-You can use this function to enable a user to revoke installations without a client. Instead, you'll use their wallet and information available in their static local database to enable them to revoke one or more installations to free up slots so their reinstall can succeed.
+Static revocation enables users to revoke installations using only their recovery address signer. For example:
+
+1. **Identify installations to revoke**: Determine which installation IDs to revoke
+2. **Create signature request**: Generate a signature request for the revocation
+3. **Sign with recovery address**: Use the recovery address signer to authorize the revocation
+4. **Apply revocation**: Submit the signed request to revoke the specified installations
 
 :::code-group
 
 ```tsx [Browser]
-// ────────────────────────────────────────────────
-// 0. Inputs
-// ────────────────────────────────────────────────
-const DB_PATH = "/data/app/inbox.db";
-const ENC_KEY: Uint8Array | undefined = loadEncKey();
-const inboxId: string            = "ab12…ef";          // hex InboxId
-const wallet:  Wallet            = loadWallet();       // wallet used for XMTP
-const installationsToRevoke: Uint8Array[] = [
-  hexToBytes("deadbeef…01"),
-  // hexToBytes("cafebabe…02"),  // uncomment to drop multiple
+import { Client, type Signer } from "@xmtp/browser-sdk";
+
+// Recovery address signer (the address that created the inbox)
+const recoveryAddressSigner: Signer = {
+  // Your recovery address signer implementation
+};
+
+// Installation IDs to revoke
+const installationIdsToRevoke = [
+  "installation_id_1",
+  "installation_id_2"
 ];
 
-// ────────────────────────────────────────────────
-// 1. Build an unsigned SignatureRequest
-// ────────────────────────────────────────────────
-const sigReq: SignatureRequest = await staticRevokeInstallations(
-  api,
-  DB_PATH,
-  ENC_KEY,
-  inboxId,
-  installationsToRevoke,
-);
+async function revokeInstallationsStatically() {
+  try {
+    // Create a signature request for revoking installations
+    const signatureRequest = await createRevocationSignatureRequest(
+      recoveryAddressSigner.getIdentifier().identifier,
+      installationIdsToRevoke
+    );
+    
+    // Sign the revocation request with the recovery address
+    const signature = await recoveryAddressSigner.signMessage(
+      signatureRequest.signatureText
+    );
+    
+    // Apply the signed revocation
+    await applyRevocationSignature({
+      signatureRequest,
+      signature,
+      recoveryAddress: recoveryAddressSigner.getIdentifier().identifier
+    });
+    
+    console.log("Successfully revoked installations:", installationIdsToRevoke);
+  } catch (error) {
+    console.error("Failed to revoke installations:", error);
+  }
+}
 
-// ────────────────────────────────────────────────
-// 2. Sign with the inbox-owning wallet
-// ────────────────────────────────────────────────
-await sigReq.addWalletSignature(wallet);
-
-// ────────────────────────────────────────────────
-// 3. Publish the signed update
-// ────────────────────────────────────────────────
-await staticApplySignatureRequest(api, DB_PATH, ENC_KEY, sigReq);
-
-// ────────────────────────────────────────────────
-// 4. Retry client registration (slot is now free)
-// ────────────────────────────────────────────────
-const client = await Client.create(wallet, {
-  dbPath: DB_PATH,
-  encryptionKey: ENC_KEY,
-});
+// Apply the revocation
+revokeInstallationsStatically();
 ```
 
 ```tsx [Node]

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -45,7 +45,7 @@ To avoid this scenario altogether, inboxes are limited to having only 5 active i
 
 ### Rotate an inbox ID
 
-When you create an inbox ID, there is nonce on it that is used to create the ID. If an inbox reaches its inbox updates limit, you can increment the nonce and it will create a new inbox ID associated with the user's information.
+When you create an inbox ID, there is a nonce on it that is used to create the ID. If an inbox reaches its inbox updates limit, you can increment the nonce and it will create a new inbox ID associated with the user's information.
 
 ## Help users manage installations
 


### PR DESCRIPTION
### Document static installation revocation and inbox management limits including 256 inbox updates and 5 active installations in manage-inboxes.mdx
The documentation restructures and expands inbox management guidance with new sections covering installation limits and revocation processes. The changes include:

- Adds documentation for 256 inbox updates limit and 5 active installations limit with guidance on inbox ID rotation
- Introduces static installation revocation feature for users unable to access their installations
- Adds recommendations for storing installation metadata such as last login date and device information
- Reorganizes existing content about adding and removing identities from inboxes

#### 📍Where to Start
Start with the new "Inbox update and installation limits" section in [manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/238/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a) to understand the newly documented limits and constraints.



#### Changes since #238 opened

- Corrected grammatical error in inbox management documentation [776e10f]
- Corrected grammatical error in documentation [5855dfd]
- Removed draft content from inbox management documentation [50c6649]
- Added code examples for static installation revocation across React Native, Kotlin, and Swift [60e5337]
----

_[Macroscope](https://app.macroscope.com) summarized 60e5337._