### PR TITLE
Update home

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -20,7 +20,7 @@ import "../styles.css";
       icon="🤝"
     />
     <CustomHomePage.Tile
-      href="/inboxes/pick-an-sdk"
+      href="/inboxes/quickstart"
       title="Build chat inboxes"
       description="Build standalone inbox apps with 1:1 and group chats built with MLS"
       icon="📥"


### PR DESCRIPTION
### Update home page navigation link for 'Build chat inboxes' tile to redirect from '/inboxes/pick-an-sdk' to '/inboxes/quickstart'
The `href` attribute in the `CustomHomePage.Tile` component for the 'Build chat inboxes' tile is modified to point to '/inboxes/quickstart' instead of '/inboxes/pick-an-sdk' in [docs/pages/index.mdx](https://github.com/xmtp/docs-xmtp-org/pull/241/files#diff-e21e58ba504b9adc10039b3f8bf6939cf003cf21c26ace30807b99bf5c0229e1).

#### 📍Where to Start
Start with the `CustomHomePage.Tile` component for 'Build chat inboxes' in [docs/pages/index.mdx](https://github.com/xmtp/docs-xmtp-org/pull/241/files#diff-e21e58ba504b9adc10039b3f8bf6939cf003cf21c26ace30807b99bf5c0229e1).

----

_[Macroscope](https://app.macroscope.com) summarized 08cda9f._