### PR TITLE
Add upcoming releases link

### DIFF
--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -11,7 +11,7 @@ Building with XMTP gives your agent access to:
 
 ### Quickstart video guide
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/djRLnWUvwIA?si=JX25iQt57wgXnqVX" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/djRLnWUvwIA?si=JX25iQt57wgXnqVX" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
 
 ### Agent examples
 

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -53,6 +53,10 @@ export default defineConfig({
           link: "/intro/intro",
         },
         {
+          text: "Upcoming releases ↗",
+          link: "https://ephemerahq.notion.site/upcoming-xmtp-releases",
+        },
+        {
           text: "FAQ",
           link: "/intro/faq",
         },


### PR DESCRIPTION
### Add upcoming releases link to navigation menu in vocs.config.tsx
- Adds a new navigation link titled "Upcoming releases ↗" pointing to an external Notion page in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/246/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a)
- Updates HTML attributes in an iframe element from kebab-case to camelCase format (`frameborder` to `frameBorder`, `referrerpolicy` to `referrerPolicy`, `allowfullscreen` to `allowFullScreen`) in [docs/pages/agents/build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/246/files#diff-e4c7ad50c015ddc89cd44b428d9bcb6977ac9ab677dd59c843632bb3e1160288)

#### 📍Where to Start
Start with the navigation configuration changes in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/246/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) where the new "Upcoming releases" link has been added to the navigation menu.

----

_[Macroscope](https://app.macroscope.com) summarized ad867e0._