### PR TITLE
Add installation limit and static revocation walkthrough video

### DIFF
--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -30,6 +30,12 @@ You can enable a user to remove an identity from their inbox. You cannot remove 
 
 ## Inbox update and installation limits
 
+### 🎥 walkthrough: Installation limits and static revocation
+
+This video provides a walkthrough of the idea behind the XMTP installation limit (5) and how to use [static installation revocation](#revoke-installations-for-a-user-who-cant-log-in). After watching, feel free to continue reading for more details.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/66bHc_MBQKo?si=5ZuqFBrQm885ILSk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 An inbox ID is limited to 256 inbox updates. Inbox updates include actions like:
 
 - Add a wallet
@@ -60,8 +66,6 @@ To help users make informed decisions when managing and revoking their installat
 - Device make and model
 
 Installation IDs that don't have this additional information can be treated as unknown installations, which can also provide helpful signals to users.
-
-
 
 ## Revoke installations
 
@@ -152,6 +156,8 @@ try await client.revokeAllOtherInstallations(signingKey)
 :::
 
 ### Revoke installations for a user who can't log in
+
+For a video walkthrough of this feature, see [🎥 walkthrough: Installation limits and static revocation](#-walkthrough-installation-limits-and-static-revocation).
 
 Static installation revocation enables users to revoke installations without needing to log in or have access to their installations. 
 


### PR DESCRIPTION
### Add installation limit and static revocation walkthrough video to inbox management documentation
Adds a new documentation section containing an embedded YouTube video walkthrough that explains XMTP installation limits and static installation revocation in [docs/pages/inboxes/manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/248/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a). The video is embedded using an iframe element and includes a reference link in the existing "Revoke installations for a user who can't log in" section.

#### 📍Where to Start
Start with the new "🎥 walkthrough: Installation limits and static revocation" section in [docs/pages/inboxes/manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/248/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a).

----

_[Macroscope](https://app.macroscope.com) summarized 41578f4._