### PR TITLE
Debug and sign

### DIFF
--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -231,6 +231,11 @@ export default defineConfig({
           ]
         },
         {
+          text: "Debug your app",
+          link: "/inboxes/debug-your-app",
+          items: [],
+        },
+        {
           text: "Upgrade to a stable XMTP V3 SDK",
           collapsed: false,
           items: [
@@ -243,7 +248,12 @@ export default defineConfig({
               link: "/upgrade-from-legacy-V3",
             },
           ],
-        },    
+        },
+        {
+          text: "Sign and verify payloads",
+          link: "/inboxes/use-signatures",
+          items: [],
+        },
       {
       text: "Network",
       collapsed: false,


### PR DESCRIPTION
### Add debug and sign navigation items to documentation sidebar in vocs.config.tsx
This change adds two new navigation items to the documentation configuration: "Debug your app" linking to `/inboxes/debug-your-app` and "Sign and verify payloads" linking to `/inboxes/use-signatures`. The modification also corrects indentation formatting for the "Network" section in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/250/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a).

#### 📍Where to Start
Start with the navigation configuration section in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/250/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) where the new sidebar items are added.

----

_[Macroscope](https://app.macroscope.com) summarized 531619c._