### PR TITLE
Update network statistics for browser and node SDKs

### DIFF
--- a/docs/pages/inboxes/debug-your-app.md
+++ b/docs/pages/inboxes/debug-your-app.md
@@ -63,10 +63,10 @@ These statistics are maintained per client instance, so each app installation ha
 
 ### Get aggregated statistics
 
-To return aggregated statistics, you can run:
+To return aggregated statistics, run:
 
-- Browser and Node SDKs: `client.apiAggregateStatistics()`
-- React Native, iOS, and Android SDKs: `client.debugInformation.aggregateStatistics` 
+- For Browser, Node, iOS, and Android SDKs: `client.debugInformation.apiAggregateStatistics()`
+- For React Native SDK: `client.debugInformation.aggregateStatistics`
 
 ```text
 Aggregate Stats:
@@ -89,23 +89,32 @@ SubscribeWelcomes       0
 
 ### Get an individual statistic
 
-To return an individual statistic as a number, you can run:
+To return an individual statistic as a number, run:
 
-- Browser and Node SDKs:
-  - `client.apiStatistics().uploadKeyPackage` to track `uploadKeyPackage` only
-  - `client.apiIdentityStatistics().publishIdentityUpdate` to track `PublishIdentityUpdate` only
-- React Native, iOS, and Android SDKs: 
-  - `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeyPackage` only
-  - `client.debugInformation.apiIdentityStatistics.publishIdentityUpdate` to track `publishIdentityUpdate` only
+- `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeyPackage` only, for example
+- `client.debugInformation.apiIdentityStatistics.publishIdentityUpdate` to track `publishIdentityUpdate` only, for example
+
+For available individual statistics, see [Statistic descriptions](#statistic-descriptions).
 
 ### Clear statistics
 
-To clear all API, identity, and stream statistics and set them to zero, you can run:
-
-- Browser and Node SDKs: `client.clearAllStatistics()`
-- React Native, iOS, and Android SDKs: `client.debugInformation.clearAllStatistics()`
+To clear all API, identity, and stream statistics and set them to zero, run `client.debugInformation.clearAllStatistics()`.
 
 This is useful when you want to get a clean baseline before running specific actions. It's also particularly helpful for managing memory usage on mobile devices where gRPC client caching can accumulate large statistics.
+
+### Upload an archive of network statistics
+
+With the Browser and Node SDKs, you can upload an archive of collected network statistics.
+
+```tsx [TypeScript]
+// Upload to default server (no serverUrl needed)
+const result1 = await client.debugInformation.uploadDebugArchive();
+
+// Upload to custom server (serverUrl provided)
+const result2 = await client.debugInformation.uploadDebugArchive(
+  "https://my-debug-server.com/api/upload"
+);
+```
 
 ### Statistic descriptions
 

--- a/docs/pages/inboxes/debug-your-app.md
+++ b/docs/pages/inboxes/debug-your-app.md
@@ -91,8 +91,13 @@ SubscribeWelcomes       0
 
 To return an individual statistic as a number, run:
 
-- `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeyPackage` only, for example
-- `client.debugInformation.apiIdentityStatistics.publishIdentityUpdate` to track `publishIdentityUpdate` only, for example
+- For Browser, Node, iOS, and Android SDKs: 
+  - `client.debugInformation.apiStatistics.uploadKeyPackage` to track `uploadKeyPackage` only, for example
+  - `client.debugInformation.apiIdentityStatistics.publishIdentityUpdate` to track `publishIdentityUpdate` only, for example
+
+- For React Native SDK:
+  - `client.debugInformation.Statistics.uploadKeyPackage` to track `uploadKeyPackage` only, for example
+  - `client.debugInformation.IdentityStatistics.publishIdentityUpdate` to track `publishIdentityUpdate` only, for example
 
 For available individual statistics, see [Statistic descriptions](#statistic-descriptions).
 


### PR DESCRIPTION
### Update network statistics documentation to standardize API references across Browser and Node SDKs and add uploadDebugArchive functionality
The documentation updates standardize API method references across SDK platforms and add new functionality for uploading network statistics:

- Standardizes Browser, Node, iOS, and Android SDKs to use `client.debugInformation.apiAggregateStatistics()` while React Native SDK continues using `client.debugInformation.aggregateStatistics`
- Consolidates individual statistics and clearing statistics instructions to use consistent `debugInformation` namespace methods across all SDK types
- Adds new "Upload an archive of network statistics" section documenting `uploadDebugArchive()` method for Browser and Node SDKs with examples for default and custom server uploads

#### 📍Where to Start
Start with the updated API method references in the aggregated statistics section of [debug-your-app.md](https://github.com/xmtp/docs-xmtp-org/pull/252/files#diff-494e288b115bcb23dd0effd89bf3d2b5e3f54a38ad92e539434bad9008227adf).



#### Changes since #252 opened

- Updated documentation to provide platform-specific instructions for accessing debug statistics across different SDK platforms [8c8594c]
----

_[Macroscope](https://app.macroscope.com) summarized 8c8594c._