### PR TITLE
Add Browser and Node code samples for static installation revocation

### DIFF
--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -177,6 +177,90 @@ Here is how static installation revocation works behind the scenes:
 
 :::code-group
 
+```tsx [Browser]
+// Step 1: Get inbox state data for the specified inbox IDs.
+// Gets the installation data needed to revoke installations.
+static async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
+  const host = ApiUrls[env ?? "dev"];
+  return inboxStateFromInboxIds(host, inboxIds);
+}
+
+// Step 2: Call the method to get inbox states
+// The second argument is optional and defaults to "dev" if not provided
+const inboxStates = Client.inboxStateFromInboxIds([inboxId], "production");
+
+// Step 3: Access the installation ID bytes from the first inbox state
+// This gets the raw bytes needed for the revocation request
+const installationBytes = inboxStates[0].installations[0].bytes
+
+// Step 4: Call Client.revokeInstallations to revoke the specified installations
+// This method allows revocation without needing an active client instance
+await Client.revokeInstallations(
+  signer,           // The signer (recovery wallet) to authorize the revocation
+  inboxId,          // The inbox ID containing the installations to revoke
+  [installationIdBytes], // Array of installation ID bytes to revoke
+  "production",     // The XMTP environment
+);
+
+// Method signature for reference:
+/**
+ * Revokes specific installations of the client's inbox without a client
+ *
+ * @param env - The environment to use
+ * @param signer - The signer to use
+ * @param inboxId - The inbox ID to revoke installations for
+ * @param installationIds - The installation IDs to revoke
+ */
+static async revokeInstallations(
+  signer: Signer,
+  inboxId: string,
+  installationIds: Uint8Array[],
+  env?: XmtpEnv,
+) => Promise<void>
+```
+
+```tsx [Node]
+// Step 1: Get inbox state data for the specified inbox IDs.
+// Gets the installation data needed to revoke installations.
+static async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
+  const host = ApiUrls[env ?? "dev"];
+  return inboxStateFromInboxIds(host, inboxIds);
+}
+
+// Step 2: Call the method to get inbox states
+// The second argument is optional and defaults to "dev" if not provided
+const inboxStates = Client.inboxStateFromInboxIds([inboxId], "production");
+
+// Step 3: Access the installation ID bytes from the first inbox state
+// This gets the raw bytes needed for the revocation request
+const installationBytes = inboxStates[0].installations[0].bytes
+
+// Step 4: Call Client.revokeInstallations to revoke the specified installations
+// This method allows revocation without needing an active client instance
+await Client.revokeInstallations(
+  signer,           // The signer (recovery wallet) to authorize the revocation
+  inboxId,          // The inbox ID containing the installations to revoke
+  [installationIdBytes], // Array of installation ID bytes to revoke
+  "production",     // The XMTP environment
+);
+
+// Method signature for reference:
+/**
+ * Revokes specific installations of the client's inbox without a client
+ *
+ * @param env - The environment to use
+ * @param signer - The signer to use
+ * @param inboxId - The inbox ID to revoke installations for
+ * @param installationIds - The installation IDs to revoke
+ */
+static async revokeInstallations(
+  signer: Signer,
+  inboxId: string,
+  installationIds: Uint8Array[],
+  env?: XmtpEnv,
+) => Promise<void>
+```
+
 ```jsx [React Native]
   const states = await Client.inboxStatesForInboxIds('production', [inboxId])
 
@@ -420,7 +504,7 @@ To help users avoid this state, ensure that your UX surfaces their ability to ad
 
 The identity used to initiate a client should be matched to its original inbox ID. 
 
-You do have the ability to rotate inbox IDs if a user reaches the limit of 257 identity actions (adding, removing, or revoking identities or installations). Hopefully, users won’t reach this limit, but if they do, inbox IDs have a nonce and can be created an infinite number of times. 
+You do have the ability to rotate inbox IDs if a user reaches the limit of 257 identity actions (adding, removing, or revoking identities or installations). Hopefully, users won't reach this limit, but if they do, inbox IDs have a nonce and can be created an infinite number of times. 
 
 However, anytime a new inbox ID is created for an identity, the conversations and messages in any existing inbox ID associated with the identity are lost.
 

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -178,100 +178,42 @@ Here is how static installation revocation works behind the scenes:
 :::code-group
 
 ```tsx [Browser]
-// Step 1: Get inbox state data for the specified inbox IDs.
-// Gets the installation data needed to revoke installations.
-static async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
-  const host = ApiUrls[env ?? "dev"];
-  return inboxStateFromInboxIds(host, inboxIds);
-}
-
-// Step 2: Call the method to get inbox states
-// The second argument is optional and defaults to "dev" if not provided
 const inboxStates = Client.inboxStateFromInboxIds([inboxId], "production");
 
-// Step 3: Access the installation ID bytes from the first inbox state
-// This gets the raw bytes needed for the revocation request
-const installationBytes = inboxStates[0].installations[0].bytes
+const toRevokeInstallationBytes = inboxStates[0].installations.map((i) => i.bytes);
 
-// Step 4: Call Client.revokeInstallations to revoke the specified installations
-// This method allows revocation without needing an active client instance
 await Client.revokeInstallations(
-  signer,           // The signer (recovery wallet) to authorize the revocation
-  inboxId,          // The inbox ID containing the installations to revoke
-  [installationIdBytes], // Array of installation ID bytes to revoke
-  "production",     // The XMTP environment
+  signer,
+  inboxId,
+  toRevokeInstallationBytes,
+  "production", // optional, defaults to "dev"
 );
-
-// Method signature for reference:
-/**
- * Revokes specific installations of the client's inbox without a client
- *
- * @param env - The environment to use
- * @param signer - The signer to use
- * @param inboxId - The inbox ID to revoke installations for
- * @param installationIds - The installation IDs to revoke
- */
-static async revokeInstallations(
-  signer: Signer,
-  inboxId: string,
-  installationIds: Uint8Array[],
-  env?: XmtpEnv,
-) => Promise<void>
 ```
 
 ```tsx [Node]
-// Step 1: Get inbox state data for the specified inbox IDs.
-// Gets the installation data needed to revoke installations.
-static async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
-  const host = ApiUrls[env ?? "dev"];
-  return inboxStateFromInboxIds(host, inboxIds);
-}
-
-// Step 2: Call the method to get inbox states
-// The second argument is optional and defaults to "dev" if not provided
 const inboxStates = Client.inboxStateFromInboxIds([inboxId], "production");
 
-// Step 3: Access the installation ID bytes from the first inbox state
-// This gets the raw bytes needed for the revocation request
-const installationBytes = inboxStates[0].installations[0].bytes
+const toRevokeInstallationBytes = inboxStates[0].installations.map((i) => i.bytes);
 
-// Step 4: Call Client.revokeInstallations to revoke the specified installations
-// This method allows revocation without needing an active client instance
 await Client.revokeInstallations(
-  signer,           // The signer (recovery wallet) to authorize the revocation
-  inboxId,          // The inbox ID containing the installations to revoke
-  [installationIdBytes], // Array of installation ID bytes to revoke
-  "production",     // The XMTP environment
+  signer,
+  inboxId,
+  toRevokeInstallationBytes,
+  "production", // optional, defaults to "dev"
 );
-
-// Method signature for reference:
-/**
- * Revokes specific installations of the client's inbox without a client
- *
- * @param env - The environment to use
- * @param signer - The signer to use
- * @param inboxId - The inbox ID to revoke installations for
- * @param installationIds - The installation IDs to revoke
- */
-static async revokeInstallations(
-  signer: Signer,
-  inboxId: string,
-  installationIds: Uint8Array[],
-  env?: XmtpEnv,
-) => Promise<void>
 ```
 
 ```jsx [React Native]
-  const states = await Client.inboxStatesForInboxIds('production', [inboxId])
+const states = await Client.inboxStatesForInboxIds('production', [inboxId])
 
-  const toRevokeIds = states[0].installations.map((i) => i.id)
+const toRevokeIds = states[0].installations.map((i) => i.id)
 
-  await Client.revokeInstallations(
-    'production',
-    recoveryWallet,
-    inboxId,
-    toRevokeIds as InstallationId[]
-  )
+await Client.revokeInstallations(
+  'production',
+  recoveryWallet,
+  inboxId,
+  toRevokeIds as InstallationId[]
+)
 ```
 
 ```kotlin [Kotlin]


### PR DESCRIPTION
### Add Browser and Node code samples for static installation revocation in inbox management documentation
The documentation adds two new code examples demonstrating installation revocation functionality. Browser and Node examples show usage of `Client.inboxStateFromInboxIds` and `Client.revokeInstallations` methods within the code-group section of [docs/pages/inboxes/manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/254/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a). The existing React Native example receives formatting improvements with better spacing while maintaining identical content.

#### 📍Where to Start
Start with the code-group section in [docs/pages/inboxes/manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/254/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a) where the new Browser and Node examples have been added.

----

_[Macroscope](https://app.macroscope.com) summarized a055a4b._