### PR TITLE
Updates to agent quickstart

### DIFF
--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -100,7 +100,39 @@ To learn more, see the example [xmtp-attachments](https://github.com/ephemeraHQ/
 
 If helpful, you can also see the [Support attachments](/inboxes/content-types/attachments) documentation. 
 
-### Try out your agent using xmtp.chat
+### Support replies
+
+To learn more, see the example [good example for this?](#TODO) agent.
+
+If helpful, you can also see the [Support replies](/inboxes/content-types/replies) documentation. 
+
+### Support reactions
+
+To learn more, see the example [good example for this?](#TODO) agent.
+
+If helpful, you can also see the [Support reactions](/inboxes/content-types/reactions) documentation. 
+
+### Follow security best practices
+
+For an agent to function—whether it's answering questions, executing commands, or providing automated responses—it must be able to read the conversation to understand what's being asked, and write messages to respond. 
+
+Like any other user, this means your agent holds the cryptographic keys required to decrypt and send messages in the conversation. As an agent developer, it's important to uphold the security of these keys and messages.
+
+Here are some security best practices:
+
+- **Never expose private keys**: Use environment variables.
+- **Keep messages secure and private**: Do not log messages in plaintext. Do not share messages with third parties.
+- **Label agents clearly**: Clearly identify your agent as an agent and don't have an agent impersonate a human.
+
+### Handle rate limits
+
+
+
+### Provide error handling
+
+
+
+## Test your agent
 
 You can test and interact with your agent using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
@@ -191,3 +223,28 @@ Consider registering an [ENS domain](https://ens.domains/) for your agent to mak
 ### Example Railway deployment
 
 For reference, here's an example Railway deployment of a [gm-bot](https://railway.com/deploy/UCyz5b) agent.
+
+## Monitor and maintain your agent
+
+### Monitor agent health
+
+```tsx
+const inboxState = await client.preferences.inboxState();
+const address = inboxState.identifiers[0].identifier;
+const inboxId = client.inboxId;
+const installationId = client.installationId;
+const conversations = await client.conversations.list();
+
+console.log(`
+XMTP Client:
+  • InboxId: ${inboxId}
+  • Address: ${address}
+  • Conversations: ${conversations.length}
+  • Installations: ${inboxState.installations.length}
+  • InstallationId: ${installationId}
+  • Network: ${process.env.XMTP_ENV}
+`);
+```
+
+### Log agent activity
+

--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -5,7 +5,7 @@ This quickstart provides a map to building agents that can communicate with huma
 Building with XMTP gives your agent access to:
 - The [most secure](/protocol/security), [decentralized](/network/network-nodes) messaging network
 - The building blocks of AI + money + secure chat
-- Users accessing apps built with XMTP, including Coinbase Wallet and Convos.
+- Users on apps built with XMTP, including Coinbase Wallet, Convos, and more
 
 ## Resources to get started
 
@@ -90,9 +90,9 @@ const addressFromInboxId = inboxState[0].identifiers[0].identifier;
 
 To learn more, see [View the inbox state](/inboxes/manage-inboxes#view-the-inbox-state).
 
-### Support onchain transactions
+### Support onchain transactions and transaction references
 
-To learn more, see the example [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) agent and [Support onchain transactions](/inboxes/content-types/transactions) documentation.
+To learn more, see the example [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) agent, as well as the [Support onchain transactions](/inboxes/content-types/transactions) and [Support onchain transaction references](/inboxes/content-types/transaction-refs) (receipts) documentation.
 
 ### Support attachments
 
@@ -106,6 +106,20 @@ To learn more, see the example [good example for this?](#TODO) agent and [Suppor
 
 To learn more, see the example [good example for this?](#TODO) agent and [Support reactions](/inboxes/content-types/reactions) documentation. 
 
+### Observe rate limits
+
+XMTP enforces a rate limit of 10,000 calls to the network per client per a rolling 5-minute window.
+
+These network calls include actions like:
+
+- Sending chat messages
+- Adding and removing wallets
+- Adding and revoking installations
+- Adding and removing group members
+- Updating group metadata
+
+When you reach the rate limit, your API calls will be rejected with a 429 (Too Many Requests) error. 
+
 ### Follow security best practices
 
 For an agent to function—whether it's answering questions, executing commands, or providing automated responses—it must be able to read the conversation to understand what's being asked, and write messages to respond. 
@@ -118,19 +132,31 @@ Here are some security best practices:
 - **Keep messages secure and private**: Do not log messages in plaintext. Do not share messages with third parties.
 - **Label agents clearly**: Clearly identify your agent as an agent and don't have an agent impersonate a human.
 
-### Handle rate limits
-
-
-
-### Provide error handling
-
-
-
-## Test your agent
+## Test and debug an agent
 
 You can test and interact with your agent using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
 Be sure to point xmtp.chat to the XMTP environment set in your agent's `.env` file.
+
+You can use this code to get your agent's client information, which provides useful values for testing and debugging: 
+
+```tsx
+const inboxState = await client.preferences.inboxState();
+const address = inboxState.identifiers[0].identifier;
+const inboxId = client.inboxId;
+const installationId = client.installationId;
+const conversations = await client.conversations.list();
+
+console.log(`
+XMTP Client:
+  • InboxId: ${inboxId}
+  • Address: ${address}
+  • Conversations: ${conversations.length}
+  • Installations: ${inboxState.installations.length}
+  • InstallationId: ${installationId}
+  • Network: ${process.env.XMTP_ENV}
+`);
+```
 
 ## Deploy an agent
 
@@ -217,28 +243,3 @@ Consider registering an [ENS domain](https://ens.domains/) for your agent to mak
 ### Example Railway deployment
 
 For reference, here's an example Railway deployment of a [gm-bot](https://railway.com/deploy/UCyz5b) agent.
-
-## Monitor and maintain your agent
-
-### Monitor agent health
-
-```tsx
-const inboxState = await client.preferences.inboxState();
-const address = inboxState.identifiers[0].identifier;
-const inboxId = client.inboxId;
-const installationId = client.installationId;
-const conversations = await client.conversations.list();
-
-console.log(`
-XMTP Client:
-  • InboxId: ${inboxId}
-  • Address: ${address}
-  • Conversations: ${conversations.length}
-  • Installations: ${inboxState.installations.length}
-  • InstallationId: ${installationId}
-  • Network: ${process.env.XMTP_ENV}
-`);
-```
-
-### Log agent activity
-

--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -23,9 +23,9 @@ You can use these [Cursor rules](https://github.com/ephemeraHQ/xmtp-agent-exampl
 
 ### llms-full.txt
 
-To make it easier to use AI coding tools to build agents with XMTP, you can find an llms-full.txt file at https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-full.txt.
+To make it easier to use AI coding tools to build agents with XMTP, you can find an `llms-full.txt` file at https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-full.txt.
 
-This llms-full.txt file includes all XMTP documentation in a single plain text file for easy parsing by AI.
+This `llms-full.txt` file includes all XMTP documentation in a single plain text file for easy parsing by AI.
 
 ## Build an agent
 
@@ -59,15 +59,17 @@ for await (const message of stream) {
 }
 ```
 
-To learn more about `Client.create`, see [Create an XMTP client](/inboxes/create-a-client).
+To learn more about:
 
-To learn more about `conversations.sync`, see [Sync new conversations](/inboxes/sync-and-syncall#sync-new-conversations).
+- `Client.create`, see [Create an XMTP client](/inboxes/create-a-client).
 
-To learn more about `conversations.streamAllMessages`, see [Stream all group chat and DM messages and preferences](/inboxes/stream#stream-all-group-chat-and-dm-messages-and-preferences).
+- `conversations.sync`, see [Sync new conversations](/inboxes/sync-and-syncall#sync-new-conversations).
 
-To learn more about `conversations.getConversationById`, see [Conversation helper methods](/inboxes/create-conversations#conversation-helper-methods).
+- `conversations.streamAllMessages`, see [Stream all group chat and DM messages and preferences](/inboxes/stream#stream-all-group-chat-and-dm-messages-and-preferences).
 
-To learn more about `conversation.send`, see [Send messages](/inboxes/send-messages).
+- `conversations.getConversationById`, see [Conversation helper methods](/inboxes/create-conversations#conversation-helper-methods).
+
+- `conversation.send`, see [Send messages](/inboxes/send-messages).
 
 ### Get the address of a user
 
@@ -90,27 +92,19 @@ To learn more, see [View the inbox state](/inboxes/manage-inboxes#view-the-inbox
 
 ### Support onchain transactions
 
-To learn more, see the example [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) agent.
-
-If helpful, you can also see the [Support onchain transactions](/inboxes/content-types/transactions) documentation.
+To learn more, see the example [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) agent and [Support onchain transactions](/inboxes/content-types/transactions) documentation.
 
 ### Support attachments
 
-To learn more, see the example [xmtp-attachments](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-attachments) agent.
-
-If helpful, you can also see the [Support attachments](/inboxes/content-types/attachments) documentation. 
+To learn more, see the example [xmtp-attachments](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-attachments) agent and [Support attachments](/inboxes/content-types/attachments) documentation. 
 
 ### Support replies
 
-To learn more, see the example [good example for this?](#TODO) agent.
-
-If helpful, you can also see the [Support replies](/inboxes/content-types/replies) documentation. 
+To learn more, see the example [good example for this?](#TODO) agent and [Support replies](/inboxes/content-types/replies) documentation. 
 
 ### Support reactions
 
-To learn more, see the example [good example for this?](#TODO) agent.
-
-If helpful, you can also see the [Support reactions](/inboxes/content-types/reactions) documentation. 
+To learn more, see the example [good example for this?](#TODO) agent and [Support reactions](/inboxes/content-types/reactions) documentation. 
 
 ### Follow security best practices
 

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -80,7 +80,7 @@ export default defineConfig({
       items: [],
     },
     {
-      text: "Quickstart: Build an agent 🤖",
+      text: "Tutorial: Build an agent 🤖",
       link: "/agents/build-an-agent",
       items: [],
     },


### PR DESCRIPTION
### Update agent building documentation to include rate limits of 10,000 calls per 5-minute window, security best practices, and debugging guidance in build-an-agent.mdx
The agent building documentation receives updates to improve structure and add new sections covering operational requirements and best practices. The changes include:

- Addition of rate limiting documentation specifying 10,000 calls per 5-minute window threshold
- New security best practices section for agent developers
- Test and debug section with code examples for retrieving agent client information
- Placeholder sections for replies and reactions support (#TODO items)
- Reorganization of documentation links into bulleted format in [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/261/files#diff-e4c7ad50c015ddc89cd44b428d9bcb6977ac9ab677dd59c843632bb3e1160288)
- Navigation menu item reclassification from "Quickstart" to "Tutorial" in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/261/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a)

#### 📍Where to Start
Start with the new sections added to [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/261/files#diff-e4c7ad50c015ddc89cd44b428d9bcb6977ac9ab677dd59c843632bb3e1160288), particularly the "Observe rate limits" and "Follow security best practices" sections which contain the most significant new content.

----

_[Macroscope](https://app.macroscope.com) summarized a34b3fe._