### PR TITLE
Restart agents

### DIFF
--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -120,6 +120,10 @@ These network calls include actions like:
 
 When you reach the rate limit, your API calls will be rejected with a 429 (Too Many Requests) error. 
 
+### Handle errors
+
+[#TODO Document callback to streaming methods that will allow devs to restart their agents]
+
 ### Follow security best practices
 
 For an agent to function—whether it's answering questions, executing commands, or providing automated responses—it must be able to read the conversation to understand what's being asked, and write messages to respond. 

--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -120,9 +120,59 @@ These network calls include actions like:
 
 When you reach the rate limit, your API calls will be rejected with a 429 (Too Many Requests) error. 
 
-### Handle errors
+### Handle stream failures
 
-[#TODO Document callback to streaming methods that will allow devs to restart their agents]
+All streaming methods accept a callback as the last argument that will be called when the stream fails. Use this callback to restart the stream.
+
+An example of how to use the callback to restart the stream:
+
+```tsx
+const MAX_RETRIES = 5;
+// wait 5 seconds before each retry
+const RETRY_INTERVAL = 5000;
+
+let retries = MAX_RETRIES;
+
+const retry = () => {
+  console.log(
+    `Retrying in ${RETRY_INTERVAL / 1000}s, ${retries} retries left`,
+  );
+  if (retries > 0) {
+    retries--;
+    setTimeout(() => {
+      handleStream(client);
+    }, RETRY_INTERVAL);
+  } else {
+    console.log("Max retries reached, ending process");
+    process.exit(1);
+  }
+};
+
+const onFail = () => {
+  console.log("Stream failed");
+  retry();
+};
+
+const handleStream = async (client) => {
+  console.log("Syncing conversations...");
+  await client.conversations.sync();
+
+  const stream = await client.conversations.streamAllMessages(
+    onMessage,
+    undefined,
+    undefined,
+    onFail,
+  );
+
+  console.log("Waiting for messages...");
+
+  for await (const message of stream) {
+    // process streammessage
+  }
+};
+
+await handleStream(client);
+```
 
 ### Follow security best practices
 


### PR DESCRIPTION
### Add documentation for handling stream failures with retry logic to restart agents in the build-an-agent guide
Adds a new "Handle stream failures" section to [docs/pages/agents/build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/268/files#diff-e4c7ad50c015ddc89cd44b428d9bcb6977ac9ab677dd59c843632bb3e1160288) that documents how to implement retry mechanisms for streaming API failures. The documentation includes a code example demonstrating retry parameters (`MAX_RETRIES` and `RETRY_INTERVAL`), a retry function with delay logic, an `onFail` callback for stream failure handling, and a `handleStream` function that syncs conversations and processes stream messages with failure recovery.

#### 📍Where to Start
Start with the new "Handle stream failures" section in [docs/pages/agents/build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/268/files#diff-e4c7ad50c015ddc89cd44b428d9bcb6977ac9ab677dd59c843632bb3e1160288).

----

_[Macroscope](https://app.macroscope.com) summarized b303239._