### PR TITLE
Update inbox docs

### DIFF
--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -1,10 +1,14 @@
 # Manage XMTP inboxes, identities, and installations
 
-With XMTP, a user can have one or more inboxes they use to access their messages. An inbox can have multiple identities associated with it. An identity has a kind, such as EOA or SCW, and a string, which in the case of an EOA or SCW, is an Ethereum address. However, this extensible inbox-based identity model means that support for additional kinds of identities, such as Passkey or Bitcoin, can be added in the future.
+With XMTP, a user can have one or more **inboxes** they use to access their messages. An inbox ID is a stable identifier for a user's messaging identity and is used as the destination for messages in direct message and group conversations. It is derived from the public key material in their key package.
+
+An inbox can have multiple **identities** associated with it. An identity has a kind, such as EOA or SCW, and a string, which in the case of an EOA or SCW, is an Ethereum address. However, this extensible inbox-based identity model means that support for additional kinds of identities, such as Passkey or Bitcoin, can be added in the future.
+
+The identity signs a key package, which defines the user's identity for messaging. This signature is used to prove control of the address and to bind it to a specific public key.
 
 All messages associated with these identities flow through the one inbox ID and are accessible in any XMTP app.
 
-The first time someone uses your app with an identity they've never used with any app built with XMTP, your app creates an inbox ID and installation ID associated with the identity. To do this, you [create a client](/inboxes/create-a-client) for their identity. 
+The first time someone uses your app with an identity they've never used with any app built with XMTP, your app creates an inbox ID and **installation** associated with the identity. To do this, you [create a client](/inboxes/create-a-client) for their identity.
 
 :::tip[Note for agent developers]
 

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -4,8 +4,6 @@ With XMTP, a user can have one or more **inboxes** they use to access their mess
 
 An inbox can have multiple **identities** associated with it. An identity has a kind, such as EOA or SCW, and a string, which in the case of an EOA or SCW, is an Ethereum address. However, this extensible inbox-based identity model means that support for additional kinds of identities, such as Passkey or Bitcoin, can be added in the future.
 
-The identity signs a key package, which defines the user's identity for messaging. This signature is used to prove control of the address and to bind it to a specific public key.
-
 All messages associated with these identities flow through the one inbox ID and are accessible in any XMTP app.
 
 The first time someone uses your app with an identity they've never used with any app built with XMTP, your app creates an inbox ID and **installation** associated with the identity. To do this, you [create a client](/inboxes/create-a-client) for their identity.


### PR DESCRIPTION
### Update inbox documentation to clarify terminology and add explanation of inbox ID in manage-inboxes.mdx
Updates the XMTP inbox documentation in [manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/278/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a) with formatting changes and additional explanations. Adds bold formatting to highlight key terms `inboxes`, `identities`, and `installation`. Includes a new sentence explaining that an inbox ID is a stable identifier for a user's messaging identity derived from public key material in their key package. Changes "installation ID" reference to just "installation" for consistency.

#### 📍Where to Start
Start with the documentation file [manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/278/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a) to review the terminology clarifications and new inbox ID explanation.

----

_[Macroscope](https://app.macroscope.com) summarized 85f2058._