### PR TITLE
Clarify content type fallback usage

### DIFF
--- a/docs/pages/inboxes/content-types/fallback.mdx
+++ b/docs/pages/inboxes/content-types/fallback.mdx
@@ -6,7 +6,9 @@ To prevent a poor user experience or app crashes, you should use the `fallback` 
 
 **For sending:** When sending a message with a custom content type, always provide a `fallback` string. This string offers a human-readable representation of the content. If the recipient's app doesn't support your custom type, it can display the `fallback` text instead. To learn more, see [Build custom content types](/inboxes/content-types/custom).
 
-**For receiving:** When your app receives a message, check if it supports the message's `contentType`. If not, display the `fallback` text. The code examples below show how to implement this check. Note that for some content types, such as read receipts, the `fallback` may be `undefined`, indicating the content is not meant to be rendered.
+**For receiving:** When your app receives a message, check if it supports the message's `contentType`. If not, render the `fallback` text.
+
+However, some content types, especially those not meant for display (like read receipts), won't have a `fallback`. In these `undefined` cases, you should generally ignore the message entirely. Displaying a generic "unsupported content" message for every silent background event would create a poor user experience and clutter the chat. The code examples below show how to handle both scenarios.
 
 :::code-group
 

--- a/docs/pages/inboxes/content-types/fallback.mdx
+++ b/docs/pages/inboxes/content-types/fallback.mdx
@@ -1,8 +1,12 @@
-# Handle unsupported content types
+# Use fallback text for content type compatibility
 
-As more [custom](/inboxes/content-types/content-types#create-a-custom-content-type) and [standards-track](/inboxes/content-types/content-types#standards-track-content-types) content types are introduced into the XMTP ecosystem, your app may encounter content types it does not support. This situation, if not handled properly, could lead to app crashes.
+When building with XMTP, you can't know in advance whether a recipient's app will support a given content type, especially a [custom one](/inboxes/content-types/content-types#create-a-custom-content-type). Likewise, your own app might receive messages with content types it doesn't support.
 
-Each message is accompanied by a `fallback` property, which offers a descriptive string representing the content type's expected value. It's important to note that fallbacks are immutable and are predefined in the content type specification. In instances where `fallback` is `undefined`, such as read receipts, it indicates that the content is not intended to be rendered. If you're venturing into creating custom content types, you're provided with the flexibility to specify a custom fallback string. For a deeper dive into this, see [Build custom content types](/inboxes/content-types/custom).
+To prevent a poor user experience or app crashes, you should use the `fallback` property.
+
+**For sending:** When sending a message with a custom content type, always provide a `fallback` string. This string offers a human-readable representation of the content. If the recipient's app doesn't support your custom type, it can display the `fallback` text instead. To learn more, see [Build custom content types](/inboxes/content-types/custom).
+
+**For receiving:** When your app receives a message, check if it supports the message's `contentType`. If not, display the `fallback` text. The code examples below show how to implement this check. Note that for some content types, such as read receipts, the `fallback` may be `undefined`, indicating the content is not meant to be rendered.
 
 :::code-group
 

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -193,7 +193,7 @@ export default defineConfig({
               link: "/inboxes/content-types/custom",
             },
             {
-              text: "Handle unsupported content",
+              text: "Fallback text for compatibility",
               link: "/inboxes/content-types/fallback",
             },
           ],


### PR DESCRIPTION
### Update fallback content type documentation to clarify usage and revise navigation menu text
- Revises [docs/pages/inboxes/content-types/fallback.mdx](https://github.com/xmtp/docs-xmtp-org/pull/292/files#diff-73e9f31bc42c1407b78af6c86a3fa3359155392aa8ae9a5f6211964b20c37131) to restructure content with separate sending and receiving scenarios, explains that some content types like read receipts won't have fallback text, and changes the title from "Handle unsupported content types" to "Use fallback text for content type compatibility"
- Updates navigation menu text in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/292/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) from "Handle unsupported content" to "Fallback text for compatibility" to match the revised documentation page title

#### 📍Where to Start
Start with the revised documentation in [docs/pages/inboxes/content-types/fallback.mdx](https://github.com/xmtp/docs-xmtp-org/pull/292/files#diff-73e9f31bc42c1407b78af6c86a3fa3359155392aa8ae9a5f6211964b20c37131) to understand the restructured content and guidance changes.

----

_[Macroscope](https://app.macroscope.com) summarized 1587e28._