### PR TITLE
Add agent form to tutorial

### DIFF
--- a/docs/pages/agents/build-an-agent.mdx
+++ b/docs/pages/agents/build-an-agent.mdx
@@ -364,8 +364,8 @@ For reference, here's an example Railway deployment of a [gm-bot](https://railwa
 
 :::tip
 
-**Want your agent featured on TBA?**
+**Want your agent or mini-app featured on TBA?**
 
-[Complete this form](https://docs.google.com/forms/d/e/1FAIpQLSfZ7JgOt4tw36dGLL9cEmw_y09VoE5_Knk7X6EnJd1IJ3CLEg/viewform) to tell the team about your agent, get feedback, and collaborate on possibly getting your agent featured.
+[Complete this form](https://docs.google.com/forms/d/e/1FAIpQLSfZ7JgOt4tw36dGLL9cEmw_y09VoE5_Knk7X6EnJd1IJ3CLEg/viewform) to tell the team about your project, get feedback, and collaborate on possibly getting it featured.
 
 :::


### PR DESCRIPTION
### Add agent form to tutorial documentation in build-an-agent.mdx
Adds a new "Get featured" section to the agent tutorial documentation that includes a tip box with instructions for users to submit their agents or mini-apps for potential featuring on TBA through a Google Form. The section provides the form link and explains the submission process for getting feedback and collaboration opportunities.

#### 📍Where to Start
Start with the new "Get featured" section at the end of [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/294/files#diff-e4c7ad50c015ddc89cd44b428d9bcb6977ac9ab677dd59c843632bb3e1160288).

----

_[Macroscope](https://app.macroscope.com) summarized 055c424._