### PR TITLE
Maintenance

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -35,7 +35,9 @@
     "geoblocking",
     "groupname",
     "hexlify",
+    "hijklmn",
     "HMAC",
+    "HNDL",
     "HPKE",
     "HPKEX",
     "inboxid",
@@ -71,6 +73,7 @@
     "xmtp",
     "xmtpd",
     "XMTP",
+    "XWING",
     "YOURFCMJSON",
     "YOURFCMPROJECTID"
   ]

--- a/docs/footer.tsx
+++ b/docs/footer.tsx
@@ -3,6 +3,19 @@ export default function Footer() {
     <div style={{ textAlign: "center" }}>
       <div>
         <small>
+          <a
+            href="https://xmtp.org/"
+            target="_blank"
+            style={{
+              "--vocs_ExternalLink_iconUrl":
+                "url(/.vocs/icons/arrow-diagonal.svg)",
+            }}
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
+          >
+            XMTP.org
+          </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </small>
+        <small>
         <a
             href="https://status.xmtp.org/"
             target="_blank"
@@ -26,19 +39,6 @@ export default function Footer() {
             className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
           >
             XMTP.chat
-          </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-        </small>
-        <small>
-        <a
-            href="https://xmtp.org/"
-            target="_blank"
-            style={{
-              "--vocs_ExternalLink_iconUrl":
-                "url(/.vocs/icons/arrow-diagonal.svg)",
-            }}
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
-          >
-            XMTP.org
           </a>
         </small>
       </div>

--- a/docs/pages/inboxes/manage-inboxes.mdx
+++ b/docs/pages/inboxes/manage-inboxes.mdx
@@ -414,7 +414,7 @@ For UI display purposes, you can use the following logic to select the most appr
 
 1. If there is only one identity in the `identities` array, use that as the display identity.
 2. If there are two identities, use the one that does not match the `recoveryIdentity`. The first non-recovery identifier in the array is typically the preferred identity for display.
-3. If there are more than two identities, the first non-recovery identity in the ordered array is typically the preferred idenity for display.
+3. If there are more than two identities, the first non-recovery identity in the ordered array is typically the preferred identity for display.
 
 ## FAQ
 

--- a/docs/pages/inboxes/support-group-invite-links.mdx
+++ b/docs/pages/inboxes/support-group-invite-links.mdx
@@ -289,7 +289,7 @@ GET /groupJoinRequest/hijklmn
 
 ```json
 {
-	id: "hijlkmn",
+	id: "hijklmn",
 	status: "approved"// Possible statuses ("approved", "rejected", "pending")
 	reason: null // Allow the system to pass a reason back to the client
 }
@@ -315,7 +315,7 @@ You can have the invite link creator mark an invite as approved or rejected. For
 
 ```json
 {
-	id: "hijlkmn",
+	id: "hijklmn",
 	status: "approved",
 	reason: null // Allow the system to pass a reason back to the client
 }

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -39,7 +39,7 @@ import "../styles.css";
       icon="🕸️"
     />
     <CustomHomePage.Tile
-      href="/protocol/security"
+      href="/protocol/envelope-types"
       title="Learn protocol concepts"
       description="Dive deeper into XMTP by learning about key protocol concepts"
       icon="🧠"

--- a/docs/pages/intro/dev-support.md
+++ b/docs/pages/intro/dev-support.md
@@ -9,3 +9,5 @@ Please open an issue in the relevant repo:
 - [React Native SDK](https://github.com/xmtp/xmtp-react-native/issues)
 - [Android SDK](https://github.com/xmtp/xmtp-android/issues)
 - [iOS SDK](https://github.com/xmtp/xmtp-ios/issues)
+
+For all other topics, post to the [XMTP Community Forums](https://community.xmtp.org/).

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -30,7 +30,6 @@ export default defineConfig({
   topNav: [
     { text: "XMTP status", link: "https://status.xmtp.org/" },
     { text: "XMTP.chat", link: "https://xmtp.chat/" },
-    { text: "XMTP.org", link: "https://xmtp.org/" },
   ],
   ogImageUrl: {
     "/": "/xmtp-og-card.jpeg",
@@ -67,10 +66,6 @@ export default defineConfig({
         {
           text: "Dev support",
           link: "/intro/dev-support",
-        },
-        {
-          text: "XMTP Improvement Proposals",
-          link: "/intro/xips",
         },
       ],
     },
@@ -315,6 +310,10 @@ export default defineConfig({
         {
           text: "Wallet signatures",
           link: "/protocol/signatures",
+        },
+        {
+          text: "XMTP Improvement Proposals",
+          link: "/intro/xips",
         },
       ],
     },


### PR DESCRIPTION
### Perform maintenance updates to documentation navigation, spell checker configuration, and content corrections
This maintenance pull request updates multiple aspects of the documentation site:

- Reorganizes navigation by removing the XMTP.org link from top navigation in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) and moving XMTP Improvement Proposals from intro to protocol section
- Reorders footer links in [docs/footer.tsx](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-aa793144904cfdf3cebd9b480f73587ae40edf53e0a6533806e4a8cc8277061a) while maintaining all existing links
- Updates the Learn protocol concepts tile to redirect to `/protocol/envelope-types` instead of `/protocol/security` in [docs/pages/index.mdx](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-e21e58ba504b9adc10039b3f8bf6939cf003cf21c26ace30807b99bf5c0229e1)
- Adds three new words (`hijklmn`, `HNDL`, `XWING`) to spell checker configuration in [cspell.config.json](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-8c08d31ca450eac0c902634bbee0fd18630466fb1edaaffa6a489287b237f7d6)
- Fixes typos including changing `preferred idenity` to `preferred identity` in [docs/pages/inboxes/manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-e4180e97cd8987c28c78e42aca60a9478785f26209785d08a18e547086a6395a) and correcting `hijlkmn` to `hijklmn` in JSON examples in [docs/pages/inboxes/support-group-invite-links.mdx](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-619e6d80be5d3d94d341fc0e7caeb1507d5c83670f05fc625c169b65719cb034)
- Adds reference to XMTP Community Forums in [docs/pages/intro/dev-support.md](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-6421046df1e762480a6c6d0a3ea47db808f81d97d9ae601a7bcc8fb0bf98a9db)

#### 📍Where to Start
Start with the navigation configuration changes in [vocs.config.tsx](https://github.com/xmtp/docs-xmtp-org/pull/301/files#diff-8b19f3397c3f9b904660f6ee8df61c2e4b7b2cd721341a6b5abe647cd716d74a) to understand the structural changes to the documentation site navigation.

----

_[Macroscope](https://app.macroscope.com) summarized f54001e._