### PR TITLE
Update reactions doc for Node

### DIFF
--- a/docs/pages/inboxes/content-types/reactions.mdx
+++ b/docs/pages/inboxes/content-types/reactions.mdx
@@ -38,6 +38,10 @@ xmtp.registerCodec(new ReactionCodec());
 
 </div>
 
+```jsx [Node]
+
+```
+
 ```jsx [React Native]
 const client = await Client.create(signer, {
   env: "production",
@@ -79,6 +83,18 @@ const reaction = {
 };
 
 await conversation.send(reaction, {
+  contentType: ContentTypeReaction,
+});
+```
+
+```jsx [Node]
+const reaction: Reaction = {
+  reference: someMessageID,
+  action: "added",
+  content: "smile",
+};
+
+await conversation.messages.send(reaction, {
   contentType: ContentTypeReaction,
 });
 ```
@@ -144,6 +160,19 @@ if (message.contentType.sameAs(ContentTypeReaction)) {
   // We've got a reaction.
   const reaction: Reaction = message.content;
 }
+```
+
+```jsx [Node]
+// Assume `loadLastMessage` is a thing you have
+const message: DecodedMessage = await loadLastMessage();
+
+if (!message.contentType.sameAs(ContentTypeReaction)) {
+  // We do not have a reaction. A topic for another blog post.
+  return;
+}
+
+// We've got a reaction.
+const reaction: Reaction = message.content;
 ```
 
 ```jsx [React Native]


### PR DESCRIPTION
### Add Node.js code examples to reactions documentation for XMTP implementation
Adds three Node.js code blocks to the reactions documentation in [docs/pages/inboxes/content-types/reactions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/305/files#diff-e8e59b8ae18545c6a251eef3ce2a953865c3c2b31d77cb8083b46891ef7153a2). The new examples demonstrate creating and sending reactions, and checking and processing received reaction messages in Node.js, complementing the existing React and React Native examples.

#### 📍Where to Start
Start with the reactions documentation file at [docs/pages/inboxes/content-types/reactions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/305/files#diff-e8e59b8ae18545c6a251eef3ce2a953865c3c2b31d77cb8083b46891ef7153a2) to review the newly added Node.js code examples.

----

_[Macroscope](https://app.macroscope.com) summarized 0424760._