### PR TITLE
Update content types docs

### DIFF
--- a/docs/pages/inboxes/content-types/attachments.mdx
+++ b/docs/pages/inboxes/content-types/attachments.mdx
@@ -22,9 +22,21 @@ To send multiple remote attachments of any size in a single message, see [Suppor
 
 In some SDKs, the `AttachmentCodec` is already included in the SDK. If not, you can install the package using the following command:
 
-```bash
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-remote-attachment
 ```
+
+```bash [yarn]
+yarn add @xmtp/content-type-remote-attachment
+```
+
+```bash [pnpm]
+pnpm add @xmtp/content-type-remote-attachment
+```
+
+:::
 
 ### Configure the content type
 
@@ -32,22 +44,17 @@ After importing the package, you can register the codec.
 
 :::code-group
 
-<div data-title="Browser">
-
-```jsx
+```jsx [Browser]
 import {
-  ContentTypeAttachment,
   AttachmentCodec,
   RemoteAttachmentCodec,
-  ContentTypeRemoteAttachment,
 } from "@xmtp/content-type-remote-attachment";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new AttachmentCodec());
-xmtp.registerCodec(new RemoteAttachmentCodec());
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
+});
 ```
-
-</div>
 
 ```jsx [React Native]
 const client = await Client.create(signer, {
@@ -734,9 +741,20 @@ Unless a very specific use case we recommend using the [remote attachment conten
 
 ### Install the package
 
-```bash
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-remote-attachment
 ```
+
+```bash [yarn]
+yarn add @xmtp/content-type-remote-attachment
+```
+
+```bash [pnpm]
+pnpm add @xmtp/content-type-remote-attachment
+```
+:::
 
 > In some SDKs, the `AttachmentCodec` is already included in the SDK. If not, you can install the package using the following command:
 
@@ -746,12 +764,13 @@ npm i @xmtp/content-type-remote-attachment
 
 ```jsx [Browser]
 import {
-  ContentTypeAttachment,
   AttachmentCodec,
 } from "@xmtp/content-type-remote-attachment";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new AttachmentCodec());
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new AttachmentCodec()],
+});
 ```
 
 ```jsx [React Native]

--- a/docs/pages/inboxes/content-types/attachments.mdx
+++ b/docs/pages/inboxes/content-types/attachments.mdx
@@ -741,6 +741,8 @@ Unless a very specific use case we recommend using the [remote attachment conten
 
 ### Install the package
 
+In some SDKs, the `AttachmentCodec` is already included in the SDK. If not, you can install the package using the following command:
+
 :::code-group
 
 ```bash [npm]
@@ -755,8 +757,6 @@ yarn add @xmtp/content-type-remote-attachment
 pnpm add @xmtp/content-type-remote-attachment
 ```
 :::
-
-> In some SDKs, the `AttachmentCodec` is already included in the SDK. If not, you can install the package using the following command:
 
 ### Import and register
 

--- a/docs/pages/inboxes/content-types/reactions.mdx
+++ b/docs/pages/inboxes/content-types/reactions.mdx
@@ -12,6 +12,8 @@ Use a local database to store reactions. This enables your app to performantly d
 
 ### Install the package
 
+In some SDKs, the `ReactionCodec` is already included in the SDK. If not, you can install the package using the following command:
+
 :::code-group
 
 ```bash [npm]
@@ -27,8 +29,6 @@ pnpm add @xmtp/content-type-reaction
 ```
 
 :::
-
-> In some SDKs, the `ReactionCodec` is already included in the SDK. If not, you can install the package using the following command:
 
 ## Configure the content type
 

--- a/docs/pages/inboxes/content-types/reactions.mdx
+++ b/docs/pages/inboxes/content-types/reactions.mdx
@@ -12,9 +12,21 @@ Use a local database to store reactions. This enables your app to performantly d
 
 ### Install the package
 
-```bash [Bash]
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-reaction
 ```
+
+```bash [yarn]
+yarn add @xmtp/content-type-reaction
+```
+
+```bash [pnpm]
+pnpm add @xmtp/content-type-reaction
+```
+
+:::
 
 > In some SDKs, the `ReactionCodec` is already included in the SDK. If not, you can install the package using the following command:
 
@@ -24,19 +36,16 @@ After importing the package, you can register the codec.
 
 :::code-group
 
-<div data-title="Browser">
-
-```jsx
+```jsx [Browser]
 import {
-  ContentTypeReaction,
   ReactionCodec,
 } from "@xmtp/content-type-reaction";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new ReactionCodec());
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new ReactionCodec()],
+});
 ```
-
-</div>
 
 ```jsx [React Native]
 const client = await Client.create(signer, {

--- a/docs/pages/inboxes/content-types/read-receipts.mdx
+++ b/docs/pages/inboxes/content-types/read-receipts.mdx
@@ -12,29 +12,38 @@ While this is a per-app decision, the best practice is to provide users with the
 
 ## Install the package
 
-```bash [Bash]
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-read-receipt
 ```
+
+```bash [yarn]
+yarn add @xmtp/content-type-read-receipt
+```
+
+```bash [pnpm]
+pnpm add @xmtp/content-type-read-receipt
+```
+
+:::
 
 ## Configure the content type
 
 :::code-group
 
-<div data-title="Browser">
-
-```tsx
+```js [Browser]
 import {
-  ContentTypeReadReceipt,
   ReadReceiptCodec,
 } from "@xmtp/content-type-read-receipt";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new ReadReceiptCodec());
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new ReadReceiptCodec()],
+});
 ```
 
-</div>
-
-```jsx [React Native]
+```js [React Native]
 const client = await Client.create(signer, {
   env: "production",
   codecs: [new ReadReceiptCodec()],
@@ -58,7 +67,7 @@ Client.register(codec = ReadReceiptCodec())
 
 :::code-group
 
-```jsx [Browser]
+```js [Browser]
 // The content of a read receipt message must be an empty object.
 
 await conversation.messages.send({}, ContentTypeReadReceipt);
@@ -101,14 +110,14 @@ Here's how you can receive a read receipt:
 
 :::code-group
 
-```tsx [Browser]
+```js [Browser]
 if (message.contentType.sameAs(ContentTypeReadReceipt)) {
   // The message is a read receipt
   const timestamp = message.sent;
 }
 ```
 
-```jsx [React Native]
+```js [React Native]
 if (message.contentTypeId === "xmtp.org/readReceipt:1.0") {
   return message.sent; //Date received
 }

--- a/docs/pages/inboxes/content-types/replies.mdx
+++ b/docs/pages/inboxes/content-types/replies.mdx
@@ -14,9 +14,21 @@ Use a local database to store replies. This will enable your app to performantly
 
 In some SDKs, the `ReplyCodec` is already included in the SDK. If not, you can install the package using the following command:
 
-```bash
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-reply
 ```
+
+```bash [yarn]
+yarn add @xmtp/content-type-reply
+```
+
+```bash [pnpm]
+pnpm add @xmtp/content-type-reply
+```
+
+:::
 
 ## Configure the content type
 
@@ -24,14 +36,16 @@ After importing the package, you can register the codec.
 
 :::code-group
 
-```jsx [Browser]
-import { ContentTypeReply, ReplyCodec } from "@xmtp/content-type-reply";
+```js [Browser]
+import { ReplyCodec } from "@xmtp/content-type-reply";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new ReplyCodec());
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new ReplyCodec()],
+});
 ```
 
-```jsx [React Native]
+```js [React Native]
 const client = await Client.create(signer, {
   env: "production",
   codecs: [new ReplyCodec()],
@@ -60,7 +74,7 @@ Once you've created a reply, you can send it. Replies are represented as objects
 
 :::code-group
 
-```tsx [Browser]
+```ts [Browser]
 import { ContentTypeText } from "@xmtp/content-type-text";
 import { ContentTypeReply } from "@xmtp/content-type-reply";
 import type { Reply } from "@xmtp/content-type-reply";
@@ -76,7 +90,7 @@ await conversation.send(reply, {
 });
 ```
 
-```jsx [React Native]
+```js [React Native]
 // Assuming you have a conversation object and the ID of the message you're replying to
 const replyContent = {
   reply: {
@@ -127,7 +141,7 @@ try await conversation.send(
 
 :::code-group
 
-```tsx [Browser]
+```ts [Browser]
 if (message.contentType.sameAs(ContentTypeReply)) {
   // We've got a reply.
   const reply: Reply = message.content;

--- a/docs/pages/inboxes/content-types/transaction-refs.mdx
+++ b/docs/pages/inboxes/content-types/transaction-refs.mdx
@@ -14,29 +14,43 @@ You're welcome to provide feedback by commenting on [XIP-21: On-chain transactio
 
 ## Install the package
 
-```bash [Bash]
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-transaction-reference
 ```
+
+```bash [yarn]
+yarn add @xmtp/content-type-transaction-reference
+```
+
+```bash [pnpm]
+pnpm add @xmtp/content-type-transaction-reference
+```
+
+:::
 
 ## Configure the content type
 
 After importing the package, you can register the codec.
 
-```jsx [Browser]
+```js [Browser]
 import {
   ContentTypeTransactionReference,
   TransactionReferenceCodec,
 } from "@xmtp/content-type-transaction-reference";
 // Create the XMTP client
-const xmtp = await Client.create(signer, { env: "dev" });
-xmtp.registerCodec(new TransactionReferenceCodec());
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new TransactionReferenceCodec()],
+});
 ```
 
 ## Send a transaction reference
 
 With XMTP, a transaction reference is represented as an object with the following keys:
 
-```tsx [Browser]
+```ts [Browser]
 const transactionReference: TransactionReference = {
   /**
    * Optional namespace for the networkId
@@ -65,7 +79,7 @@ const transactionReference: TransactionReference = {
 ```
 Once you have a transaction reference, you can send it as part of your conversation:
 
-```jsx [Browser]
+```js [Browser]
 await conversation.messages.send(transactionReference, {
   contentType: ContentTypeTransactionReference,
 });
@@ -77,7 +91,7 @@ To receive and process a transaction reference, you can use the following code s
 
 To handle unsupported content types, refer to the [fallback](/inboxes/content-types/fallback) section.
 
-```tsx [Browser]
+```ts [Browser]
 // Assume `loadLastMessage` is a thing you have
 const message: DecodedMessage = await loadLastMessage();
 

--- a/docs/pages/inboxes/content-types/transactions.mdx
+++ b/docs/pages/inboxes/content-types/transactions.mdx
@@ -1,6 +1,6 @@
 # Support onchain transactions in your app built with XMTP
 
-This package provides an XMTP content type to support sending transactions to a wallet for execution. 
+This package provides an XMTP content type to support sending transactions to a wallet for execution.
 
 Currently, this content type is supported in the Browser, Node, and React Native SDKs only.
 
@@ -14,22 +14,42 @@ You are welcome to provide feedback on this implementation by commenting on [XIP
 
 ## Install the package
 
-```bash [Bash]
-# npm
+:::code-group
+
+```bash [npm]
 npm i @xmtp/content-type-wallet-send-calls
+```
 
-# yarn
+```bash [yarn]
 yarn add @xmtp/content-type-wallet-send-calls
+```
 
-# pnpm
+```bash [pnpm]
 pnpm i @xmtp/content-type-wallet-send-calls
+```
+
+:::
+
+## Configure the content type
+
+After importing the package, you can register the codec.
+
+```js [Browser]
+import {
+  WalletSendCallsCodec,
+} from "@xmtp/content-type-wallet-send-calls";
+// Create the XMTP client
+const xmtp = await Client.create(signer, {
+  env: "dev",
+  codecs: [new WalletSendCallsCodec()],
+});
 ```
 
 ## Create a transaction request
 
 With XMTP, a transaction request is represented using `wallet_sendCalls` with additional metadata for display.
 
-```tsx [TypeScript]
+```ts [TypeScript]
 const walletSendCalls: WalletSendCallsParams = {
   version: "1.0",
   from: "0x123...abc",
@@ -68,7 +88,7 @@ const walletSendCalls: WalletSendCallsParams = {
 
 Once you have a transaction reference, you can send it as part of your conversation:
 
-```tsx [TypeScript]
+```ts [TypeScript]
 await conversation.messages.send(walletSendCalls, {
   contentType: ContentTypeWalletSendCalls,
 });
@@ -78,7 +98,7 @@ await conversation.messages.send(walletSendCalls, {
 
 To receive and process a transaction request:
 
-```tsx [TypeScript]
+```ts [TypeScript]
 // Assume `loadLastMessage` is a thing you have
 const message: DecodedMessage = await loadLastMessage();
 


### PR DESCRIPTION
### Update content types documentation to use codecs parameter in client initialization and add package manager installation options
Updates documentation across six content type files to replace deprecated `registerCodec()` method calls with the newer `codecs` parameter pattern in XMTP client initialization. The changes modify code examples in [attachments.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-f041425971bce631130ae63a612854dd567fd3f40764add70bd6eff51f032400), [reactions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-e8e59b8ae18545c6a251eef3ce2a953865c3c2b31d77cb8083b46891ef7153a2), [read-receipts.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-361ee7eb2490f73afa4c2158c2e3f0cfaf42c9b96812df779337baeef6fbb631), [replies.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-c2796b102e5308575e742f3df364af06c544d72cfc610687750bc9c8a03b007c), [transaction-refs.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-3a9dd8305c8449c81998aa48f4309452e93e9218ab1d1065eef78fedde7e0482), and [transactions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-5763c6c3f77cdce8f59d3a1766272201760d87332ebda747960aaffb48fea934). Additionally adds yarn and pnpm installation options alongside existing npm instructions, removes unnecessary content type imports, and standardizes code block language specifications.

#### 📍Where to Start
Start with the client initialization code examples in [attachments.mdx](https://github.com/xmtp/docs-xmtp-org/pull/309/files#diff-f041425971bce631130ae63a612854dd567fd3f40764add70bd6eff51f032400) to see the pattern change from `registerCodec()` to the `codecs` parameter approach.

----

_[Macroscope](https://app.macroscope.com) summarized 3bc5164._