### PR TITLE
Sync first N messages in unknown conversation

### DIFF
--- a/docs/pages/inboxes/sync-and-syncall.mdx
+++ b/docs/pages/inboxes/sync-and-syncall.mdx
@@ -101,3 +101,31 @@ try await client.conversations.syncAllConversations(consentState: [.allowed])
 ```
 
 :::
+
+### Sync a limited number of messages per conversation
+
+To protect from spam, you can sync just the first few messages of new conversations. For example, you can sync all conversations with an `unknown` consent state, but limit it to the first 5 messages per conversation.
+
+:::code-group
+
+```js [Browser]
+await client.conversations.syncAll({ consentState: ["unknown"], numMessages: 5 });
+```
+
+```js [Node]
+await client.conversations.syncAll({ consentState: ["unknown"], numMessages: 5 });
+```
+
+```tsx [React Native]
+await client.conversations.syncAllConversations({ consentState: ["unknown"], numMessages: 5 });
+```
+
+```kotlin [Kotlin]
+client.conversations.syncAllConversations(consentState = listOf(ConsentState.UNKNOWN), numMessages = 5)
+```
+
+```swift [Swift]
+try await client.conversations.syncAllConversations(consentState: [.unknown], numMessages: 5)
+```
+
+:::


### PR DESCRIPTION
### Document how to sync first N messages in unknown conversation using numMessages parameter with syncAll and syncAllConversations methods
Adds documentation section explaining how to use the `numMessages` parameter with `syncAll` or `syncAllConversations` methods to limit syncing to the first 5 messages per conversation with unknown consent state. The documentation includes code examples across Browser, Node, React Native, Kotlin, and Swift platforms in [docs/pages/inboxes/sync-and-syncall.mdx](https://github.com/xmtp/docs-xmtp-org/pull/315/files#diff-7bee2f127ade739679f1f0e0510c278922c36d0a1f9951ba6cdb554347f584ab).

#### 📍Where to Start
Start with the new documentation section in [docs/pages/inboxes/sync-and-syncall.mdx](https://github.com/xmtp/docs-xmtp-org/pull/315/files#diff-7bee2f127ade739679f1f0e0510c278922c36d0a1f9951ba6cdb554347f584ab).

----

_[Macroscope](https://app.macroscope.com) summarized d2fde91._