### PR TITLE
List limited number of members

### DIFF
--- a/docs/pages/inboxes/group-permissions.mdx
+++ b/docs/pages/inboxes/group-permissions.mdx
@@ -353,6 +353,34 @@ try await group.removeMembers(inboxIds: [inboxId])
 
 :::
 
+### List a limited number of members
+
+Fetch a specified number of members from a group. This is useful for displaying a preview of the group's membership without fetching the entire list.
+
+:::code-group
+
+```js [Browser]
+
+```
+
+```js [Node]
+
+```
+
+```tsx [React Native]
+
+```
+
+```kotlin [Kotlin]
+
+```
+
+```swift [Swift]
+
+```
+
+:::
+
 ### Get inbox IDs for members
 
 :::code-group


### PR DESCRIPTION
### Add documentation section for listing limited number of members in group permissions
Adds a new documentation section titled 'List a limited number of members' to [docs/pages/inboxes/group-permissions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/316/files#diff-7254ee9ec1933f567635cac900f8aca2d810b53f60df67d74b49ddcd59ffa1d6). The section describes how to fetch a specified number of members from a group and includes a code-group structure with placeholders for examples across Browser, Node, React Native, Kotlin, and Swift platforms, though the actual code examples are not yet implemented.

#### 📍Where to Start
Start with the new 'List a limited number of members' section in [docs/pages/inboxes/group-permissions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/316/files#diff-7254ee9ec1933f567635cac900f8aca2d810b53f60df67d74b49ddcd59ffa1d6).

----

_[Macroscope](https://app.macroscope.com) summarized e133c55._