### PR TITLE
Update stream docs for browser and node

### DIFF
--- a/docs/pages/inboxes/stream.mdx
+++ b/docs/pages/inboxes/stream.mdx
@@ -144,9 +144,13 @@ for await message in try await alix.conversations.streamAllMessages(type: /* OPT
 
 :::
 
-## Handle stream failures in the Node SDK
+## Handle stream failures
+
+:::warning
+**Node SDK only**
 
 Streams will automatically attempt to reconnect if they fail. By default, a stream will attempt to reconnect up to 6 times with a 10 second delay between each retry. To change these defaults, use the `retryAttempts` and `retryDelay` options. To disable this feature, set the `retryOnFail` option to `false`. During the retry process, the `onRetry` and `onRestart` callbacks can be used to monitor progress.
+:::
 
 :::code-group
 

--- a/docs/pages/inboxes/stream.mdx
+++ b/docs/pages/inboxes/stream.mdx
@@ -55,9 +55,9 @@ for await convo in try await alix.conversations.stream(type: /* OPTIONAL .dms, .
 
 :::
 
-## Stream new group chat and DM messages and preference updates
+## Stream new group chat and DM messages
 
-This function listens to the network for new messages within all active group chats and DMs, as well as [preference updates](/inboxes/sync-preferences). 
+This function listens to the network for new messages within all active group chats and DMs. 
 
 Whenever a new message is sent to any of these conversations, the callback is triggered with a `DecodedMessage` object. This keeps the inbox up to date by streaming in messages as they arrive.
 
@@ -76,7 +76,12 @@ The stream is infinite. Therefore, any looping construct used with the stream wo
 :::code-group
 
 ```js [Browser]
-const stream = await client.conversations.streamAllMessages(["allowed"]);
+// stream all messages from conversations with a consent state of allowed
+const stream = await client.conversations.streamAllMessages(
+  undefined,
+  undefined,
+  [ConsentState.Allowed],
+);
  
 try {
   for await (const message of stream) {
@@ -90,18 +95,25 @@ try {
 ```
 
 ```js [Node]
-// stream all messages from all conversations
-const stream = await client.conversations.streamAllMessages(["allowed"]);
+// stream all messages from conversations with a consent state of allowed
+const stream = await client.conversations.streamAllMessages({
+  consentStates: [ConsentState.Allowed],
+});
  
 // stream only group messages
-const stream = await client.conversations.streamAllGroupMessages(["allowed"]);
+const stream = await client.conversations.streamAllGroupMessages({
+  consentStates: [ConsentState.Allowed],
+});
  
 // stream only dm messages
-const stream = await client.conversations.streamAllDmMessages(["allowed"]);
+const stream = await client.conversations.streamAllDmMessages({
+  consentStates: [ConsentState.Allowed],
+});
  
 try {
   for await (const message of stream) {
     // Received a message
+    console.log("New message:", message);
   }
 } catch (error) {
   // log any stream errors
@@ -132,58 +144,29 @@ for await message in try await alix.conversations.streamAllMessages(type: /* OPT
 
 :::
 
-## Handle stream failures
+## Handle stream failures in the Node SDK
 
-All streaming methods accept a callback as the last argument that will be called when the stream closes. Use this callback to restart the stream.
+Streams will automatically attempt to reconnect if they fail. By default, a stream will attempt to reconnect up to 6 times with a 10 second delay between each retry. To change these defaults, use the `retryAttempts` and `retryDelay` options. To disable this feature, set the `retryOnFail` option to `false`. During the retry process, the `onRetry` and `onRestart` callbacks can be used to monitor progress.
 
 :::code-group
 
-```tsx [Node]
-const MAX_RETRIES = 5;
-// wait 5 seconds before each retry
-const RETRY_INTERVAL = 5000;
- 
-let retries = MAX_RETRIES;
- 
-const retry = () => {
-  console.log(
-    `Retrying in ${RETRY_INTERVAL / 1000}s, ${retries} retries left`,
-  );
-  if (retries > 0) {
-    retries--;
-    setTimeout(() => {
-      handleStream(client);
-    }, RETRY_INTERVAL);
-  } else {
-    console.log("Max retries reached, ending process");
-    process.exit(1);
-  }
-};
- 
-const onFail = () => {
-  console.log("Stream failed");
-  retry();
-};
- 
-const handleStream = async (client) => {
-  console.log("Syncing conversations...");
-  await client.conversations.sync();
- 
-  const stream = await client.conversations.streamAllMessages(
-    onMessage,
-    undefined,
-    undefined,
-    onFail,
-  );
- 
-  console.log("Waiting for messages...");
- 
-  for await (const message of stream) {
-    // process streammessage
-  }
-};
- 
-await handleStream(client);
+```ts [Node]
+// disable automatic reconnects
+const stream = await client.conversations.streamAllMessages({
+  retryOnFail: false,
+});
+
+// use stream options
+const stream = await client.conversations.streamAllMessages({
+  retryAttempts: 10,
+  retryDelay: 20000, // 20 seconds
+  onRestart: () => {
+    console.log("Stream restarted");
+  },
+  onRetry: (attempt, maxAttempts) => {
+    console.log(`Stream retry attempt ${attempt} of ${maxAttempts}`);
+  },
+});
 ```
 
 ```tsx [Browser]

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -12,10 +12,7 @@ export default defineConfig({
           data-domain="docs.xmtp.org"
           defer
         />
-        <script
-          src="/popup.js"
-          async
-        />
+        <script src="/popup.js" async />
       </>
     );
   },
@@ -37,7 +34,7 @@ export default defineConfig({
       "https://vocs.dev/api/og?logo=%logo&title=%title&description=%description",
   },
   socials: [
-   {
+    {
       icon: "github",
       link: "https://github.com/xmtp",
     },
@@ -73,27 +70,27 @@ export default defineConfig({
       text: "Get started",
       collapsed: false,
       items: [
-          {
-            text: "Browser SDK",
-            link: "/sdks/browser",
-          },
-          {
-            text: "Node SDK",
-            link: "/sdks/node",
-          },
-          {
-            text: "React Native SDK",
-            link: "/sdks/react-native",
-          },
-          {
-            text: "Android SDK",
-            link: "/sdks/android",
-          },
-          {
-            text: "iOS SDK",
-            link: "/sdks/ios",
-          },
-        ]
+        {
+          text: "Browser SDK",
+          link: "/sdks/browser",
+        },
+        {
+          text: "Node SDK",
+          link: "/sdks/node",
+        },
+        {
+          text: "React Native SDK",
+          link: "/sdks/react-native",
+        },
+        {
+          text: "Android SDK",
+          link: "/sdks/android",
+        },
+        {
+          text: "iOS SDK",
+          link: "/sdks/ios",
+        },
+      ],
     },
     {
       text: "Tutorial: Build an agent 🤖",
@@ -104,163 +101,163 @@ export default defineConfig({
       text: "Build core messaging",
       collapsed: false,
       items: [
-          {
-            text: "Create an EOA or SCW signer",
-            link: "/inboxes/create-a-signer",
-          },
-          {
-            text: "Create a client",
-            link: "/inboxes/create-a-client",
-          },
-          {
-            text: "Create conversations",
-            link: "/inboxes/create-conversations",
-          },
-          {
-            text: "Send messages",
-            link: "/inboxes/send-messages",
-          },
-          {
-            text: "Manage group permissions",
-            link: "/inboxes/group-permissions",
-          },
-          {
-            text: "Manage group metadata",
-            link: "/inboxes/group-metadata",
-          },
-          {
-            text: "Support group invite links",
-            link: "/inboxes/support-group-invite-links",
-          },
-          {
-            text: "Manage inboxes, IDs, and installations",
-            link: "/inboxes/manage-inboxes",
-          },
-          {
-            text: "Observe rate limits",
-            link: "/inboxes/rate-limits",
-          },
-        ]
-      },
-      {
-        text: "List, stream, and sync",
-        collapsed: false,
-        items: [
-            {
-              text: "List conversations",
-              link: "/inboxes/list",
-            },
-            {
-              text: "Stream messages and preferences",
-              link: "/inboxes/stream",
-            },
-            {
-              text: "Sync conversations and messages",
-              link: "/inboxes/sync-and-syncall",
-            },
-            {
-              text: "Sync preferences",
-              link: "/inboxes/sync-preferences",
-            },
-            {
-              text: "History sync",
-              link: "/inboxes/history-sync",
-            },    
-          ],
+        {
+          text: "Create an EOA or SCW signer",
+          link: "/inboxes/create-a-signer",
         },
         {
-          text: "Support rich content types",
-          collapsed: false,
-          items: [
-            {
-              text: "Understand content types",
-              link: "/inboxes/content-types/content-types",
-            },
-            {
-              text: "Attachments",
-              link: "/inboxes/content-types/attachments",
-            },
-            {
-              text: "Onchain transactions",
-              link: "/inboxes/content-types/transactions",
-            },
-            {
-              text: "Onchain transaction references",
-              link: "/inboxes/content-types/transaction-refs",
-            },
-            {
-              text: "Reactions",
-              link: "/inboxes/content-types/reactions",
-            },
-            {
-              text: "Replies",
-              link: "/inboxes/content-types/replies",
-            },
-            {
-              text: "Read receipts",
-              link: "/inboxes/content-types/read-receipts",
-            },
-            {
-              text: "Custom content",
-              link: "/inboxes/content-types/custom",
-            },
-            {
-              text: "Fallback text for compatibility",
-              link: "/inboxes/content-types/fallback",
-            },
-          ],
+          text: "Create a client",
+          link: "/inboxes/create-a-client",
         },
         {
-          text: "Support spam-free inboxes",
-          collapsed: false,
-          items: [
-              {
-                text: "Understand user consent",
-                link: "/inboxes/user-consent/user-consent",
-              },
-              {
-                text: "Support user consent",
-                link: "/inboxes/user-consent/support-user-consent",
-              },        
-            ],
-          },
-          {
+          text: "Create conversations",
+          link: "/inboxes/create-conversations",
+        },
+        {
+          text: "Send messages",
+          link: "/inboxes/send-messages",
+        },
+        {
+          text: "Manage group permissions",
+          link: "/inboxes/group-permissions",
+        },
+        {
+          text: "Manage group metadata",
+          link: "/inboxes/group-metadata",
+        },
+        {
+          text: "Support group invite links",
+          link: "/inboxes/support-group-invite-links",
+        },
+        {
+          text: "Manage inboxes, IDs, and installations",
+          link: "/inboxes/manage-inboxes",
+        },
+        {
+          text: "Observe rate limits",
+          link: "/inboxes/rate-limits",
+        },
+      ],
+    },
+    {
+      text: "List, stream, and sync",
+      collapsed: false,
+      items: [
+        {
+          text: "List conversations",
+          link: "/inboxes/list",
+        },
+        {
+          text: "Stream messages",
+          link: "/inboxes/stream",
+        },
+        {
+          text: "Sync conversations and messages",
+          link: "/inboxes/sync-and-syncall",
+        },
+        {
+          text: "Sync preferences",
+          link: "/inboxes/sync-preferences",
+        },
+        {
+          text: "History sync",
+          link: "/inboxes/history-sync",
+        },
+      ],
+    },
+    {
+      text: "Support rich content types",
+      collapsed: false,
+      items: [
+        {
+          text: "Understand content types",
+          link: "/inboxes/content-types/content-types",
+        },
+        {
+          text: "Attachments",
+          link: "/inboxes/content-types/attachments",
+        },
+        {
+          text: "Onchain transactions",
+          link: "/inboxes/content-types/transactions",
+        },
+        {
+          text: "Onchain transaction references",
+          link: "/inboxes/content-types/transaction-refs",
+        },
+        {
+          text: "Reactions",
+          link: "/inboxes/content-types/reactions",
+        },
+        {
+          text: "Replies",
+          link: "/inboxes/content-types/replies",
+        },
+        {
+          text: "Read receipts",
+          link: "/inboxes/content-types/read-receipts",
+        },
+        {
+          text: "Custom content",
+          link: "/inboxes/content-types/custom",
+        },
+        {
+          text: "Fallback text for compatibility",
+          link: "/inboxes/content-types/fallback",
+        },
+      ],
+    },
+    {
+      text: "Support spam-free inboxes",
+      collapsed: false,
+      items: [
+        {
+          text: "Understand user consent",
+          link: "/inboxes/user-consent/user-consent",
+        },
+        {
+          text: "Support user consent",
+          link: "/inboxes/user-consent/support-user-consent",
+        },
+      ],
+    },
+    {
+      text: "Support push notifications",
+      collapsed: false,
+      items: [
+        {
+          text: "Understand push notifications",
+          link: "/inboxes/push-notifs/understand-push-notifs",
+        },
+        {
           text: "Support push notifications",
-          collapsed: false,
-          items: [
-            {
-              text: "Understand push notifications",
-              link: "/inboxes/push-notifs/understand-push-notifs",
-            },
-            {
-              text: "Support push notifications",
-              link: "/inboxes/push-notifs/push-notifs",
-            },
-            {
-              text: "Run a push notifications server",
-              link: "/inboxes/push-notifs/pn-server",
-            },
-            {
-              text: "Try Android push notifications",
-              link: "/inboxes/push-notifs/android-pn",
-            },
-            {
-              text: "Try iOS push notifications",
-              link: "/inboxes/push-notifs/ios-pn",
-            },
-          ]
+          link: "/inboxes/push-notifs/push-notifs",
         },
         {
-          text: "Debug your app",
-          link: "/inboxes/debug-your-app",
-          items: [],
+          text: "Run a push notifications server",
+          link: "/inboxes/push-notifs/pn-server",
         },
         {
-          text: "Sign and verify payloads",
-          link: "/inboxes/use-signatures",
-          items: [],
+          text: "Try Android push notifications",
+          link: "/inboxes/push-notifs/android-pn",
         },
-      {
+        {
+          text: "Try iOS push notifications",
+          link: "/inboxes/push-notifs/ios-pn",
+        },
+      ],
+    },
+    {
+      text: "Debug your app",
+      link: "/inboxes/debug-your-app",
+      items: [],
+    },
+    {
+      text: "Sign and verify payloads",
+      link: "/inboxes/use-signatures",
+      items: [],
+    },
+    {
       text: "Network",
       collapsed: false,
       items: [


### PR DESCRIPTION
# Summary

- Removed references to preferences in streaming docs (see below)
- Updated browser and node SDK docs on streaming
- Updated section on stream failures

### Removed references to preferences

The streaming docs were wrong on preferences being streamed in along with messages. They have a separate streaming function. Let's add a new section after this lands on streaming preferences and/or consent.