### PR TITLE
Fork detection debug tool - Browser and Node updates

### DIFF
--- a/docs/pages/inboxes/debug-your-app.mdx
+++ b/docs/pages/inboxes/debug-your-app.mdx
@@ -33,6 +33,7 @@ The `isCommitLogForked`/`commitLogForkStatus` field provides definitive fork det
 const debugInfo = await conversation?.debugInfo();
 
 console.log('Epoch:', debugInfo.epoch);
+console.log('Cursor:', debugInfo.cursor);
 console.log('Fork Status:', debugInfo.isCommitLogForked); // true, false, or undefined
 console.log('Local Commit Log:', debugInfo.localCommitLog);
 console.log('Remote Commit Log:', debugInfo.remoteCommitLog);


### PR DESCRIPTION
### Update the fork detection debug tool documentation for Browser and Node in [debug-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/341/files#diff-181ea5c4f67e5feb8de7ce720aa380a9b7d389b58e744aee950366ed82097cca) by specifying `Conversation.debugInfo().isCommitLogForked` and distinguishing it from React Native/Android/iOS `Conversation.getDebugInformation().commitLogForkStatus`.
- Replace the single reference to `commitLogForkStatus` with SDK-specific fields: `Conversation.debugInfo().isCommitLogForked` (Browser/Node) and `Conversation.getDebugInformation().commitLogForkStatus` (React Native/Android/iOS) in [debug-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/341/files#diff-181ea5c4f67e5feb8de7ce720aa380a9b7d389b58e744aee950366ed82097cca).
- Add code-group blocks separating Browser/Node examples from React Native/Kotlin/Swift.
- Add a Browser/Node example using `Conversation.debugInfo()` to read `isCommitLogForked` and retain the React Native/Kotlin/Swift example using `Conversation.getDebugInformation()` to read `commitLogForkStatus`.
- Add a conversation list example that checks `conversation.isCommitLogForked` alongside `conversation.commitLogForkStatus` and wrap both in a code-group.
- Update surrounding text to reference `isCommitLogForked` and `commitLogForkStatus` together.

#### 📍Where to Start
Start in [docs/pages/inboxes/debug-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/341/files#diff-181ea5c4f67e5feb8de7ce720aa380a9b7d389b58e744aee950366ed82097cca), reviewing the fork detection section and the new Browser/Node code-group examples that introduce `Conversation.debugInfo().isCommitLogForked` and the mapping to `commitLogForkStatus`.

----

_[Macroscope](https://app.macroscope.com) summarized e856883._