### PR TITLE
Fix hydration error

### DIFF
--- a/docs/components/CustomHomePage.tsx
+++ b/docs/components/CustomHomePage.tsx
@@ -149,10 +149,11 @@ const SDKTile: React.FC<SDKTileProps> = ({
   );
 };
 
-const SectionTitle: React.FC<{ children: React.ReactNode }> = ({
+const SectionTitle: React.FC<{ children: React.ReactNode; id?: string }> = ({
   children,
+  id,
 }) => (
-  <h2 className="custom-homepage-tile-title custom-homepage-section-title">
+  <h2 className="custom-homepage-tile-title custom-homepage-section-title" id={id}>
     {children}
   </h2>
 );

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -59,9 +59,9 @@ The largest and most secure decentralized messaging network
 
 </CustomHomePage.TileGrid>
 
-<CustomHomePage.SectionTitle>
+<CustomHomePage.SectionTitle id="start-building">
 
-<h2 id="start-building">Start building today</h2>
+Start building today
 
 </CustomHomePage.SectionTitle>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -402,7 +402,6 @@ html body .custom-homepage-sdk-grid {
 }
 
 .dark .custom-homepage-tile:hover {
-  transform: translateY(-5px);
   background-color: rgba(255, 255, 255, 0.01); /* Slightly lighter on hover */
   box-shadow: 0 4px 12px rgba(255, 255, 255, 0.02);
   border-color: var(--vocs-color-primary);


### PR DESCRIPTION
### Fix hydration error on the docs home page by adding an optional `id` to `CustomHomePage.SectionTitle` and rendering a single h2 with id 'start-building' in [index.mdx](https://github.com/xmtp/docs-xmtp-org/pull/345/files#diff-e21e58ba504b9adc10039b3f8bf6939cf003cf21c26ace30807b99bf5c0229e1), and remove the `translateY(-5px)` hover in dark mode tiles
- Add optional `id` prop to `SectionTitle` and forward it to the rendered `<h2>` in [CustomHomePage.tsx](https://github.com/xmtp/docs-xmtp-org/pull/345/files#diff-b8e678bbaa3fa564422c5eab7e985ea2e6ea5895616091155e5357aece51f37e).
- Update [index.mdx](https://github.com/xmtp/docs-xmtp-org/pull/345/files#diff-e21e58ba504b9adc10039b3f8bf6939cf003cf21c26ace30807b99bf5c0229e1) to pass `id="start-building"` to `CustomHomePage.SectionTitle` and provide plain text children to render a single `<h2 id="start-building">`.
- Remove `transform: translateY(-5px);` from `.dark .custom-homepage-tile:hover` in [styles.css](https://github.com/xmtp/docs-xmtp-org/pull/345/files#diff-642dd6b337eceefea97f017b0bac03ef7601bde8c4986a6022db316aab7b3c5c).

#### 📍Where to Start
Start with the `SectionTitle` component in [CustomHomePage.tsx](https://github.com/xmtp/docs-xmtp-org/pull/345/files#diff-b8e678bbaa3fa564422c5eab7e985ea2e6ea5895616091155e5357aece51f37e), then review its usage in [index.mdx](https://github.com/xmtp/docs-xmtp-org/pull/345/files#diff-e21e58ba504b9adc10039b3f8bf6939cf003cf21c26ace30807b99bf5c0229e1).

----

_[Macroscope](https://app.macroscope.com) summarized afc30bf._