### PR TITLE
Include llms-full.txt generated timestamp per dev request

### DIFF
--- a/llms/generate_llms_full.py
+++ b/llms/generate_llms_full.py
@@ -1,5 +1,7 @@
 import os
 import sys
+from datetime import datetime
+import pytz
 
 # Function to extract content from markdown files
 # Handles file reading and error cases
@@ -26,6 +28,12 @@ def generate_llms_txt(directory, output_file='llms/llms-full.txt'):  # Updated f
         with open(output_file, 'w', encoding='utf-8') as llms_file:
             # Write the header and guidance at the top of the file
             llms_file.write("# XMTP Full Documentation\n\n")
+            
+            # Add timestamp
+            pacific_tz = pytz.timezone('US/Pacific')
+            current_time = datetime.now(pacific_tz)
+            timestamp = current_time.strftime("Generated at %I:%M %p Pacific / %B %d, %Y")
+            llms_file.write(f"{timestamp}\n\n")
             llms_file.write("## Instructions for AI Tools\n\n")
             llms_file.write("This documentation includes code samples for multiple SDKs. Please use the code samples that correspond to the SDK you are working with:\n\n")
             llms_file.write("- For **xmtp-react-native**, use the code samples marked with `[React Native]`.\n")

--- a/llms/generate_llms_full.py
+++ b/llms/generate_llms_full.py
@@ -30,8 +30,7 @@ def generate_llms_txt(directory, output_file='llms/llms-full.txt'):  # Updated f
             llms_file.write("# XMTP Full Documentation\n\n")
             
             # Add timestamp
-            pacific_tz = pytz.timezone('US/Pacific')
-            current_time = datetime.now(pacific_tz)
+            current_time = datetime.now(timezone.utc).astimezone(pacific_tz)
             timestamp = current_time.strftime("Generated at %I:%M %p Pacific / %B %d, %Y")
             llms_file.write(f"{timestamp}\n\n")
             llms_file.write("## Instructions for AI Tools\n\n")

--- a/llms/generate_llms_full.py
+++ b/llms/generate_llms_full.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 import pytz
 
 # Function to extract content from markdown files
@@ -30,8 +30,9 @@ def generate_llms_txt(directory, output_file='llms/llms-full.txt'):  # Updated f
             llms_file.write("# XMTP Full Documentation\n\n")
             
             # Add timestamp
+            pacific_tz = pytz.timezone('US/Pacific')
             current_time = datetime.now(timezone.utc).astimezone(pacific_tz)
-            timestamp = current_time.strftime("Generated at %I:%M %p Pacific / %B %d, %Y")
+            timestamp = current_time.strftime("Generated at %I:%M %p %Z / %B %d, %Y")
             llms_file.write(f"{timestamp}\n\n")
             llms_file.write("## Instructions for AI Tools\n\n")
             llms_file.write("This documentation includes code samples for multiple SDKs. Please use the code samples that correspond to the SDK you are working with:\n\n")


### PR DESCRIPTION
### Add a US/Pacific 'Generated at %I:%M %p %Z / %B %d, %Y' timestamp to `llms/llms-full.txt` after the '# XMTP Full Documentation' header per dev request
- Update `llms.generate_llms_full.generate_llms_txt` to write a formatted US/Pacific timestamp line immediately after the header in [`generate_llms_full.py`](https://github.com/xmtp/docs-xmtp-org/pull/347/files#diff-3ea1d6d46d7e83096238b1709440a34afe4f3f4b6bb250aa524144084b5a5766).
- Add imports for `datetime`, `timezone`, and `pytz` in [`generate_llms_full.py`](https://github.com/xmtp/docs-xmtp-org/pull/347/files#diff-3ea1d6d46d7e83096238b1709440a34afe4f3f4b6bb250aa524144084b5a5766).
- Introduce a dependency on `pytz` when importing `llms.generate_llms_full`.

#### 📍Where to Start
Start with the `generate_llms_txt` function in [`generate_llms_full.py`](https://github.com/xmtp/docs-xmtp-org/pull/347/files#diff-3ea1d6d46d7e83096238b1709440a34afe4f3f4b6bb250aa524144084b5a5766).

----

_[Macroscope](https://app.macroscope.com) summarized 7ccde7d._