### PR TITLE
Maintenance

### DIFF
--- a/docs/pages/inboxes/sdks/android.mdx
+++ b/docs/pages/inboxes/sdks/android.mdx
@@ -1,6 +1,6 @@
 # Get started with the XMTP Android SDK
 
-Use the XMTP Kotlin SDK to build secure, private, and decentralized messaging into your Android app.
+Use the [XMTP Android SDK](https://github.com/xmtp/xmtp-android) to build secure, private, and decentralized messaging into your Android app.
 
 The guide provides some quickstart code, as well as a map to building a [secure messaging app](/protocol/security) with XMTP, including support for:
 

--- a/docs/pages/inboxes/sdks/browser.mdx
+++ b/docs/pages/inboxes/sdks/browser.mdx
@@ -1,6 +1,6 @@
 # Get started with the XMTP Browser SDK
 
-Use the XMTP Browser SDK to build web-based apps, tools, and experiences with secure, private, and decentralized messaging.
+Use the [XMTP Browser SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk) to build web-based apps, tools, and experiences with secure, private, and decentralized messaging.
 
 The guide provides some quickstart code, as well as a map to building a [secure messaging app](/protocol/security) with XMTP, including support for:
 

--- a/docs/pages/inboxes/sdks/ios.mdx
+++ b/docs/pages/inboxes/sdks/ios.mdx
@@ -1,6 +1,6 @@
 # Get started with the XMTP iOS SDK
 
-Use the XMTP Swift SDK to build secure, private, and decentralized messaging into your iOS app.
+Use the [XMTP iOS SDK](https://github.com/xmtp/xmtp-ios) to build secure, private, and decentralized messaging into your iOS app.
 
 The guide provides some quickstart code, as well as a map to building a [secure messaging app](/protocol/security) with XMTP, including support for:
 

--- a/docs/pages/inboxes/sdks/node.mdx
+++ b/docs/pages/inboxes/sdks/node.mdx
@@ -1,6 +1,6 @@
 # Get started with the XMTP Node SDK
 
-Use the XMTP Node SDK to build agents and other server-side applications that interact with the XMTP network.
+Use the [XMTP Node SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk) to build agents and other server-side applications that interact with the XMTP network.
 
 :::tip[🤖 Building an agent?]
 

--- a/docs/pages/inboxes/sdks/react-native.mdx
+++ b/docs/pages/inboxes/sdks/react-native.mdx
@@ -1,6 +1,6 @@
 # Get started with the XMTP React Native SDK
 
-Use the XMTP React Native SDK to build secure, private, and decentralized messaging into your cross-platform mobile app.
+Use the [XMTP React Native SDK](https://github.com/xmtp/xmtp-react-native) to build secure, private, and decentralized messaging into your cross-platform mobile app.
 
 The guide provides some quickstart code, as well as a map to building a [secure messaging app](/protocol/security) with XMTP, including support for:
 


### PR DESCRIPTION
### Replace plain-text SDK names with Markdown links in docs/pages/inboxes/sdks Android, iOS, Browser, Node, and React Native pages for maintenance
Update documentation to convert SDK name mentions into Markdown links across multiple pages.

- [android.mdx](https://github.com/xmtp/docs-xmtp-org/pull/353/files#diff-0cf014ce74b942a0748d4f78d8d67ead9e7a4daee26c8aa7232923541cbccc99): Replace 'XMTP Kotlin SDK' with a link to https://github.com/xmtp/xmtp-android
- [ios.mdx](https://github.com/xmtp/docs-xmtp-org/pull/353/files#diff-e7f0e14c0edca869efe47f01a76176380ab8c2b8f2779e4fc0c69516125e9303): Replace 'XMTP Swift SDK' with a link to https://github.com/xmtp/xmtp-ios
- [react-native.mdx](https://github.com/xmtp/docs-xmtp-org/pull/353/files#diff-17d4fb9bad45ed67da0090951572fcac15dc861bc309e5be7c81ecdb8e489fca): Replace 'XMTP React Native SDK' with a link to https://github.com/xmtp/xmtp-react-native
- [browser.mdx](https://github.com/xmtp/docs-xmtp-org/pull/353/files#diff-cc7b08c9b8466525e542e685e3ab83fb21a09c2966a8d676ef69a7d1a4840064): Replace 'XMTP Browser SDK' with a link to https://github.com/xmtp/xmtp-js/tree/main/sdks/browser-sdk
- [node.mdx](https://github.com/xmtp/docs-xmtp-org/pull/353/files#diff-d0bcb31d9b2874a1f2f2799328bb32c4c64c221f22ee4f90a77ec27eca6c9388): Replace 'XMTP Node SDK' with a link to https://github.com/xmtp/xmtp-js/tree/main/sdks/node-sdk

#### 📍Where to Start
Start with the link update in [android.mdx](https://github.com/xmtp/docs-xmtp-org/pull/353/files#diff-0cf014ce74b942a0748d4f78d8d67ead9e7a4daee26c8aa7232923541cbccc99) and verify the link pattern is consistent across the other edited files.

----

_[Macroscope](https://app.macroscope.com) summarized 95cec8d._