### PR TITLE
Enhance deployment guide with links and warnings

### DIFF
--- a/docs/pages/agents/deploy-agent.mdx
+++ b/docs/pages/agents/deploy-agent.mdx
@@ -1,13 +1,12 @@
 # Deploy an agent
 
-This section covers how to deploy an agent using Railway—a platform many developers prefer for quickly and easily deploying agents. While this tutorial focuses on Railway, you can use any hosting provider that supports Node.js and environment variables.
+This section covers how to deploy an agent using [Railway](https://railway.com)—a platform many developers prefer for quickly and easily deploying agents. While this tutorial focuses on Railway, you can use any hosting provider that supports Node.js and environment variables.
 
-Alternative platforms include:
+Alternative platforms include: [heroku](https://www.heroku.com/), [fly.io](https://fly.io/), [render](https://render.com/), [vercel](https://vercel.com)  
 
-- Heroku
-- Fly.io
-- Render
-- Vercel
+:::warn
+XMTP node-sdk and agent-sdk work in ubuntu distribution, not debian.
+:::
 
 Want to contribute a deployment guide for another platform? We welcome [pull requests](https://github.com/xmtp/docs-xmtp-org/blob/main/README.md)!
 


### PR DESCRIPTION
Updated the deployment guide to include links for alternative platforms and added a warning about compatibility with Ubuntu.