### PR TITLE
Update dbPath options for Node.js SDK

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,18 @@
 {
-  "singleQuote": false,
+  "arrowParens": "always",
+  "bracketSameLine": true,
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
   "semi": true,
-  "tabWidth": 2
+  "singleAttributePerLine": false,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
 }

--- a/docs/pages/agents/core-messaging/create-a-client.mdx
+++ b/docs/pages/agents/core-messaging/create-a-client.mdx
@@ -71,7 +71,9 @@ import { Client, type Signer } from "@xmtp/node-sdk";
 import { getRandomValues } from "node:crypto";
 
 // create a signer
-const signer: Signer = { /* ... */ };
+const signer: Signer = {
+  /* ... */
+};
 
 /**
  * The database encryption key is optional but strongly recommended for
@@ -87,7 +89,7 @@ const client = await Client.create(
   // client options
   {
     dbEncryptionKey,
-  },
+  }
 );
 ```
 
@@ -111,11 +113,11 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'AGENT_NAME/AGENT_VERSION'`.
    * For example, `appVersion: 'alix/2.x'`
    *
-   * If you have an agent and an app, it's best to distinguish them from each other by 
+   * If you have an agent and an app, it's best to distinguish them from each other by
    * adding `-agent` and `-app` to the names. For example:
    * - Agent: `appVersion: 'alix-agent/2.x'`
    * - App: `appVersion: 'alix-app/3.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which agents are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with agent
    * support, especially around communicating important SDK updates, including
@@ -130,7 +132,7 @@ type ClientOptions = {
   /**
    * Path to the local DB
    *
-   * There are 3 value types that can be used to specify the database path:
+   * There are 4 value types that can be used to specify the database path:
    *
    * - `undefined` (or excluded from the client options)
    *    The database will be created in the current working directory and is based on
@@ -143,8 +145,12 @@ type ClientOptions = {
    * - `string`
    *    The given path will be used to create the database.
    *    Example: `./my-db.db3`
+   *
+   * - `function`
+   *    A callback function that receives the inbox ID and returns a string path.
+   *    Example: `(inboxId) => string`
    */
-  dbPath?: string | null;
+  dbPath?: string | null | ((inboxId: string) => string);
   /**
    * Encryption key for the local DB
    */

--- a/docs/pages/agents/core-messaging/create-a-client.mdx
+++ b/docs/pages/agents/core-messaging/create-a-client.mdx
@@ -14,8 +14,7 @@ This video provides a walkthrough of creating and building a client.
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
-  allowFullScreen
-></iframe>
+  allowFullScreen></iframe>
 
 ### How it works
 
@@ -89,7 +88,7 @@ const client = await Client.create(
   // client options
   {
     dbEncryptionKey,
-  }
+  },
 );
 ```
 

--- a/docs/pages/chat-apps/core-messaging/create-a-client.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-client.mdx
@@ -14,8 +14,7 @@ This video provides a walkthrough of creating and building a client.
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
-  allowFullScreen
-></iframe>
+  allowFullScreen></iframe>
 
 ### How it works
 
@@ -83,7 +82,7 @@ const client = await Client.create(
   // client options
   {
     // Note: dbEncryptionKey is not used for encryption in browser environments
-  }
+  },
 );
 ```
 
@@ -110,7 +109,7 @@ const client = await Client.create(
   // client options
   {
     dbEncryptionKey,
-  }
+  },
 );
 ```
 

--- a/docs/pages/chat-apps/core-messaging/create-a-client.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-client.mdx
@@ -74,14 +74,16 @@ To call `Client.create()`, you must pass in a required `signer` and can also pas
 import { Client, type Signer } from "@xmtp/browser-sdk";
 
 // create a signer
-const signer: Signer = { /* ... */ };
+const signer: Signer = {
+  /* ... */
+};
 
 const client = await Client.create(
   signer,
   // client options
   {
-  // Note: dbEncryptionKey is not used for encryption in browser environments
-  },
+    // Note: dbEncryptionKey is not used for encryption in browser environments
+  }
 );
 ```
 
@@ -90,7 +92,9 @@ import { Client, type Signer } from "@xmtp/node-sdk";
 import { getRandomValues } from "node:crypto";
 
 // create a signer
-const signer: Signer = { /* ... */ };
+const signer: Signer = {
+  /* ... */
+};
 
 /**
  * The database encryption key is optional but strongly recommended for
@@ -106,7 +110,7 @@ const client = await Client.create(
   // client options
   {
     dbEncryptionKey,
-  },
+  }
 );
 ```
 
@@ -163,13 +167,13 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'APP_NAME/APP_VERSION'`.
    *
    * For example: `appVersion: 'alix/2.x'`
-   * 
-   * If you have an app and an agent, it's best to distinguish them from each other by 
+   *
+   * If you have an app and an agent, it's best to distinguish them from each other by
    * adding `-app` and `-agent` to the names. For example:
-   * 
+   *
    * - App: `appVersion: 'alix-app/3.x'`
    * - Agent: `appVersion: 'alix-agent/2.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which apps are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with app
    * support, especially around communicating important SDK updates, deprecations,
@@ -233,7 +237,6 @@ type ClientOptions = {
    */
   disableDeviceSync?: boolean;
 };
-
 ```
 
 ```tsx [Node]
@@ -252,13 +255,13 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'APP_NAME/APP_VERSION'`.
    *
    * For example: `appVersion: 'alix/2.x'`
-   * 
-   * If you have an app and an agent, it's best to distinguish them from each other by 
+   *
+   * If you have an app and an agent, it's best to distinguish them from each other by
    * adding `-app` and `-agent` to the names. For example:
-   * 
+   *
    * - App: `appVersion: 'alix-app/3.x'`
    * - Agent: `appVersion: 'alix-agent/2.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which apps are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with app
    * support, especially around communicating important SDK updates, deprecations,
@@ -278,7 +281,7 @@ type ClientOptions = {
   /**
    * Path to the local DB
    *
-   * There are 3 value types that can be used to specify the database path:
+   * There are 4 value types that can be used to specify the database path:
    *
    * - `undefined` (or excluded from the client options)
    *    The database will be created in the current working directory and is based on
@@ -291,8 +294,12 @@ type ClientOptions = {
    * - `string`
    *    The given path will be used to create the database.
    *    Example: `./my-db.db3`
+   *
+   * - `function`
+   *    A callback function that receives the inbox ID and returns a string path.
+   *    Example: `(inboxId) => string`
    */
-  dbPath?: string | null;
+  dbPath?: string | null | ((inboxId: string) => string);
   /**
    * Encryption key for the local DB
    */
@@ -327,7 +334,7 @@ type ClientOptions = {
   /**
    * Specify which XMTP environment to connect to. (default: `dev`)
    */
-  env: 'local' | 'dev' | 'production'
+  env: "local" | "dev" | "production";
   /**
    * Add a client app version identifier that's included with API requests.
    * Production apps are strongly encouraged to set this value.
@@ -335,13 +342,13 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'APP_NAME/APP_VERSION'`.
    *
    * For example: `appVersion: 'alix/2.x'`
-   * 
-   * If you have an app and an agent, it's best to distinguish them from each other by 
+   *
+   * If you have an app and an agent, it's best to distinguish them from each other by
    * adding `-app` and `-agent` to the names. For example:
-   * 
+   *
    * - App: `appVersion: 'alix-app/3.x'`
    * - Agent: `appVersion: 'alix-agent/2.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which apps are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with app
    * support, especially around communicating important SDK updates, deprecations,
@@ -351,28 +358,28 @@ type ClientOptions = {
   /**
    * REQUIRED specify the encryption key for the database. The encryption key must be exactly 32 bytes.
    */
-  dbEncryptionKey: Uint8Array
+  dbEncryptionKey: Uint8Array;
   /**
    * Set optional callbacks for handling identity setup
    */
-  preAuthenticateToInboxCallback?: () => Promise<void> | void
+  preAuthenticateToInboxCallback?: () => Promise<void> | void;
   /**
    * OPTIONAL specify the XMTP managed database directory
    */
-  dbDirectory?: string
+  dbDirectory?: string;
   /**
    * OPTIONAL specify a url to sync message history from
    */
-  historySyncUrl?: string
+  historySyncUrl?: string;
   /**
    * OPTIONAL specify a custom local host for testing on physical devices for example `localhost`
    */
-  customLocalHost?: string
+  customLocalHost?: string;
   /**
    * Allow configuring codecs for additional content types
    */
-  codecs?: ContentCodec[]
-}
+  codecs?: ContentCodec[];
+};
 ```
 
 ```kotlin [Kotlin]
@@ -403,7 +410,7 @@ data class ClientOptions(
          *
          * For example: `appVersion: 'alix/2.x'`
          *
-         * If you have an app and an agent, it's best to distinguish them from each other by 
+         * If you have an app and an agent, it's best to distinguish them from each other by
          * adding `-app` and `-agent` to the names. For example:
          *
          * - App: `appVersion: 'alix-app/3.x'`
@@ -411,7 +418,7 @@ data class ClientOptions(
          *
          * Setting this value provides telemetry that shows which apps are using the
          * XMTP client SDK. This information can help XMTP core developers provide you
-         * with app support, especially around communicating important SDK updates, 
+         * with app support, especially around communicating important SDK updates,
          * deprecations, and required upgrades.
          */
         val appVersion: String? = null,
@@ -437,8 +444,8 @@ public struct ClientOptions {
   /// You can use the following format: `appVersion: "APP_NAME/APP_VERSION"`.
   ///
   /// For example: `appVersion: 'alix/2.x'`
-  /// 
-  /// If you have an app and an agent, it's best to distinguish them from each other by 
+  ///
+  /// If you have an app and an agent, it's best to distinguish them from each other by
   /// adding `-app` and `-agent` to the names. For example:
   /// - App: `appVersion: 'alix-app/3.x'`
   /// - Agent: `appVersion: 'alix-agent/2.x'`


### PR DESCRIPTION
### Update Node.js SDK docs to document `ClientOptions.dbPath` supporting `string | null | ((inboxId: string) => string)` for client creation
- Update Node.js SDK documentation to add a function callback option to `ClientOptions.dbPath` and change its type to `string | null | ((inboxId: string) => string)` in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-956108c7409503436b2a0d2b92c483a2b6c01871779ed6e905cd05f8594fe731) and [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-0c4654346ef573194e351c6490f5afa5d3549c291035004f8de0d1a0f06dec4e).
- Reformat code samples for `Client.create(...)` and signer literals, adjust trailing commas and parenthesis placement, and normalize comment spacing and string quotes in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-0c4654346ef573194e351c6490f5afa5d3549c291035004f8de0d1a0f06dec4e) and [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-956108c7409503436b2a0d2b92c483a2b6c01871779ed6e905cd05f8594fe731).
- Add Prettier configuration specifying `singleQuote: false`, `semi: true`, and `tabWidth: 2` in [.prettierrc](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2).

#### 📍Where to Start
Start with the `ClientOptions` section in [docs/pages/agents/core-messaging/create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-956108c7409503436b2a0d2b92c483a2b6c01871779ed6e905cd05f8594fe731), then verify the parallel updates in [docs/pages/chat-apps/core-messaging/create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/377/files#diff-0c4654346ef573194e351c6490f5afa5d3549c291035004f8de0d1a0f06dec4e).



#### Changes since #377 opened

- Expanded Prettier configuration with comprehensive formatting rules [ecc97f1]
- Standardized formatting in documentation files for iframe elements and object syntax [ecc97f1]
----

_[Macroscope](https://app.macroscope.com) summarized ecc97f1._