### PR TITLE
Add Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,18 @@
+{
+  "arrowParens": "always",
+  "bracketSameLine": true,
+  "bracketSpacing": true,
+  "embeddedLanguageFormatting": "auto",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleAttributePerLine": false,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false
+}

--- a/docs/components/AutoBreadcrumb.tsx
+++ b/docs/components/AutoBreadcrumb.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { sidebarConfig } from '../../shared-sidebar.config';
+import React, { useState, useEffect } from "react";
+import { sidebarConfig } from "../../shared-sidebar.config";
 
 interface BreadcrumbItem {
   label: string;
@@ -12,24 +12,24 @@ interface AutoBreadcrumbProps {
 
 export default function AutoBreadcrumb({ path }: AutoBreadcrumbProps) {
   const [isMounted, setIsMounted] = useState(false);
-  
-  useEffect(() => { 
-    setIsMounted(true); 
+
+  useEffect(() => {
+    setIsMounted(true);
   }, []);
-  
+
   // Prevent hydration mismatches by not rendering until mounted
   if (!isMounted) return null;
-  
+
   // Get current path from browser if available (for client-side)
   const getCurrentPath = () => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       return window.location.pathname;
     }
-    return '';
+    return "";
   };
 
   const currentPath = getCurrentPath();
-  
+
   // If custom path is provided, use it
   if (path && path.length > 0) {
     return (
@@ -42,9 +42,7 @@ export default function AutoBreadcrumb({ path }: AutoBreadcrumbProps) {
                   {item.label}
                 </a>
               ) : (
-                <span className="breadcrumb-current">
-                  {item.label}
-                </span>
+                <span className="breadcrumb-current">{item.label}</span>
               )}
               {index < path.length - 1 && (
                 <span className="breadcrumb-separator" aria-hidden="true">
@@ -64,39 +62,44 @@ export default function AutoBreadcrumb({ path }: AutoBreadcrumbProps) {
   const generateBreadcrumb = (path: string) => {
     path = path.replace(/\/$/, "");
     const breadcrumbs: BreadcrumbItem[] = [];
-    
+
     // Determine section
-    let sectionKey = '';
-    let sectionName = '';
-    
-    if (path.startsWith('/agents')) {
-      sectionKey = '/agents/';
-      sectionName = 'Build agents';
-    } else if (path.startsWith('/chat-apps')) {
-      sectionKey = '/chat-apps/';
-      sectionName = 'Build chat apps';
-    } else if (path.startsWith('/protocol')) {
-      sectionKey = '/protocol/';
-      sectionName = 'Protocol';
-    } else if (path.startsWith('/network')) {
-      sectionKey = '/network/';
-      sectionName = 'Network';
+    let sectionKey = "";
+    let sectionName = "";
+
+    if (path.startsWith("/agents")) {
+      sectionKey = "/agents/";
+      sectionName = "Build agents";
+    } else if (path.startsWith("/chat-apps")) {
+      sectionKey = "/chat-apps/";
+      sectionName = "Build chat apps";
+    } else if (path.startsWith("/protocol")) {
+      sectionKey = "/protocol/";
+      sectionName = "Protocol";
+    } else if (path.startsWith("/network")) {
+      sectionKey = "/network/";
+      sectionName = "Network";
     }
-    
+
     if (!sectionKey) return [];
-    
+
     // Always add the main section
     breadcrumbs.push({
       label: sectionName,
-      href: undefined
+      href: undefined,
     });
-    
+
     // Find if this page is nested in a subsection
-    const sidebarSection = sidebarConfig[sectionKey as keyof typeof sidebarConfig];
+    const sidebarSection =
+      sidebarConfig[sectionKey as keyof typeof sidebarConfig];
     if (sidebarSection) {
       for (const section of sidebarSection) {
         // Handle flat structure (like Protocol and Network sections)
-        if (typeof section === 'object' && 'link' in section && !('items' in section)) {
+        if (
+          typeof section === "object" &&
+          "link" in section &&
+          !("items" in section)
+        ) {
           // This is a direct page item (flat structure)
           if (section.link === path) {
             // This is a top-level page, just return the section breadcrumb
@@ -104,21 +107,21 @@ export default function AutoBreadcrumb({ path }: AutoBreadcrumbProps) {
           }
         }
         // Handle nested structure (like Agents and Chat apps sections)
-        else if (typeof section === 'object' && 'items' in section) {
+        else if (typeof section === "object" && "items" in section) {
           // Check if this is a direct page (like build-an-agent)
-          if ('link' in section && section.link === path) {
+          if ("link" in section && section.link === path) {
             // This is a top-level page, just return the section breadcrumb
             return breadcrumbs;
           }
-          
+
           // Check if this page is in a subsection
           if (section.items && section.items.length > 0) {
             for (const item of section.items) {
               if (item.link === path) {
                 // Found the page in this subsection
                 breadcrumbs.push({
-                  label: section.text.replace(' 🤖', ''), // Remove emojis
-                  href: undefined // Don't make subsection clickable for now
+                  label: section.text.replace(" 🤖", ""), // Remove emojis
+                  href: undefined, // Don't make subsection clickable for now
                 });
                 return breadcrumbs;
               }
@@ -127,12 +130,12 @@ export default function AutoBreadcrumb({ path }: AutoBreadcrumbProps) {
         }
       }
     }
-    
+
     return breadcrumbs;
   };
 
   const breadcrumbs = generateBreadcrumb(currentPath);
-  
+
   if (breadcrumbs.length === 0) {
     return null; // No breadcrumb for homepage or unknown sections
   }
@@ -147,9 +150,7 @@ export default function AutoBreadcrumb({ path }: AutoBreadcrumbProps) {
                 {item.label}
               </a>
             ) : (
-              <span className="breadcrumb-current">
-                {item.label}
-              </span>
+              <span className="breadcrumb-current">{item.label}</span>
             )}
             {index < breadcrumbs.length - 1 && (
               <span className="breadcrumb-separator" aria-hidden="true">

--- a/docs/components/CustomHomePage.tsx
+++ b/docs/components/CustomHomePage.tsx
@@ -70,8 +70,7 @@ const ExternalLinkIcon = () => (
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
-    className="custom-homepage-tile-external-icon"
-  >
+    className="custom-homepage-tile-external-icon">
     <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
     <polyline points="15 3 21 3 21 9"></polyline>
     <line x1="10" y1="14" x2="21" y2="3"></line>
@@ -93,11 +92,7 @@ const Tile: React.FC<TileProps> = ({
     </>
   );
 
-  return (
-    <div className="custom-homepage-tile">
-      {content}
-    </div>
-  );
+  return <div className="custom-homepage-tile">{content}</div>;
 };
 
 interface SDKTileProps {
@@ -153,7 +148,9 @@ const SectionTitle: React.FC<{ children: React.ReactNode; id?: string }> = ({
   children,
   id,
 }) => (
-  <h2 className="custom-homepage-tile-title custom-homepage-section-title" id={id}>
+  <h2
+    className="custom-homepage-tile-title custom-homepage-section-title"
+    id={id}>
     {children}
   </h2>
 );

--- a/docs/components/Mermaid.tsx
+++ b/docs/components/Mermaid.tsx
@@ -1,15 +1,15 @@
 // docs/components/Mermaid.tsx
-'use client';
+"use client";
 
-import { useEffect, useRef } from 'react';
-import mermaid from 'mermaid';
+import { useEffect, useRef } from "react";
+import mermaid from "mermaid";
 
 type MermaidProps = {
   chart: string;
   id?: string;
 };
 
-export default function Mermaid({ chart, id = 'mermaid-graph' }: MermaidProps) {
+export default function Mermaid({ chart, id = "mermaid-graph" }: MermaidProps) {
   const container = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export default function Mermaid({ chart, id = 'mermaid-graph' }: MermaidProps) {
           container.current.innerHTML = svg;
         }
       } catch (error) {
-        console.error('Mermaid render error:', error);
+        console.error("Mermaid render error:", error);
         if (container.current) {
           container.current.innerHTML = `<pre style="color: red;">Failed to render diagram: ${String(error)}</pre>`;
         }

--- a/docs/footer.tsx
+++ b/docs/footer.tsx
@@ -10,57 +10,54 @@ export default function Footer() {
               "--vocs_ExternalLink_iconUrl":
                 "url(/.vocs/icons/arrow-diagonal.svg)",
             }}
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
-          >
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink">
             XMTP.org
-          </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          </a>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
         </small>
         <small>
-        <a
+          <a
             href="https://status.xmtp.org/"
             target="_blank"
             style={{
               "--vocs_ExternalLink_iconUrl":
                 "url(/.vocs/icons/arrow-diagonal.svg)",
             }}
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
-          >
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink">
             XMTP status
-          </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          </a>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
         </small>
         <small>
-        <a
+          <a
             href="https://xmtp.chat/"
             target="_blank"
             style={{
               "--vocs_ExternalLink_iconUrl":
                 "url(/.vocs/icons/arrow-diagonal.svg)",
             }}
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
-          >
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink">
             XMTP.chat
           </a>
         </small>
       </div>
       <div>
-      <small>
+        <small>
           <a
             href="/privacy"
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined"
-          >
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined">
             Privacy policy
           </a>
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
           <a
             href="/terms"
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined"
-          >
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined">
             Terms of service
           </a>
         </small>
       </div>
       <div>
-        <small>         
+        <small>
           <a
             href="https://creativecommons.org/licenses/by/4.0/"
             target="_blank"
@@ -68,11 +65,11 @@ export default function Footer() {
               "--vocs_ExternalLink_iconUrl":
                 "url(/.vocs/icons/arrow-diagonal.svg)",
             }}
-            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink"
-          >
+            className="vocs_Anchor vocs_Link vocs_Link_accent_underlined vocs_ExternalLink">
             CC BY 4.0
           </a>
-          &nbsp;&nbsp;Copyright © 2024-present XMTP.</small>
+          &nbsp;&nbsp;Copyright © 2024-present XMTP.
+        </small>
       </div>
     </div>
   );

--- a/docs/pages/agents/content-types/attachments.mdx
+++ b/docs/pages/agents/content-types/attachments.mdx
@@ -73,7 +73,7 @@ Use `RemoteAttachmentCodec.encodeEncrypted` to encrypt an attachment:
 ```tsx [Node]
 const encryptedEncoded = await RemoteAttachmentCodec.encodeEncrypted(
   attachment,
-  new AttachmentCodec()
+  new AttachmentCodec(),
 );
 ```
 
@@ -128,7 +128,7 @@ Once you've created the attachment object, you can create a preview to show in t
 const objectURL = URL.createObjectURL(
   new Blob([Buffer.from(attachment.data)], {
     type: attachment.mimeType,
-  })
+  }),
 );
 
 const img = document.createElement("img");

--- a/docs/pages/agents/content-types/reactions.mdx
+++ b/docs/pages/agents/content-types/reactions.mdx
@@ -31,9 +31,7 @@ pnpm add @xmtp/content-type-reaction
 After importing the package, you can register the codec.
 
 ```jsx [Node]
-import {
-  ReactionCodec,
-} from "@xmtp/content-type-reaction";
+import { ReactionCodec } from "@xmtp/content-type-reaction";
 // Create the XMTP client
 const xmtp = await Client.create(signer, {
   env: "dev",

--- a/docs/pages/agents/content-types/transactions.mdx
+++ b/docs/pages/agents/content-types/transactions.mdx
@@ -33,9 +33,7 @@ pnpm i @xmtp/content-type-wallet-send-calls
 After importing the package, you can register the codec.
 
 ```js [Node]
-import {
-  WalletSendCallsCodec,
-} from "@xmtp/content-type-wallet-send-calls";
+import { WalletSendCallsCodec } from "@xmtp/content-type-wallet-send-calls";
 // Create the XMTP client
 const xmtp = await Client.create(signer, {
   env: "dev",

--- a/docs/pages/agents/core-messaging/agent-installations.mdx
+++ b/docs/pages/agents/core-messaging/agent-installations.mdx
@@ -15,11 +15,15 @@ Your agent can have **up to 10 active installations** before you need to revoke 
 For example, if you deploy your agent across these network environments, you will have 3 inboxes, each with 1 installation:
 
 - Local development: `local` network
-- Railway: `dev` network  
+- Railway: `dev` network
 - Production server: `production` network
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/agent-install-sep.png" width="500px" alt="Diagram showing agent deployments across different network environments (local, dev, production) creating separate inboxes with one installation each" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/agent-install-sep.png"
+    width="500px"
+    alt="Diagram showing agent deployments across different network environments (local, dev, production) creating separate inboxes with one installation each"
+  />
 </div>
 
 If you deploy your agent to this same network environment, you have 1 inbox with 3 installations:
@@ -29,7 +33,11 @@ If you deploy your agent to this same network environment, you have 1 inbox with
 - Production server: `production` network
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/agent-install.png" width="500px" alt="Diagram showing agent deployments to the same production network environment creating one inbox with three installations" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/agent-install.png"
+    width="500px"
+    alt="Diagram showing agent deployments to the same production network environment creating one inbox with three installations"
+  />
 </div>
 
 Here are some best practices for agent installation management:

--- a/docs/pages/agents/core-messaging/create-a-client.mdx
+++ b/docs/pages/agents/core-messaging/create-a-client.mdx
@@ -14,8 +14,7 @@ This video provides a walkthrough of creating and building a client.
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
-  allowFullScreen
-></iframe>
+  allowFullScreen></iframe>
 
 ### How it works
 
@@ -71,7 +70,9 @@ import { Client, type Signer } from "@xmtp/node-sdk";
 import { getRandomValues } from "node:crypto";
 
 // create a signer
-const signer: Signer = { /* ... */ };
+const signer: Signer = {
+  /* ... */
+};
 
 /**
  * The database encryption key is optional but strongly recommended for
@@ -113,11 +114,11 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'AGENT_NAME/AGENT_VERSION'`.
    * For example, `appVersion: 'alix/2.x'`
    *
-   * If you have an agent and an app, it's best to distinguish them from each other by 
+   * If you have an agent and an app, it's best to distinguish them from each other by
    * adding `-agent` and `-app` to the names. For example:
    * - Agent: `appVersion: 'alix-agent/2.x'`
    * - App: `appVersion: 'alix-app/3.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which agents are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with agent
    * support, especially around communicating important SDK updates, including

--- a/docs/pages/agents/core-messaging/create-a-signer.mdx
+++ b/docs/pages/agents/core-messaging/create-a-signer.mdx
@@ -30,14 +30,14 @@ The SCW signer has the same 3 required properties as the EOA signer, but also re
 
 Here is a list of supported chain IDs:
 
-- chain_rpc_1     = string
-- chain_rpc_8453  = string
+- chain_rpc_1 = string
+- chain_rpc_8453 = string
 - chain_rpc_42161 = string
-- chain_rpc_10    = string
-- chain_rpc_137   = string
-- chain_rpc_324   = string
+- chain_rpc_10 = string
+- chain_rpc_137 = string
+- chain_rpc_324 = string
 - chain_rpc_59144 = string
-- chain_rpc_480   = string
+- chain_rpc_480 = string
 
 Need support for a different chain ID? Please post your request to the [XMTP Community Forums](https://community.xmtp.org/c/general/ideas/54).
 

--- a/docs/pages/agents/core-messaging/create-conversations.mdx
+++ b/docs/pages/agents/core-messaging/create-conversations.mdx
@@ -25,7 +25,7 @@ Once you have the verified identities, create a new group chat. The maximum grou
 ```js [Node]
 const group = await client.conversations.newGroup(
   [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
+  createGroupOptions /* optional */,
 );
 ```
 
@@ -43,9 +43,8 @@ Use these helper methods to quickly locate and access specific conversations—w
 
 ```js [Node]
 // get a conversation by its ID
-const conversationById = await client.conversations.getConversationById(
-  conversationId
-);
+const conversationById =
+  await client.conversations.getConversationById(conversationId);
 
 // get a message by its ID
 const messageById = await client.conversations.getMessageById(messageId);

--- a/docs/pages/agents/core-messaging/group-permissions.mdx
+++ b/docs/pages/agents/core-messaging/group-permissions.mdx
@@ -55,19 +55,23 @@ The app's developer can provide a UI that enables group participants to make fur
 - Update group metadata
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/group-perm-toggles.png" width="300px" alt="UI screenshot showing group permission toggle options including Add members and Edit group info settings" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/group-perm-toggles.png"
+    width="300px"
+    alt="UI screenshot showing group permission toggle options including Add members and Edit group info settings"
+  />
 </div>
 
 You can use member statuses, options, and permissions to create a custom policy set. The following table represents the valid policy options for each of the permissions:
 
-| Permission | Allow all | Deny all  | Admin only | Super admin only |
-| --- | --- | --- | --- | --- |
-| Add member | ✅ | ✅ | ✅ | ✅ |
-| Remove member | ✅ | ✅ | ✅ | ✅ |
-| Add admin | ❌ | ✅ | ✅ | ✅ |
-| Remove admin | ❌ | ✅ | ✅ | ✅ |
-| Update group permissions | ❌ | ❌ | ❌ | ✅ |
-| Update group metadata | ✅ | ✅ | ✅ | ✅ |
+| Permission               | Allow all | Deny all | Admin only | Super admin only |
+| ------------------------ | --------- | -------- | ---------- | ---------------- |
+| Add member               | ✅        | ✅       | ✅         | ✅               |
+| Remove member            | ✅        | ✅       | ✅         | ✅               |
+| Add admin                | ❌        | ✅       | ✅         | ✅               |
+| Remove admin             | ❌        | ✅       | ✅         | ✅               |
+| Update group permissions | ❌        | ❌       | ❌         | ✅               |
+| Update group metadata    | ✅        | ✅       | ✅         | ✅               |
 
 If you aren't opinionated and don't set any permissions and options, groups will default to using the delivered `All_Members` policy set, which applies the following permissions and options:
 
@@ -149,7 +153,10 @@ await group.removeMembers([inboxId]);
 ### Get inbox IDs for members
 
 ```js [Node]
-const inboxId = await client.getInboxIdByIdentities([bo.identity, caro.identity]);
+const inboxId = await client.getInboxIdByIdentities([
+  bo.identity,
+  caro.identity,
+]);
 ```
 
 ### Get identities for members
@@ -163,7 +170,7 @@ const members = group.members;
 
 // map inbox ID to account identity
 const inboxIdIdentityMap = new Map(
-  members.map((member) => [member.inboxId, member.accountIdentity])
+  members.map((member) => [member.inboxId, member.accountIdentity]),
 );
 ```
 

--- a/docs/pages/agents/core-messaging/stream.mdx
+++ b/docs/pages/agents/core-messaging/stream.mdx
@@ -16,7 +16,7 @@ const stream = await client.conversations.stream({
   },
   onFail: () => {
     console.log("Stream failed");
-  }
+  },
 });
 
 // Or use for-await loop
@@ -51,23 +51,23 @@ const stream = await client.conversations.streamAllMessages({
   },
   onFail: () => {
     console.log("Stream failed");
-  }
+  },
 });
- 
+
 // stream only group messages
 const groupMessageStream = await client.conversations.streamAllGroupMessages({
   onValue: (message) => {
     console.log("New group message:", message);
-  }
+  },
 });
- 
+
 // stream only dm messages
 const dmMessageStream = await client.conversations.streamAllDmMessages({
   onValue: (message) => {
     console.log("New DM message:", message);
-  }
+  },
 });
- 
+
 // Or use for-await loop
 for await (const message of stream) {
   // Received a message
@@ -88,7 +88,7 @@ const stream = await client.conversations.streamAllMessages({
   retryOnFail: false,
   onValue: (message) => {
     console.log("New message:", message);
-  }
+  },
 });
 
 // use stream options with retry configuration

--- a/docs/pages/agents/debug-agents.mdx
+++ b/docs/pages/agents/debug-agents.mdx
@@ -28,8 +28,9 @@ const urls = [`http://xmtp.chat/dm/${clientsByAddress}`];
 
 const conversations = await client.conversations.list();
 const inboxState = await client.preferences.inboxState();
-const keyPackageStatuses =
-  await client.getKeyPackageStatusesForInstallationIds([installationId]);
+const keyPackageStatuses = await client.getKeyPackageStatusesForInstallationIds(
+  [installationId],
+);
 
 let createdDate = new Date();
 let expiryDate = new Date();

--- a/docs/pages/agents/deploy-agent.mdx
+++ b/docs/pages/agents/deploy-agent.mdx
@@ -2,12 +2,12 @@
 
 This section covers how to deploy an agent using Railway—a platform many developers prefer for quickly and easily deploying agents. While this tutorial focuses on Railway, you can use any hosting provider that supports Node.js and environment variables.
 
-Alternative platforms include: 
+Alternative platforms include:
 
 - [Fly.io](https://fly.io/)
 - [Heroku](https://www.heroku.com/)
 - [Render](https://render.com/)
-- [Vercel](https://vercel.com)  
+- [Vercel](https://vercel.com)
 
 Want to contribute a deployment guide for another platform? We welcome [pull requests](https://github.com/xmtp/docs-xmtp-org/blob/main/README.md)!
 
@@ -63,10 +63,10 @@ Then, specify `dbPath` in your client options:
 
 ```tsx [Node]
 const receiverClient = await Client.create(signer, {
-    dbEncryptionKey,
-    env: XMTP_ENV as XmtpEnv,
-    dbPath: getDbPath(XMTP_ENV),
-  });
+  dbEncryptionKey,
+  env: XMTP_ENV as XmtpEnv,
+  dbPath: getDbPath(XMTP_ENV),
+});
 ```
 
 ## 5. Configure environment variables

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -12,7 +12,15 @@ Building with XMTP gives your agent access to:
 
 ### Quickstart video guide
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/djRLnWUvwIA?si=JX25iQt57wgXnqVX" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/djRLnWUvwIA?si=JX25iQt57wgXnqVX"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ### Agent examples
 

--- a/docs/pages/agents/get-started/faq.mdx
+++ b/docs/pages/agents/get-started/faq.mdx
@@ -72,7 +72,15 @@ The XMTP SDK currently requires you to use [ethers](https://ethers.org/) or anot
 
 ### What is the invalid key package error?
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hNlby-SfPzw?si=V7LqaBxk-i4xhbNC" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/hNlby-SfPzw?si=V7LqaBxk-i4xhbNC"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ### Where can I get official XMTP brand assets?
 
@@ -121,7 +129,7 @@ This retention policy would represent a minimum retention period, not a maximum.
 For example, a retention policy may look something like the following, though specifics are subject to change:
 
 - One year for messages
-- Indefinite storage for account information and personal preferences  
+- Indefinite storage for account information and personal preferences
 
 The team is researching a way to provide this indefinite storage and have it scale forever.
 

--- a/docs/pages/agents/get-started/intro.mdx
+++ b/docs/pages/agents/get-started/intro.mdx
@@ -10,23 +10,23 @@ Build with XMTP to:
 
 - **Deliver secure and private messaging**
 
-    Using the [Messaging Layer Security](/protocol/security) (MLS) standard, a ratified [IETF](https://www.ietf.org/about/introduction/) standard, XMTP provides end-to-end encrypted messaging with forward secrecy and post-compromise security.
+  Using the [Messaging Layer Security](/protocol/security) (MLS) standard, a ratified [IETF](https://www.ietf.org/about/introduction/) standard, XMTP provides end-to-end encrypted messaging with forward secrecy and post-compromise security.
 
 - **Provide spam-free chats**
 
-    In any open and permissionless messaging ecosystem, spam is an inevitable reality, and XMTP is no exception. However, with XMTP user consent preferences, developers can give their users spam-free chats displaying conversations with chosen contacts only.
+  In any open and permissionless messaging ecosystem, spam is an inevitable reality, and XMTP is no exception. However, with XMTP user consent preferences, developers can give their users spam-free chats displaying conversations with chosen contacts only.
 
 - **Build on native crypto rails**
 
-    Build with XMTP to tap into the capabilities of crypto and web3. Support decentralized identities, crypto transactions, and more, directly in a messaging experience.
+  Build with XMTP to tap into the capabilities of crypto and web3. Support decentralized identities, crypto transactions, and more, directly in a messaging experience.
 
 - **Empower users to own and control their communications**
 
-    With apps built with XMTP, users own their conversations, data, and identity. Combined with the interoperability that comes with protocols, this means users can access their end-to-end encrypted communications using any app built with XMTP.
+  With apps built with XMTP, users own their conversations, data, and identity. Combined with the interoperability that comes with protocols, this means users can access their end-to-end encrypted communications using any app built with XMTP.
 
 - **Create with confidence**
 
-    Developers are free to create the messaging experiences their users want—on a censorship-resistant protocol architected to last forever. Because XMTP isn't a closed proprietary platform, developers can build confidently, knowing their access and functionality can't be revoked by a central authority.
+  Developers are free to create the messaging experiences their users want—on a censorship-resistant protocol architected to last forever. Because XMTP isn't a closed proprietary platform, developers can build confidently, knowing their access and functionality can't be revoked by a central authority.
 
 ## Try an app built with XMTP
 
@@ -37,11 +37,9 @@ Try [xmtp.chat](https://xmtp.chat/), an app made for devs to learn to build with
 ## Join the XMTP community
 
 - **XMTP builds in the open**
-
   - Explore the documentation on this site
   - Explore the open [XMTP GitHub org](https://github.com/xmtp), which contains code for LibXMTP, XMTP SDKs, and xmtpd, node software powering the XMTP testnet.
   - Explore the open source code for [xmtp.chat](https://github.com/xmtp/xmtp-js/tree/main/apps/xmtp.chat), an app made for devs to learn to build with XMTP—using an app built with XMTP.
 
 - **XMTP is for everyone**
-
   - [Join the conversation](https://community.xmtp.org/) and become part of the movement to redefine digital communications.

--- a/docs/pages/chat-apps/content-types/attachments.mdx
+++ b/docs/pages/chat-apps/content-types/attachments.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to use the remote attachment, multiple remote attachment, or attachment content types to support attachments in your app built with XMTP
 ---
+
 # Support attachments in your app built with XMTP
 
 Use the remote attachment, multiple remote attachments, or attachment content type to support attachments in your app.
@@ -116,7 +117,7 @@ Use `RemoteAttachmentCodec.encodeEncrypted` to encrypt an attachment:
 ```tsx
 const encryptedEncoded = await RemoteAttachmentCodec.encodeEncrypted(
   attachment,
-  new AttachmentCodec()
+  new AttachmentCodec(),
 );
 ```
 
@@ -318,7 +319,7 @@ Once you've created the attachment object, you can create a preview to show in t
 const objectURL = URL.createObjectURL(
   new Blob([Buffer.from(attachment.data)], {
     type: attachment.mimeType,
-  })
+  }),
 );
 
 const img = document.createElement("img");
@@ -420,7 +421,7 @@ Client.register(codec = MultiRemoteAttachmentCodec())
 
 ```swift [Swift]
 Client.register(codec: AttachmentCodec())
-Client.register(codec: RemoteAttachmentCodec()) 
+Client.register(codec: RemoteAttachmentCodec())
 Client.register(codec: MultiRemoteAttachmentCodec())
 ```
 
@@ -436,14 +437,14 @@ Each attachment in the attachments array contains a URL that points to an encryp
 const attachment1: DecryptedLocalAttachment = {
   fileUri: "content://media/external/images/media/image-1.png",
   mimeType: "image/png",
-  filename: "image-1.png"
-}
+  filename: "image-1.png",
+};
 
 const attachment2: DecryptedLocalAttachment = {
   fileUri: "content://media/external/images/media/image-2.png",
   mimeType: "image/png",
-  filename: "image-2.png"
-}
+  filename: "image-2.png",
+};
 ```
 
 ```kotlin [Kotlin]
@@ -463,7 +464,7 @@ val attachment2 = Attachment(
 ```swift [Swift]
 let attachment1 = Attachment(
     filename: "test1.txt",
-    mimeType: "text/plain", 
+    mimeType: "text/plain",
     data: Data("hello world".utf8)
 )
 
@@ -481,20 +482,21 @@ let attachment2 = Attachment(
 :::code-group
 
 ```ts [React Native]
-const remoteAttachments: RemoteAttachmentInfo[] = []
-  for (const attachment of [attachment1, attachment2]) {
-    // Encrypt the attachment and receive the local URI of the encrypted file
-    const { encryptedLocalFileUri, metadata } = await alix.encryptAttachment(attachment)
+const remoteAttachments: RemoteAttachmentInfo[] = [];
+for (const attachment of [attachment1, attachment2]) {
+  // Encrypt the attachment and receive the local URI of the encrypted file
+  const { encryptedLocalFileUri, metadata } =
+    await alix.encryptAttachment(attachment);
 
-    // Upload the attachment to a remote server and receive the URL
-    // (Integrator must supply upload from local uri and return url functionality!)
-    const url = uploadAttachmentForUrl(encryptedLocalFileUri)
+  // Upload the attachment to a remote server and receive the URL
+  // (Integrator must supply upload from local uri and return url functionality!)
+  const url = uploadAttachmentForUrl(encryptedLocalFileUri);
 
-    // Build the remote attachment info
-    const remoteAttachmentInfo =
-      MultiRemoteAttachmentCodec.buildMultiRemoteAttachmentInfo(url, metadata)
-    remoteAttachments.push(remoteAttachmentInfo)
-  }
+  // Build the remote attachment info
+  const remoteAttachmentInfo =
+    MultiRemoteAttachmentCodec.buildMultiRemoteAttachmentInfo(url, metadata);
+  remoteAttachments.push(remoteAttachmentInfo);
+}
 ```
 
 ```kotlin [Kotlin]
@@ -543,10 +545,10 @@ for att in [attachment1, attachment2] {
 
 ```ts [React Native]
 await convo.send({
-    multiRemoteAttachment: {
-      attachments: remoteAttachments,
-    },
-  })
+  multiRemoteAttachment: {
+    attachments: remoteAttachments,
+  },
+});
 ```
 
 ```kotlin [Kotlin]
@@ -573,12 +575,15 @@ try await alixConversation.send(encodedContent: encodedContent)
 :::code-group
 
 ```ts [React Native]
-const messages = await conversation.messages()
-if (messages.size > 0 && messages[0].contentTypeId == 'xmtp.org/multiRemoteStaticContent:1.0') {
+const messages = await conversation.messages();
+if (
+  messages.size > 0 &&
+  messages[0].contentTypeId == "xmtp.org/multiRemoteStaticContent:1.0"
+) {
   // Decode the raw content back into a MultiRemoteAttachment
-    const multiRemoteAttachment: MultiRemoteAttachment = messages[0].content()
+  const multiRemoteAttachment: MultiRemoteAttachment = messages[0].content();
 
-    // See next section for download, and decrypt the attachments
+  // See next section for download, and decrypt the attachments
 }
 ```
 
@@ -609,27 +614,27 @@ if messages.size > 0 && messages[0].encodedContent.type.id.equals(ContentTypeMul
 :::code-group
 
 ```ts [React Native]
-const decryptedAttachments: DecryptedLocalAttachment[] = []
+const decryptedAttachments: DecryptedLocalAttachment[] = [];
 
 for (const attachment of multiRemoteAttachment.attachments) {
-    // Downloading the encrypted payload from the attachment URL and save the local file
-    // (Integrator must supply download from url and save to local Uri functionality!)
-    const encryptedFileLocalURIAfterDownload: string = downloadFromUrl(
-      attachment.url
-    )
-    // Decrypt the local file
-    const decryptedLocalAttachment = await alix.decryptAttachment({
-      encryptedLocalFileUri: encryptedFileLocalURIAfterDownload,
-      metadata: {
-        secret: attachment.secret,
-        salt: attachment.salt,
-        nonce: attachment.nonce,
-        contentDigest: attachment.contentDigest,
-        filename: attachment.filename,
-      } as RemoteAttachmentContent,
-    })
-    decryptedAttachments.push(decryptedLocalAttachment)
-  }
+  // Downloading the encrypted payload from the attachment URL and save the local file
+  // (Integrator must supply download from url and save to local Uri functionality!)
+  const encryptedFileLocalURIAfterDownload: string = downloadFromUrl(
+    attachment.url,
+  );
+  // Decrypt the local file
+  const decryptedLocalAttachment = await alix.decryptAttachment({
+    encryptedLocalFileUri: encryptedFileLocalURIAfterDownload,
+    metadata: {
+      secret: attachment.secret,
+      salt: attachment.salt,
+      nonce: attachment.nonce,
+      contentDigest: attachment.contentDigest,
+      filename: attachment.filename,
+    } as RemoteAttachmentContent,
+  });
+  decryptedAttachments.push(decryptedLocalAttachment);
+}
 ```
 
 ```kotlin [Kotlin]
@@ -653,10 +658,10 @@ for (remoteAttachmentInfo: FfiRemoteAttachmentInfo in multiRemoteAttachment.atta
 
   // Combine encrypted payload with RemoteAttachment to create an EncryptedEncodedContent Object
   val encryptedAttachment: EncryptedEncodedContent = MultiRemoteAttachmentCodec.buildEncryptAttachmentResult(remoteAttachment, encryptedPayload)
-  
+
   // Decrypt payload
   val encodedContent: EncodedContent = MultiRemoteAttachmentCodec.decryptAttachment(encryptedAttachment)
-  
+
   // Convert EncodedContent to Attachment
   val attachment = attachmentCodec.decode(encodedContent)
   decryptedAttachments.add(attachment)
@@ -763,9 +768,7 @@ pnpm add @xmtp/content-type-remote-attachment
 :::code-group
 
 ```jsx [Browser]
-import {
-  AttachmentCodec,
-} from "@xmtp/content-type-remote-attachment";
+import { AttachmentCodec } from "@xmtp/content-type-remote-attachment";
 // Create the XMTP client
 const xmtp = await Client.create(signer, {
   env: "dev",

--- a/docs/pages/chat-apps/content-types/custom.mdx
+++ b/docs/pages/chat-apps/content-types/custom.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to build custom content types
 ---
+
 # Build custom content types
 
 Any developer building with XMTP can create a custom content type and immediately start using it in their app. Unlike a standard content type, use of a custom content type doesn't require prerequisite formal adoption through the XRC and XIP processes.

--- a/docs/pages/chat-apps/content-types/reactions.mdx
+++ b/docs/pages/chat-apps/content-types/reactions.mdx
@@ -37,9 +37,7 @@ After importing the package, you can register the codec.
 :::code-group
 
 ```jsx [Browser]
-import {
-  ReactionCodec,
-} from "@xmtp/content-type-reaction";
+import { ReactionCodec } from "@xmtp/content-type-reaction";
 // Create the XMTP client
 const xmtp = await Client.create(signer, {
   env: "dev",

--- a/docs/pages/chat-apps/content-types/read-receipts.mdx
+++ b/docs/pages/chat-apps/content-types/read-receipts.mdx
@@ -33,9 +33,7 @@ pnpm add @xmtp/content-type-read-receipt
 :::code-group
 
 ```js [Browser]
-import {
-  ReadReceiptCodec,
-} from "@xmtp/content-type-read-receipt";
+import { ReadReceiptCodec } from "@xmtp/content-type-read-receipt";
 // Create the XMTP client
 const xmtp = await Client.create(signer, {
   env: "dev",

--- a/docs/pages/chat-apps/content-types/transaction-refs.mdx
+++ b/docs/pages/chat-apps/content-types/transaction-refs.mdx
@@ -1,6 +1,7 @@
 ---
 description: Learn how to implement an onchain transaction reference content type
 ---
+
 # Support onchain transaction references in your app built with XMTP
 
 This package provides an XMTP content type to support onchain transaction references. It is a reference to an onchain transaction sent as a message. This content type facilitates sharing transaction hashes or IDs, thereby providing a direct link to onchain activities. Transaction references serve to display transaction details, facilitating the sharing of onchain activities, such as token transfers, between users.

--- a/docs/pages/chat-apps/content-types/transactions.mdx
+++ b/docs/pages/chat-apps/content-types/transactions.mdx
@@ -35,9 +35,7 @@ pnpm i @xmtp/content-type-wallet-send-calls
 After importing the package, you can register the codec.
 
 ```js [Browser]
-import {
-  WalletSendCallsCodec,
-} from "@xmtp/content-type-wallet-send-calls";
+import { WalletSendCallsCodec } from "@xmtp/content-type-wallet-send-calls";
 // Create the XMTP client
 const xmtp = await Client.create(signer, {
   env: "dev",

--- a/docs/pages/chat-apps/core-messaging/create-a-client.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-client.mdx
@@ -14,8 +14,7 @@ This video provides a walkthrough of creating and building a client.
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   referrerPolicy="strict-origin-when-cross-origin"
-  allowFullScreen
-></iframe>
+  allowFullScreen></iframe>
 
 ### How it works
 
@@ -74,13 +73,15 @@ To call `Client.create()`, you must pass in a required `signer` and can also pas
 import { Client, type Signer } from "@xmtp/browser-sdk";
 
 // create a signer
-const signer: Signer = { /* ... */ };
+const signer: Signer = {
+  /* ... */
+};
 
 const client = await Client.create(
   signer,
   // client options
   {
-  // Note: dbEncryptionKey is not used for encryption in browser environments
+    // Note: dbEncryptionKey is not used for encryption in browser environments
   },
 );
 ```
@@ -90,7 +91,9 @@ import { Client, type Signer } from "@xmtp/node-sdk";
 import { getRandomValues } from "node:crypto";
 
 // create a signer
-const signer: Signer = { /* ... */ };
+const signer: Signer = {
+  /* ... */
+};
 
 /**
  * The database encryption key is optional but strongly recommended for
@@ -165,13 +168,13 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'APP_NAME/APP_VERSION'`.
    *
    * For example: `appVersion: 'alix/2.x'`
-   * 
-   * If you have an app and an agent, it's best to distinguish them from each other by 
+   *
+   * If you have an app and an agent, it's best to distinguish them from each other by
    * adding `-app` and `-agent` to the names. For example:
-   * 
+   *
    * - App: `appVersion: 'alix-app/3.x'`
    * - Agent: `appVersion: 'alix-agent/2.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which apps are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with app
    * support, especially around communicating important SDK updates, deprecations,
@@ -239,7 +242,6 @@ type ClientOptions = {
    */
   disableDeviceSync?: boolean;
 };
-
 ```
 
 ```tsx [Node]
@@ -258,13 +260,13 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'APP_NAME/APP_VERSION'`.
    *
    * For example: `appVersion: 'alix/2.x'`
-   * 
-   * If you have an app and an agent, it's best to distinguish them from each other by 
+   *
+   * If you have an app and an agent, it's best to distinguish them from each other by
    * adding `-app` and `-agent` to the names. For example:
-   * 
+   *
    * - App: `appVersion: 'alix-app/3.x'`
    * - Agent: `appVersion: 'alix-agent/2.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which apps are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with app
    * support, especially around communicating important SDK updates, deprecations,
@@ -337,7 +339,7 @@ type ClientOptions = {
   /**
    * Specify which XMTP environment to connect to. (default: `dev`)
    */
-  env: 'local' | 'dev' | 'production'
+  env: "local" | "dev" | "production";
   /**
    * Add a client app version identifier that's included with API requests.
    * Production apps are strongly encouraged to set this value.
@@ -345,13 +347,13 @@ type ClientOptions = {
    * You can use the following format: `appVersion: 'APP_NAME/APP_VERSION'`.
    *
    * For example: `appVersion: 'alix/2.x'`
-   * 
-   * If you have an app and an agent, it's best to distinguish them from each other by 
+   *
+   * If you have an app and an agent, it's best to distinguish them from each other by
    * adding `-app` and `-agent` to the names. For example:
-   * 
+   *
    * - App: `appVersion: 'alix-app/3.x'`
    * - Agent: `appVersion: 'alix-agent/2.x'`
-   * 
+   *
    * Setting this value provides telemetry that shows which apps are using the
    * XMTP client SDK. This information can help XMTP core developers provide you with app
    * support, especially around communicating important SDK updates, deprecations,
@@ -361,28 +363,28 @@ type ClientOptions = {
   /**
    * REQUIRED specify the encryption key for the database. The encryption key must be exactly 32 bytes.
    */
-  dbEncryptionKey: Uint8Array
+  dbEncryptionKey: Uint8Array;
   /**
    * Set optional callbacks for handling identity setup
    */
-  preAuthenticateToInboxCallback?: () => Promise<void> | void
+  preAuthenticateToInboxCallback?: () => Promise<void> | void;
   /**
    * OPTIONAL specify the XMTP managed database directory
    */
-  dbDirectory?: string
+  dbDirectory?: string;
   /**
    * OPTIONAL specify a url to sync message history from
    */
-  historySyncUrl?: string
+  historySyncUrl?: string;
   /**
    * OPTIONAL specify a custom local host for testing on physical devices for example `localhost`
    */
-  customLocalHost?: string
+  customLocalHost?: string;
   /**
    * Allow configuring codecs for additional content types
    */
-  codecs?: ContentCodec[]
-}
+  codecs?: ContentCodec[];
+};
 ```
 
 ```kotlin [Kotlin]
@@ -413,7 +415,7 @@ data class ClientOptions(
          *
          * For example: `appVersion: 'alix/2.x'`
          *
-         * If you have an app and an agent, it's best to distinguish them from each other by 
+         * If you have an app and an agent, it's best to distinguish them from each other by
          * adding `-app` and `-agent` to the names. For example:
          *
          * - App: `appVersion: 'alix-app/3.x'`
@@ -421,7 +423,7 @@ data class ClientOptions(
          *
          * Setting this value provides telemetry that shows which apps are using the
          * XMTP client SDK. This information can help XMTP core developers provide you
-         * with app support, especially around communicating important SDK updates, 
+         * with app support, especially around communicating important SDK updates,
          * deprecations, and required upgrades.
          */
         val appVersion: String? = null,
@@ -447,8 +449,8 @@ public struct ClientOptions {
   /// You can use the following format: `appVersion: "APP_NAME/APP_VERSION"`.
   ///
   /// For example: `appVersion: 'alix/2.x'`
-  /// 
-  /// If you have an app and an agent, it's best to distinguish them from each other by 
+  ///
+  /// If you have an app and an agent, it's best to distinguish them from each other by
   /// adding `-app` and `-agent` to the names. For example:
   /// - App: `appVersion: 'alix-app/3.x'`
   /// - Agent: `appVersion: 'alix-agent/2.x'`

--- a/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
@@ -104,14 +104,14 @@ The SCW signer has the same 3 required properties as the EOA signer, but also re
 
 Here is a list of supported chain IDs:
 
-- chain_rpc_1     = string
-- chain_rpc_8453  = string
+- chain_rpc_1 = string
+- chain_rpc_8453 = string
 - chain_rpc_42161 = string
-- chain_rpc_10    = string
-- chain_rpc_137   = string
-- chain_rpc_324   = string
+- chain_rpc_10 = string
+- chain_rpc_137 = string
+- chain_rpc_324 = string
 - chain_rpc_59144 = string
-- chain_rpc_480   = string
+- chain_rpc_480 = string
 
 Need support for a different chain ID? Please post your request to the [XMTP Community Forums](https://community.xmtp.org/c/general/ideas/54).
 

--- a/docs/pages/chat-apps/core-messaging/create-conversations.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-conversations.mdx
@@ -91,14 +91,14 @@ If you want to provide faster and offline group creation, consider using [optimi
 ```js [Browser]
 const group = await client.conversations.newGroup(
   [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
+  createGroupOptions /* optional */,
 );
 ```
 
 ```js [Node]
 const group = await client.conversations.newGroup(
   [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
+  createGroupOptions /* optional */,
 );
 ```
 
@@ -268,9 +268,8 @@ Use these helper methods to quickly locate and access specific conversations—w
 
 ```js [Browser]
 // get a conversation by its ID
-const conversationById = await client.conversations.getConversationById(
-  conversationId
-);
+const conversationById =
+  await client.conversations.getConversationById(conversationId);
 
 // get a message by its ID
 const messageById = await client.conversations.getMessageById(messageId);
@@ -281,9 +280,8 @@ const dmByInboxId = await client.conversations.getDmByInboxId(peerInboxId);
 
 ```js [Node]
 // get a conversation by its ID
-const conversationById = await client.conversations.getConversationById(
-  conversationId
-);
+const conversationById =
+  await client.conversations.getConversationById(conversationId);
 
 // get a message by its ID
 const messageById = await client.conversations.getMessageById(messageId);

--- a/docs/pages/chat-apps/core-messaging/group-permissions.mdx
+++ b/docs/pages/chat-apps/core-messaging/group-permissions.mdx
@@ -55,19 +55,23 @@ As the app developer, you can provide a UI that enables group participants to ma
 - Update group metadata
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/group-perm-toggles.png" width="300px" alt="UI screenshot showing group permission toggle options including Add members and Edit group info settings" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/group-perm-toggles.png"
+    width="300px"
+    alt="UI screenshot showing group permission toggle options including Add members and Edit group info settings"
+  />
 </div>
 
 You can use member statuses, options, and permissions to create a custom policy set. The following table represents the valid policy options for each of the permissions:
 
-| Permission | Allow all | Deny all  | Admin only | Super admin only |
-| --- | --- | --- | --- | --- |
-| Add member | ✅ | ✅ | ✅ | ✅ |
-| Remove member | ✅ | ✅ | ✅ | ✅ |
-| Add admin | ❌ | ✅ | ✅ | ✅ |
-| Remove admin | ❌ | ✅ | ✅ | ✅ |
-| Update group permissions | ❌ | ❌ | ❌ | ✅ |
-| Update group metadata | ✅ | ✅ | ✅ | ✅ |
+| Permission               | Allow all | Deny all | Admin only | Super admin only |
+| ------------------------ | --------- | -------- | ---------- | ---------------- |
+| Add member               | ✅        | ✅       | ✅         | ✅               |
+| Remove member            | ✅        | ✅       | ✅         | ✅               |
+| Add admin                | ❌        | ✅       | ✅         | ✅               |
+| Remove admin             | ❌        | ✅       | ✅         | ✅               |
+| Update group permissions | ❌        | ❌       | ❌         | ✅               |
+| Update group metadata    | ✅        | ✅       | ✅         | ✅               |
 
 If you aren't opinionated and don't set any permissions and options, groups will default to using the delivered `All_Members` policy set, which applies the following permissions and options:
 
@@ -358,11 +362,17 @@ try await group.removeMembers(inboxIds: [inboxId])
 :::code-group
 
 ```js [Browser]
-const inboxId = await client.findInboxIdByIdentities([bo.identity, caro.identity]);
+const inboxId = await client.findInboxIdByIdentities([
+  bo.identity,
+  caro.identity,
+]);
 ```
 
 ```js [Node]
-const inboxId = await client.getInboxIdByIdentities([bo.identity, caro.identity]);
+const inboxId = await client.getInboxIdByIdentities([
+  bo.identity,
+  caro.identity,
+]);
 ```
 
 ```tsx [React Native]
@@ -401,7 +411,7 @@ const members = await group.members();
 
 // map inbox ID to account identity
 const inboxIdIdentityMap = new Map(
-  members.map((member) => [member.inboxId, member.accountIdentity])
+  members.map((member) => [member.inboxId, member.accountIdentity]),
 );
 ```
 
@@ -414,7 +424,7 @@ const members = group.members;
 
 // map inbox ID to account identity
 const inboxIdIdentityMap = new Map(
-  members.map((member) => [member.inboxId, member.accountIdentity])
+  members.map((member) => [member.inboxId, member.accountIdentity]),
 );
 ```
 

--- a/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
+++ b/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
@@ -18,7 +18,11 @@ For more agent-specific guidance, see [Manage agent installations](/agents/core-
 The client creates an inbox ID and installation ID associated with the identity. By default, this identity is designated as the recovery identity. A recovery identity will always have the same inbox ID and cannot be reassigned to a different inbox ID.
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/create-inbox-install.png" width="250px" alt="Diagram showing creation of inbox ID and installation ID when a user first creates a client with their identity" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/create-inbox-install.png"
+    width="250px"
+    alt="Diagram showing creation of inbox ID and installation ID when a user first creates a client with their identity"
+  />
 </div>
 
 When you make subsequent calls to create a client for the same identity and a local database is not present, the client uses the same inbox ID, but creates a new installation ID.
@@ -26,13 +30,21 @@ When you make subsequent calls to create a client for the same identity and a lo
 An inbox ID can have up to 10 app installations before it needs to [revoke installations](#revoke-installations).
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-installation.png" width="250px" alt="Diagram showing how creating a client for the same identity without a local database creates a new installation ID with the same inbox ID" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-installation.png"
+    width="250px"
+    alt="Diagram showing how creating a client for the same identity without a local database creates a new installation ID with the same inbox ID"
+  />
 </div>
 
 You can enable a user to add multiple identities to their inbox. Added identities use the same inbox ID and the installation ID of the installation used to add the identity.
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-id.png" width="350px" alt="Diagram showing how adding multiple identities to an inbox uses the same inbox ID and installation ID" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/add-id.png"
+    width="350px"
+    alt="Diagram showing how adding multiple identities to an inbox uses the same inbox ID and installation ID"
+  />
 </div>
 
 You can enable a user to remove an identity from their inbox. You cannot remove the recovery identity.
@@ -43,7 +55,15 @@ You can enable a user to remove an identity from their inbox. You cannot remove 
 
 This video provides a walkthrough of the idea behind the XMTP installation limit (10) and how to use [static installation revocation](#revoke-installations-for-a-user-who-cant-log-in). After watching, feel free to continue reading for more details.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/66bHc_MBQKo?si=5ZuqFBrQm885ILSk" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/66bHc_MBQKo?si=5ZuqFBrQm885ILSk"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 An inbox ID is limited to 256 inbox updates. Inbox updates include actions like:
 
@@ -84,7 +104,15 @@ Installation IDs that don't have this additional information can be treated as u
 
 This video provides a walkthrough of revoking installations, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/MIw9x1Z4WXw?si=4bcbfkHTDvsM0uDG" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/MIw9x1Z4WXw?si=4bcbfkHTDvsM0uDG"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ### Revoke a specific installation
 
@@ -101,15 +129,15 @@ If preferred, you can use the [revoke all other installations](#revoke-all-other
 :::code-group
 
 ```tsx [Browser]
-await client.revokeInstallations([installationId1, installationId2])
+await client.revokeInstallations([installationId1, installationId2]);
 ```
 
 ```tsx [Node]
-await client.revokeInstallations([installationId1, installationId2])
+await client.revokeInstallations([installationId1, installationId2]);
 ```
 
 ```jsx [React Native]
-await client.revokeInstallations(signingKey, [installationIds])
+await client.revokeInstallations(signingKey, [installationIds]);
 ```
 
 ```kotlin [Kotlin]
@@ -129,13 +157,21 @@ You can revoke all installations other than the currently accessed installation.
 For example, consider a user using this current installation:
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/current-install-id.png" width="350px" alt="Diagram showing a user's current installation among multiple installations for their inbox" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/current-install-id.png"
+    width="350px"
+    alt="Diagram showing a user's current installation among multiple installations for their inbox"
+  />
 </div>
 
 When the user revokes all other installations, the action removes their identity's access to all installations other than the current installation:
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/revoke-install-id.png" width="350px" alt="Diagram showing the result after revoking all other installations, leaving only the current installation active" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/revoke-install-id.png"
+    width="350px"
+    alt="Diagram showing the result after revoking all other installations, leaving only the current installation active"
+  />
 </div>
 
 An inbox ID can have up to 10 app installations before it needs to revoke an installation.
@@ -145,15 +181,15 @@ If preferred, you can use the [revoke a specific installation](#revoke-a-specifi
 :::code-group
 
 ```tsx [Browser]
-await client.revokeAllOtherInstallations()
+await client.revokeAllOtherInstallations();
 ```
 
 ```tsx [Node]
-await client.revokeAllOtherInstallations()
+await client.revokeAllOtherInstallations();
 ```
 
 ```jsx [React Native]
-await client.revokeAllOtherInstallations(signingKey)
+await client.revokeAllOtherInstallations(signingKey);
 ```
 
 ```kotlin [Kotlin]
@@ -203,9 +239,14 @@ await Client.revokeInstallations(
 ```
 
 ```tsx [Node]
-const inboxStates = await Client.inboxStateFromInboxIds([inboxId], "production");
+const inboxStates = await Client.inboxStateFromInboxIds(
+  [inboxId],
+  "production",
+);
 
-const toRevokeInstallationBytes = inboxStates[0].installations.map((i) => i.bytes);
+const toRevokeInstallationBytes = inboxStates[0].installations.map(
+  (i) => i.bytes,
+);
 
 await Client.revokeInstallations(
   signer,
@@ -230,7 +271,7 @@ await Client.revokeInstallations(
 
 ```kotlin [Kotlin]
         val states = Client.inboxStatesForInboxIds( listOf(inboxId), api)
-  
+
  val toRevokeIds = states.first().installations.map { it.id }
 
  Client.revokeInstallations(
@@ -243,7 +284,7 @@ await Client.revokeInstallations(
 
 ```swift [Swift]
         let states = try await Client.inboxStatesForInboxIds(inboxIds: [inboxId], api)
-  
+
  let toRevokeIds = states.first.installations.map { $0.id }
 
  try await Client.revokeInstallations(
@@ -263,15 +304,15 @@ Find an `inboxId` for an identity:
 :::code-group
 
 ```tsx [Browser]
-const inboxState = await client.preferences.inboxState()
+const inboxState = await client.preferences.inboxState();
 ```
 
 ```tsx [Node]
-const inboxState = await client.preferences.inboxState()
+const inboxState = await client.preferences.inboxState();
 ```
 
 ```jsx [React Native]
-const inboxId = await client.inboxIdFromIdentity(identity)
+const inboxId = await client.inboxIdFromIdentity(identity);
 ```
 
 ```kotlin [Kotlin]
@@ -292,21 +333,27 @@ View the state of any inbox to see the identities, installations, and other info
 
 ```tsx [Browser]
 // the second argument is optional and refreshes the state from the network.
-const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
+const states = await client.preferences.inboxStateFromInboxIds(
+  [inboxId, inboxId],
+  true,
+);
 ```
 
 ```tsx [Node]
 // the second argument is optional and refreshes the state from the network.
-const states = await client.preferences.inboxStateFromInboxIds([inboxId, inboxId], true)
+const states = await client.preferences.inboxStateFromInboxIds(
+  [inboxId, inboxId],
+  true,
+);
 ```
 
 ```jsx [React Native]
-const state = await client.inboxState(true)
-const states = await client.inboxStates(true, [inboxId, inboxId])
+const state = await client.inboxState(true);
+const states = await client.inboxStates(true, [inboxId, inboxId]);
 ```
 
 ```kotlin [Kotlin]
-val state = client.inboxState(true) 
+val state = client.inboxState(true)
 val states = client.inboxStatesForInboxIds(true, listOf(inboxID, inboxID))
 ```
 
@@ -354,15 +401,15 @@ This function is delicate and should be used with caution. Adding an identity to
 :::code-group
 
 ```tsx [Browser]
-await client.unsafe_addAccount(signer, true)
+await client.unsafe_addAccount(signer, true);
 ```
 
 ```tsx [Node]
-await client.unsafe_addAccount(signer, true)
+await client.unsafe_addAccount(signer, true);
 ```
 
 ```jsx [React Native]
-await client.addAccount(identityToAdd)
+await client.addAccount(identityToAdd);
 ```
 
 ```kotlin [Kotlin]
@@ -378,21 +425,21 @@ try await client.addAccount(newAccount: identityToAdd)
 ## Remove an identity from an inbox
 
 :::tip[Note]
- A recovery identity cannot be removed. For example, if an inbox has only one associated identity, that identity serves as the recovery identity and cannot be removed.
+A recovery identity cannot be removed. For example, if an inbox has only one associated identity, that identity serves as the recovery identity and cannot be removed.
 :::
 
 :::code-group
 
 ```tsx [Browser]
-await client.removeAccount(identifier)
+await client.removeAccount(identifier);
 ```
 
 ```tsx [Node]
-await client.removeAccount(identifier)
+await client.removeAccount(identifier);
 ```
 
 ```jsx [React Native]
-await client.removeAccount(recoveryIdentity, identityToRemove)
+await client.removeAccount(recoveryIdentity, identityToRemove);
 ```
 
 ```kotlin [Kotlin]
@@ -424,19 +471,31 @@ For UI display purposes, you can use the following logic to select the most appr
 Consider an inbox with three associated identities:
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/three-ids.png" width="650px" alt="Diagram showing an inbox with three associated identities (wallet addresses)" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/three-ids.png"
+    width="650px"
+    alt="Diagram showing an inbox with three associated identities (wallet addresses)"
+  />
 </div>
 
 If the user removes an identity from the inbox, the identity no longer has access to the inbox it was removed from.
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/removed-id.png" width="650px" alt="Diagram showing the state after removing one identity from the inbox, leaving two remaining identities" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/removed-id.png"
+    width="650px"
+    alt="Diagram showing the state after removing one identity from the inbox, leaving two remaining identities"
+  />
 </div>
 
 The identity can no longer be added to or used to access conversations in that inbox. If someone sends a message to the identity, the message is not associated with the original inbox. If the user logs in to a new installation with the identity, this will create a new inbox ID.
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/new-inbox-id.png" width="650px" alt="Diagram showing how a removed identity creates a new inbox ID when logging into a new installation" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/new-inbox-id.png"
+    width="650px"
+    alt="Diagram showing how a removed identity creates a new inbox ID when logging into a new installation"
+  />
 </div>
 
 ### How is the recovery identity used?
@@ -454,13 +513,21 @@ However, while Bo has access to Alix's inbox, Bo cannot remove Alix from their o
 If a user logs in with an identity with address 0x62EE...309c and creates inbox 1 and then logs in with an identity with address 0xd0e4...DCe8 and creates inbox 2; there is no way to combine inbox 1 and 2.
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inboxes.png" width="350px" alt="Diagram showing two separate inboxes created by logging in with two different identities" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inboxes.png"
+    width="350px"
+    alt="Diagram showing two separate inboxes created by logging in with two different identities"
+  />
 </div>
 
 You can add an identity with address 0xd0e4...DCe8 to inbox 1, but both identities with addresses 0x62EE...309c and 0xd0e4...DCe8 would then have access to inbox 1 only. The identity with address 0xd0e4...DCe8 would no longer be able to access inbox 2.
 
 <div>
-  <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inbox-remap-id.png" width="350px" alt="Diagram showing how adding an identity to inbox 1 removes its access to inbox 2" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/two-inbox-remap-id.png"
+    width="350px"
+    alt="Diagram showing how adding an identity to inbox 1 removes its access to inbox 2"
+  />
 </div>
 
 To help users avoid this state, ensure that your UX surfaces their ability to add multiple identities to a single inbox.
@@ -482,7 +549,11 @@ The identity accesses that inbox ID and does not create a new inbox ID.
 For example, let's say that you create a client with an identity with address 0x62EE...309c. Inbox ID 1 is generated from that identity.
 
 <div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1.png" width="150px" alt="Simple diagram showing inbox ID 1 with one identity" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1.png"
+    width="150px"
+    alt="Simple diagram showing inbox ID 1 with one identity"
+  />
 </div>
 
 If you then add an identity with address 0xd0e4...DCe8 to inbox ID 1, the identity is also associated with inbox ID 1.
@@ -492,19 +563,31 @@ If you then log into a new app installation with the identity with address 0xd0e
 Once the identity with address 0xd0e4...DCe8 has been associated with inbox ID 1, it can then be used to log into inbox ID 1 using a new app installation.
 
 <div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2.png" width="350px" alt="Diagram showing inbox ID 1 with two identities after adding a second identity" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2.png"
+    width="350px"
+    alt="Diagram showing inbox ID 1 with two identities after adding a second identity"
+  />
 </div>
 
 The inverse is also true. Let's say an identity with address 0xd0e4...DCe8 was previously used to create and log into inbox ID 2.
 
 <div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-inbox2-id2.png" width="350px" alt="Diagram showing two separate inboxes, each with their own identity, before identity migration" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-inbox2-id2.png"
+    width="350px"
+    alt="Diagram showing two separate inboxes, each with their own identity, before identity migration"
+  />
 </div>
 
 If the identity is then added as an associated identity to inbox ID 1, the identity will no longer be able to log into inbox ID 2.
 
 <div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2-inverse.png" width="350px" alt="Diagram showing the result after moving an identity from inbox 2 to inbox 1, leaving inbox 2 empty" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/inbox1-id1-id2-inverse.png"
+    width="350px"
+    alt="Diagram showing the result after moving an identity from inbox 2 to inbox 1, leaving inbox 2 empty"
+  />
 </div>
 
 To enable the user of the identity with address 0xd0e4...DCe8 to log into inbox ID 2 again, you can use the recovery identity for inbox ID 2 to add a different identity to inbox ID 2 and have the user use that identity access it.

--- a/docs/pages/chat-apps/core-messaging/send-messages.mdx
+++ b/docs/pages/chat-apps/core-messaging/send-messages.mdx
@@ -26,7 +26,10 @@ const dm = await client.conversations.findOrCreateDm(recipientInboxId);
 await dm.send("Hello world");
 
 // OR for a group chat
-const group = await client.conversations.newGroup([recipientInboxId1, recipientInboxId2]);
+const group = await client.conversations.newGroup([
+  recipientInboxId1,
+  recipientInboxId2,
+]);
 await group.send("Hello everyone");
 ```
 
@@ -91,7 +94,12 @@ conversation.sendOptimistic("Hello world");
 
 // For custom content types, specify the content type
 const customContent = { foo: "bar" };
-const contentType = { authorityId: "example", typeId: "test", versionMajor: 1, versionMinor: 0 };
+const contentType = {
+  authorityId: "example",
+  typeId: "test",
+  versionMajor: 1,
+  versionMinor: 0,
+};
 conversation.sendOptimistic(customContent, contentType);
 ```
 
@@ -101,7 +109,12 @@ conversation.sendOptimistic("Hello world");
 
 // For custom content types, specify the content type
 const customContent = { foo: "bar" };
-const contentType = { authorityId: "example", typeId: "test", versionMajor: 1, versionMinor: 0 };
+const contentType = {
+  authorityId: "example",
+  typeId: "test",
+  versionMajor: 1,
+  versionMinor: 0,
+};
 conversation.sendOptimistic(customContent, contentType);
 ```
 
@@ -115,7 +128,7 @@ const contentType = new ContentTypeId({
   authorityId: "example",
   typeId: "test",
   versionMajor: 1,
-  versionMinor: 0
+  versionMinor: 0,
 });
 await conversation.prepareMessage(customContent, contentType);
 ```
@@ -165,7 +178,7 @@ async function sendMessageWithOptimisticUI(conversation, messageText) {
   try {
     // Add message to UI immediately
     conversation.sendOptimistic(messageText);
-    
+
     // Actually send the message to the network
     await conversation.publishMessages();
     return true;
@@ -183,7 +196,7 @@ async function sendMessageWithOptimisticUI(conversation, messageText) {
   try {
     // Add message to UI immediately
     conversation.sendOptimistic(messageText);
-    
+
     // Actually send the message to the network
     await conversation.publishMessages();
     return true;
@@ -197,11 +210,14 @@ async function sendMessageWithOptimisticUI(conversation, messageText) {
 ```tsx [React Native]
 // Publish all pending optimistically sent messages to the network
 // Call this only after using prepareMessage to send a message locally
-async function sendMessageWithOptimisticUI(conversation: Conversation, messageText: string): Promise<boolean> {
+async function sendMessageWithOptimisticUI(
+  conversation: Conversation,
+  messageText: string,
+): Promise<boolean> {
   try {
     // Add message to UI immediately
     await conversation.prepareMessage(messageText);
-    
+
     // Actually send the message to the network
     await conversation.publishMessages();
     return true;
@@ -219,7 +235,7 @@ suspend fun sendMessageWithOptimisticUI(conversation: Conversation, messageText:
     return try {
         // Add message to UI immediately
         conversation.prepareMessage(messageText)
-        
+
         // Actually send the message to the network
         conversation.publishMessages()
         true
@@ -237,7 +253,7 @@ func sendMessageWithOptimisticUI(conversation: Conversation, messageText: String
     do {
         // Add message to UI immediately
         try await conversation.prepareMessage(messageText)
-        
+
         // Actually send the message to the network
         try await conversation.publishMessages()
         return true
@@ -365,50 +381,38 @@ For example:
 
 ```js [Browser]
 // DM
-await client.conversations.newDm(
-  inboxId,
-  {
-    messageDisappearingSettings: {
-      fromNs: 1738620126404999936n,
-      inNs: 1800000000000000n
-    }
-  }
-)
+await client.conversations.newDm(inboxId, {
+  messageDisappearingSettings: {
+    fromNs: 1738620126404999936n,
+    inNs: 1800000000000000n,
+  },
+});
 
 // Group
-await client.conversations.newGroup(
-  [inboxId],
-  { 
-    messageDisappearingSettings: {
-      fromNs: 1738620126404999936n,
-      inNs: 1800000000000000n
-    }
-  }
-)
+await client.conversations.newGroup([inboxId], {
+  messageDisappearingSettings: {
+    fromNs: 1738620126404999936n,
+    inNs: 1800000000000000n,
+  },
+});
 ```
 
 ```js [Node]
 // DM
-await client.conversations.newDm(
-  inboxId,
-  {
-    messageDisappearingSettings: {
-      fromNs: 1738620126404999936,
-      inNs: 1800000000000000
-    }
-  }
-)
+await client.conversations.newDm(inboxId, {
+  messageDisappearingSettings: {
+    fromNs: 1738620126404999936,
+    inNs: 1800000000000000,
+  },
+});
 
 // Group
-await client.conversations.newGroup(
-  [inboxId],
-  { 
-    messageDisappearingSettings: {
-      fromNs: 1738620126404999936,
-      inNs: 1800000000000000
-    }
-  }
-)
+await client.conversations.newGroup([inboxId], {
+  messageDisappearingSettings: {
+    fromNs: 1738620126404999936,
+    inNs: 1800000000000000,
+  },
+});
 ```
 
 ```tsx [React Native]
@@ -426,7 +430,7 @@ await client.conversations.newConversation(
 // Group
 await client.conversations.newGroup(
   [inboxId],
-  { 
+  {
     disappearingMessageSettings: DisappearingMessageSettings(
       disappearStartingAtNs: 1738620126404999936,
       retentionDurationInNs: 1800000000000000
@@ -485,23 +489,29 @@ For example:
 
 ```tsx [Browser]
 // Update disappearing message settings
-await conversation.updateMessageDisappearingSettings(1738620126404999936n, 1800000000000000n)
+await conversation.updateMessageDisappearingSettings(
+  1738620126404999936n,
+  1800000000000000n,
+);
 
 // Clear disappearing message settings
-await conversation.removeMessageDisappearingSettings()
+await conversation.removeMessageDisappearingSettings();
 ```
 
 ```tsx [Node]
 // Update disappearing message settings
-await conversation.updateMessageDisappearingSettings(1738620126404999936, 1800000000000000)
+await conversation.updateMessageDisappearingSettings(
+  1738620126404999936,
+  1800000000000000,
+);
 
 // Clear disappearing message settings
-await conversation.removeMessageDisappearingSettings()
+await conversation.removeMessageDisappearingSettings();
 ```
 
 ```tsx [React Native]
-await conversation.updateDisappearingMessageSettings(updatedSettings)
-await conversation.clearDisappearingMessageSettings()
+await conversation.updateDisappearingMessageSettings(updatedSettings);
+await conversation.clearDisappearingMessageSettings();
 ```
 
 ```kotlin [Kotlin]
@@ -524,22 +534,22 @@ For example:
 
 ```tsx [Browser]
 // Get the disappearing message settings
-const settings = await conversation.messageDisappearingSettings()
+const settings = await conversation.messageDisappearingSettings();
 
 // Check if disappearing messages are enabled
-const isEnabled = await conversation.isDisappearingMessagesEnabled()
+const isEnabled = await conversation.isDisappearingMessagesEnabled();
 ```
 
 ```tsx [Node]
 // Get the disappearing message settings
-const settings = conversation.messageDisappearingSettings()
+const settings = conversation.messageDisappearingSettings();
 
-const isEnabled = conversation.isDisappearingMessagesEnabled()
+const isEnabled = conversation.isDisappearingMessagesEnabled();
 ```
 
 ```tsx [React Native]
-conversation.disappearingMessageSettings
-conversation.isDisappearingMessagesEnabled()
+conversation.disappearingMessageSettings;
+conversation.isDisappearingMessagesEnabled();
 ```
 
 ```kotlin [Kotlin]

--- a/docs/pages/chat-apps/core-messaging/support-group-invite-links.mdx
+++ b/docs/pages/chat-apps/core-messaging/support-group-invite-links.mdx
@@ -252,7 +252,7 @@ Want XMTP to build this API? [Open an issue](https://github.com/xmtp/libxmtp/iss
 
 If the invite link creator approves the request, in the background, you can call LibXMTP to load the group and add the member.
 
-#### Example request
+### Example request
 
 ```json
 {
@@ -260,7 +260,7 @@ If the invite link creator approves the request, in the background, you can call
 }
 ```
 
-#### Example response
+### Example response
 
 ```json
 {

--- a/docs/pages/chat-apps/core-messaging/support-group-invite-links.mdx
+++ b/docs/pages/chat-apps/core-messaging/support-group-invite-links.mdx
@@ -7,9 +7,9 @@ This document provides suggested paths you might take to provide XMTP group chat
 1. A group member with permission to add group members [creates an invite link](#create-a-group-invite-link).
 2. An non-member clicks the invite link to [request to join the group](#generate-an-invite-landing-page).
 3. The non-member is granted access to the group in one of the following ways:
-    - [Automatic join via silent push notification to the link creator](#automatic-join-via-silent-push-notification-to-link-creator)
-    - [Automatic join via silent push notification to all group members](#automatic-join-via-silent-push-notification-to-all-group-members)
-    - [Manual join via push notification to the link creator](#manual-join-via-push-notification-to-link-creator)
+   - [Automatic join via silent push notification to the link creator](#automatic-join-via-silent-push-notification-to-link-creator)
+   - [Automatic join via silent push notification to all group members](#automatic-join-via-silent-push-notification-to-all-group-members)
+   - [Manual join via push notification to the link creator](#manual-join-via-push-notification-to-link-creator)
 4. [Add the invitee to the group](#add-the-member-to-the-group)
 5. [Check and manage the invite status](#check-the-invite-status)
 
@@ -19,15 +19,24 @@ These diagrams help illustrate the sequence of interactions between users and pa
 
 #### Option 1: Automatic join via silent push notification to the link creator
 
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/Automatic-Join-via-Silent-Push-to-Link-Creator.png" alt="Sequence diagram for Automatic join via silent push notification to the link creator" />
+<img
+  src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/Automatic-Join-via-Silent-Push-to-Link-Creator.png"
+  alt="Sequence diagram for Automatic join via silent push notification to the link creator"
+/>
 
 #### Option 2: Automatic join via silent push notification to all group members
 
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/Automatic-Join-via-Silent-Push-to-All-Group-Members.png" alt="Sequence diagram for Automatic join via silent push notification to all group members" />
+<img
+  src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/Automatic-Join-via-Silent-Push-to-All-Group-Members.png"
+  alt="Sequence diagram for Automatic join via silent push notification to all group members"
+/>
 
 #### Option 3: Manual join via push notification to the link creator
 
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/Manual-Join-via-Push-Notification-to-Link-Creator.png" alt="Sequence diagram for Manual join via push notification to the link creator" />
+<img
+  src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/Manual-Join-via-Push-Notification-to-Link-Creator.png"
+  alt="Sequence diagram for Manual join via push notification to the link creator"
+/>
 
 ## Create a group invite link
 
@@ -41,10 +50,10 @@ Create the group invite by making a `POST` to a `/groupInvite` endpoint with any
 
 ```json
 {
- groupName: "XMTP Builders",
- groupImage: "https://...",
-// Inviter can be inferred from the request auth token.
-// Backend doesn't need the actual group ID, since the client can keep track in their DB
+  "groupName": "XMTP Builders",
+  "groupImage": "https://..."
+  // Inviter can be inferred from the request auth token.
+  // Backend doesn't need the actual group ID, since the client can keep track in their DB
 }
 ```
 
@@ -56,8 +65,8 @@ Save the `linkUrl` to the client's local database (alongside the XMTP `group_id`
 
 ```json
 {
- id: "abcdefg",
- linkUrl: "https://converse.xyz/invite/abcdefg"
+  "id": "abcdefg",
+  "linkUrl": "https://converse.xyz/invite/abcdefg"
 }
 ```
 
@@ -102,7 +111,7 @@ Can be used by the invitee to request to join the group.
 
 ```json
 {
- inviteId: "abcdefg", // User info implied from auth token
+  "inviteId": "abcdefg" // User info implied from auth token
 }
 ```
 
@@ -110,8 +119,8 @@ Can be used by the invitee to request to join the group.
 
 ```json
 {
- id: "hijklmn", // The id of the join request
- status: "pending"
+  "id": "hijklmn", // The id of the join request
+  "status": "pending"
 }
 ```
 
@@ -247,7 +256,7 @@ If the invite link creator approves the request, in the background, you can call
 
 ```json
 {
- inviteId: "abcdefg", // User info implied from auth token
+  "inviteId": "abcdefg" // User info implied from auth token
 }
 ```
 
@@ -298,7 +307,7 @@ You can have the invite link creator mark an invite as approved or rejected. For
 
 ```json
 {
- status: "approved"
+  "status": "approved"
 }
 ```
 
@@ -306,8 +315,8 @@ You can have the invite link creator mark an invite as approved or rejected. For
 
 ```json
 {
- id: "hijklmn",
- status: "approved",
- reason: null // Allow the system to pass a reason back to the client
+  "id": "hijklmn",
+  "status": "approved",
+  "reason": null // Allow the system to pass a reason back to the client
 }
 ```

--- a/docs/pages/chat-apps/debug-your-app.mdx
+++ b/docs/pages/chat-apps/debug-your-app.mdx
@@ -32,23 +32,23 @@ The `isCommitLogForked`/`commitLogForkStatus` field provides definitive fork det
 // Get detailed debug information for a conversation
 const debugInfo = await conversation?.debugInfo();
 
-console.log('Epoch:', debugInfo.epoch);
-console.log('Cursor:', debugInfo.cursor);
-console.log('Fork Status:', debugInfo.isCommitLogForked); // true, false, or undefined
-console.log('Local Commit Log:', debugInfo.localCommitLog);
-console.log('Remote Commit Log:', debugInfo.remoteCommitLog);
-console.log('Fork Details:', debugInfo.forkDetails);
+console.log("Epoch:", debugInfo.epoch);
+console.log("Cursor:", debugInfo.cursor);
+console.log("Fork Status:", debugInfo.isCommitLogForked); // true, false, or undefined
+console.log("Local Commit Log:", debugInfo.localCommitLog);
+console.log("Remote Commit Log:", debugInfo.remoteCommitLog);
+console.log("Fork Details:", debugInfo.forkDetails);
 ```
 
 ```typescript [React Native, Kotlin, Swift]
 // Get detailed debug information for a conversation
 const debugInfo = await conversation?.getDebugInformation();
 
-console.log('Epoch:', debugInfo.epoch);
-console.log('Fork Status:', debugInfo.commitLogForkStatus); // 'forked', 'notForked', or 'unknown'
-console.log('Local Commit Log:', debugInfo.localCommitLog);
-console.log('Remote Commit Log:', debugInfo.remoteCommitLog);
-console.log('Fork Details:', debugInfo.forkDetails);
+console.log("Epoch:", debugInfo.epoch);
+console.log("Fork Status:", debugInfo.commitLogForkStatus); // 'forked', 'notForked', or 'unknown'
+console.log("Local Commit Log:", debugInfo.localCommitLog);
+console.log("Remote Commit Log:", debugInfo.remoteCommitLog);
+console.log("Fork Details:", debugInfo.forkDetails);
 ```
 
 :::
@@ -61,7 +61,7 @@ You can also check fork status directly from conversation lists:
 // Check fork status when listing conversations
 const conversations = await client.conversations.list();
 
-conversations.forEach(conversation => {
+conversations.forEach((conversation) => {
   if (conversation.isCommitLogForked) {
     console.log(`Conversation ${conversation.id} is forked`);
   }
@@ -72,8 +72,8 @@ conversations.forEach(conversation => {
 // Check fork status when listing conversations
 const conversations = await client.conversations.list();
 
-conversations.forEach(conversation => {
-  if (conversation.commitLogForkStatus === 'forked') {
+conversations.forEach((conversation) => {
+  if (conversation.commitLogForkStatus === "forked") {
     console.log(`Conversation ${conversation.id} is forked`);
   }
 });
@@ -171,7 +171,7 @@ const result1 = await client.debugInformation.uploadDebugArchive();
 
 // Upload to custom server (serverUrl provided)
 const result2 = await client.debugInformation.uploadDebugArchive(
-  "https://my-debug-server.com/api/upload"
+  "https://my-debug-server.com/api/upload",
 );
 ```
 
@@ -179,27 +179,27 @@ const result2 = await client.debugInformation.uploadDebugArchive(
 
 #### API statistics
 
-| Statistic | Description |
-|-----------|-------------|
-| UploadKeyPackage | Number of times key packages have been uploaded. |
-| FetchKeyPackage | Number of times key packages have been fetched. |
-| SendGroupMessages | Number of times messages have been sent to group chat and DM conversations. |
-| SendWelcomeMessages | Number of times welcome messages have been sent. |
-| QueryGroupMessages | Number of times queries have been made to fetch messages being sent to group chat and DM conversations. |
-| QueryWelcomeMessages | Number of times queries have been made to fetch welcome messages. |
+| Statistic            | Description                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| UploadKeyPackage     | Number of times key packages have been uploaded.                                                        |
+| FetchKeyPackage      | Number of times key packages have been fetched.                                                         |
+| SendGroupMessages    | Number of times messages have been sent to group chat and DM conversations.                             |
+| SendWelcomeMessages  | Number of times welcome messages have been sent.                                                        |
+| QueryGroupMessages   | Number of times queries have been made to fetch messages being sent to group chat and DM conversations. |
+| QueryWelcomeMessages | Number of times queries have been made to fetch welcome messages.                                       |
 
 #### Identity statistics
 
-| Statistic | Description |
-|-----------|-------------|
-| PublishIdentityUpdate | Number of times identity updates have been published. |
-| GetIdentityUpdatesV2 | Number of times identity updates have been fetched. |
-| GetInboxIds | Number of times inbox ID queries have been made. |
-| VerifySCWSignatures | Number of times smart contract wallet signature verifications have been performed. |
+| Statistic             | Description                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| PublishIdentityUpdate | Number of times identity updates have been published.                              |
+| GetIdentityUpdatesV2  | Number of times identity updates have been fetched.                                |
+| GetInboxIds           | Number of times inbox ID queries have been made.                                   |
+| VerifySCWSignatures   | Number of times smart contract wallet signature verifications have been performed. |
 
 #### Stream statistics
 
-| Statistic | Description |
-|-----------|-------------|
+| Statistic         | Description                                                                                                 |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- |
 | SubscribeMessages | Number of times message subscription requests have been made. This is streaming messages in a conversation. |
-| SubscribeWelcomes | Number of times welcome message subscription requests have been made. This is streaming conversations. |
+| SubscribeWelcomes | Number of times welcome message subscription requests have been made. This is streaming conversations.      |

--- a/docs/pages/chat-apps/intro/faq.mdx
+++ b/docs/pages/chat-apps/intro/faq.mdx
@@ -72,7 +72,15 @@ The XMTP SDK currently requires you to use [ethers](https://ethers.org/) or anot
 
 ### What is the invalid key package error?
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hNlby-SfPzw?si=V7LqaBxk-i4xhbNC" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/hNlby-SfPzw?si=V7LqaBxk-i4xhbNC"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ### Where can I get official XMTP brand assets?
 
@@ -121,7 +129,7 @@ This retention policy would represent a minimum retention period, not a maximum.
 For example, a retention policy may look something like the following, though specifics are subject to change:
 
 - One year for messages
-- Indefinite storage for account information and personal preferences  
+- Indefinite storage for account information and personal preferences
 
 The team is researching a way to provide this indefinite storage and have it scale forever.
 

--- a/docs/pages/chat-apps/intro/get-started.mdx
+++ b/docs/pages/chat-apps/intro/get-started.mdx
@@ -9,43 +9,48 @@ To learn more, see [Why build with XMTP?](/chat-apps/intro/why-xmtp).
 - Pick your SDK:
 
   <style>
-   {`
-      /* Inline styles instead of styles.css bc vocs
-      search bug doesn't allow imports */
-      .sdk-buttons {
-         display: flex;
-         gap: 20px;
-         flex-wrap: wrap;
-         margin: 20px 0;
-      }
+    {`
+   /* Inline styles instead of styles.css bc vocs
+   search bug doesn't allow imports */
+   .sdk-buttons {
+      display: flex;
+      gap: 20px;
+      flex-wrap: wrap;
+      margin: 20px 0;
+   }
 
-      .sdk-button {
-         padding: 8px 16px;
-         background-color: #4F46E5;
-         border-radius: 5px;
-         text-decoration: none;
-         color: #ffffff;
-         font-weight: 400;
-         transition: all 0.2s;
-      }
+   .sdk-button {
+      padding: 8px 16px;
+      background-color: #4F46E5;
+      border-radius: 5px;
+      text-decoration: none;
+      color: #ffffff;
+      font-weight: 400;
+      transition: all 0.2s;
+   }
 
-      .sdk-button:hover {
-         background-color: #4338CA;
-      }
-   `}
+   .sdk-button:hover {
+      background-color: #4338CA;
+   }
+`}
   </style>
 
   <div className="sdk-buttons">
-    <a href="/chat-apps/sdks/browser"
-  className="sdk-button">Browser</a>
-    <a href="/chat-apps/sdks/node"
-  className="sdk-button">Node</a>
-    <a href="/chat-apps/sdks/react-native"
-  className="sdk-button">React Native</a>
-    <a href="/chat-apps/sdks/android"
-  className="sdk-button">Android</a>
-    <a href="/chat-apps/sdks/ios"
-  className="sdk-button">iOS</a>
+    <a href="/chat-apps/sdks/browser" className="sdk-button">
+      Browser
+    </a>
+    <a href="/chat-apps/sdks/node" className="sdk-button">
+      Node
+    </a>
+    <a href="/chat-apps/sdks/react-native" className="sdk-button">
+      React Native
+    </a>
+    <a href="/chat-apps/sdks/android" className="sdk-button">
+      Android
+    </a>
+    <a href="/chat-apps/sdks/ios" className="sdk-button">
+      iOS
+    </a>
   </div>
 
 - [Use llms-full.txt](/chat-apps/intro/build-with-llms) to provide the full text of the XMTP developer documentation to an AI coding assistant.
@@ -89,13 +94,11 @@ To learn more, see [Why build with XMTP?](/chat-apps/intro/why-xmtp).
 ## 💅🏽 Phase III: Enhance the user experience
 
 1. [Implement user consent](/chat-apps/user-consent/support-user-consent), which provides a consent value of either **unknown**, **allowed** or **denied** to each of a user's contacts. You can use these consent values to filter conversations. For example:
-
    - Conversations with **allowed** contacts go to a user's main inbox
    - Conversations with **unknown** contacts go to a possible spam tab
    - Conversations with **denied** contacts are hidden from view.
-  
-2. Support rich [content types](/chat-apps/content-types/content-types).
 
+2. Support rich [content types](/chat-apps/content-types/content-types).
    - [Attachments](/chat-apps/content-types/attachments)
      - Single remote attachment
      - Multiple remote attachments

--- a/docs/pages/chat-apps/intro/get-started.mdx
+++ b/docs/pages/chat-apps/intro/get-started.mdx
@@ -9,49 +9,53 @@ To learn more, see [Why build with XMTP?](/chat-apps/intro/why-xmtp).
 - Pick your SDK:
 
   <style>
-    {`
-   /* Inline styles instead of styles.css bc vocs
-   search bug doesn't allow imports */
-   .sdk-buttons {
-      display: flex;
-      gap: 20px;
-      flex-wrap: wrap;
-      margin: 20px 0;
-   }
 
-   .sdk-button {
-      padding: 8px 16px;
-      background-color: #4F46E5;
-      border-radius: 5px;
-      text-decoration: none;
-      color: #ffffff;
-      font-weight: 400;
-      transition: all 0.2s;
-   }
+{`
 
-   .sdk-button:hover {
-      background-color: #4338CA;
-   }
+/_Inline styles instead of styles.css bc vocs
+search bug doesn't allow imports_/
+.sdk-buttons {
+display: flex;
+gap: 20px;
+flex-wrap: wrap;
+margin: 20px 0;
+}
+
+.sdk-button {
+padding: 8px 16px;
+background-color: #4F46E5;
+border-radius: 5px;
+text-decoration: none;
+color: #ffffff;
+font-weight: 400;
+transition: all 0.2s;
+}
+
+.sdk-button:hover {
+background-color: #4338CA;
+}
+
 `}
+
   </style>
 
-  <div className="sdk-buttons">
-    <a href="/chat-apps/sdks/browser" className="sdk-button">
-      Browser
-    </a>
-    <a href="/chat-apps/sdks/node" className="sdk-button">
-      Node
-    </a>
-    <a href="/chat-apps/sdks/react-native" className="sdk-button">
-      React Native
-    </a>
-    <a href="/chat-apps/sdks/android" className="sdk-button">
-      Android
-    </a>
-    <a href="/chat-apps/sdks/ios" className="sdk-button">
-      iOS
-    </a>
-  </div>
+<div className="sdk-buttons">
+  <a href="/chat-apps/sdks/browser" className="sdk-button">
+    Browser
+  </a>
+  <a href="/chat-apps/sdks/node" className="sdk-button">
+    Node
+  </a>
+  <a href="/chat-apps/sdks/react-native" className="sdk-button">
+    React Native
+  </a>
+  <a href="/chat-apps/sdks/android" className="sdk-button">
+    Android
+  </a>
+  <a href="/chat-apps/sdks/ios" className="sdk-button">
+    iOS
+  </a>
+</div>
 
 - [Use llms-full.txt](/chat-apps/intro/build-with-llms) to provide the full text of the XMTP developer documentation to an AI coding assistant.
 

--- a/docs/pages/chat-apps/intro/why-xmtp.mdx
+++ b/docs/pages/chat-apps/intro/why-xmtp.mdx
@@ -4,23 +4,23 @@ Build with XMTP to:
 
 - **Deliver secure and private messaging**
 
-    Using the [Messaging Layer Security](/protocol/security) (MLS) standard, a ratified [IETF](https://www.ietf.org/about/introduction/) standard, XMTP provides end-to-end encrypted messaging with forward secrecy and post-compromise security.
+  Using the [Messaging Layer Security](/protocol/security) (MLS) standard, a ratified [IETF](https://www.ietf.org/about/introduction/) standard, XMTP provides end-to-end encrypted messaging with forward secrecy and post-compromise security.
 
 - **Provide spam-free chats**
 
-    In any open and permissionless messaging ecosystem, spam is an inevitable reality, and XMTP is no exception. However, with XMTP [user consent preferences](/chat-apps/user-consent/user-consent), developers can give their users spam-free chats displaying conversations with chosen contacts only.
+  In any open and permissionless messaging ecosystem, spam is an inevitable reality, and XMTP is no exception. However, with XMTP [user consent preferences](/chat-apps/user-consent/user-consent), developers can give their users spam-free chats displaying conversations with chosen contacts only.
 
 - **Build on native crypto rails**
 
-    Build with XMTP to tap into the capabilities of crypto and web3. Support decentralized identities, crypto transactions, and more, directly in a messaging experience.
+  Build with XMTP to tap into the capabilities of crypto and web3. Support decentralized identities, crypto transactions, and more, directly in a messaging experience.
 
 - **Empower users to own and control their communications**
 
-    With apps built with XMTP, users own their conversations, data, and identity. Combined with the interoperability that comes with protocols, this means users can access their end-to-end encrypted communications using any app built with XMTP.
+  With apps built with XMTP, users own their conversations, data, and identity. Combined with the interoperability that comes with protocols, this means users can access their end-to-end encrypted communications using any app built with XMTP.
 
 - **Create with confidence**
 
-    Developers are free to create the messaging experiences their users want—on a censorship-resistant protocol architected to last forever. Because XMTP isn't a closed proprietary platform, developers can build confidently, knowing their access and functionality can't be revoked by a central authority.
+  Developers are free to create the messaging experiences their users want—on a censorship-resistant protocol architected to last forever. Because XMTP isn't a closed proprietary platform, developers can build confidently, knowing their access and functionality can't be revoked by a central authority.
 
 ## Try an app built with XMTP
 
@@ -31,11 +31,9 @@ Try [xmtp.chat](https://xmtp.chat/), an app made for devs to learn to build with
 ## Join the XMTP community
 
 - **XMTP builds in the open**
-
   - Explore the documentation on this site
   - Explore the open [XMTP GitHub org](https://github.com/xmtp), which contains code for LibXMTP, XMTP SDKs, and xmtpd, node software powering the XMTP testnet.
   - Explore the open source code for [xmtp.chat](https://github.com/xmtp/xmtp-js/tree/main/apps/xmtp.chat), an app made for devs to learn to build with XMTP—using an app built with XMTP.
 
 - **XMTP is for everyone**
-
   - [Join the conversation](https://community.xmtp.org/) and become part of the movement to redefine digital communications.

--- a/docs/pages/chat-apps/list-stream-sync/archive-backups.md
+++ b/docs/pages/chat-apps/list-stream-sync/archive-backups.md
@@ -21,7 +21,6 @@ To enable a user to create an archive:
 1. Specify the archive file path (e.g., iCloud, Google Cloud, or your server). Ensure the parent folder already exists.
 2. Generate a 32-byte array encryption key to protect the archive contents. This ensures that other apps and devices cannot access the contents without the key. Securely store the key in a location that is secure, independent of the archive file, and will persist after your app has been uninstalled. A common place to store this encryption key is the iCloud Keychain.
 3. Call `createArchive(path, encryptionKey, options?)` with the archive file path and the encryption key. Optionally, you can pass in the following:
-
    - Archive start and end time. If left blank, the archive will include all time.
    - Archive contents, which can be `Consent` or `Messages`. If left blank, the archive will include both.
 

--- a/docs/pages/chat-apps/list-stream-sync/history-sync.mdx
+++ b/docs/pages/chat-apps/list-stream-sync/history-sync.mdx
@@ -21,7 +21,15 @@ History sync enables your users pick up conversations where they left off, regar
 
 This video provides a walkthrough of history sync, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/_FtNqtjk-ls?si=uZ_Mnh9phF6y2h-O" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/_FtNqtjk-ls?si=uZ_Mnh9phF6y2h-O"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ## Enable history sync
 
@@ -41,13 +49,21 @@ If needed, you can turn off history sync by setting the `historySyncUrl` client 
 When your app initializes an XMTP client and a `historySyncUrl` client option is present, history sync automatically triggers an initial sync request and creates an encrypted payload.
 
 <div>
-    <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step1.png" width="600px" alt="Diagram showing step 1 of history sync: client initialization triggers sync request and creates encrypted payload" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step1.png"
+    width="600px"
+    alt="Diagram showing step 1 of history sync: client initialization triggers sync request and creates encrypted payload"
+  />
 </div>
 
 History sync then uploads the payload, sends a sync reply, and pulls all conversation state history into the new app installation, merging it with the existing app installations in the sync group.
 
 <div>
-    <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step2.png" width="600px" alt="Diagram showing step 2 of history sync: payload upload, sync reply, and merging conversation state history across app installations" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/history-sync-step2.png"
+    width="600px"
+    alt="Diagram showing step 2 of history sync: payload upload, sync reply, and merging conversation state history across app installations"
+  />
 </div>
 
 Ongoing updates to history are streamed automatically. Updates, whether for user consent preferences or messages, are sent across the sync group, ensuring all app installations have up-to-date information.

--- a/docs/pages/chat-apps/list-stream-sync/list.mdx
+++ b/docs/pages/chat-apps/list-stream-sync/list.mdx
@@ -15,15 +15,27 @@ Conversations are listed in descending order by their `lastMessage` created at v
 :::code-group
 
 ```js [Browser]
-const allConversations = await client.conversations.list({ consentStates: [ConsentState.Allowed] });
-const allGroups = await client.conversations.listGroups({ consentStates: [ConsentState.Allowed] });
-const allDms = await client.conversations.listDms({ consentStates: [ConsentState.Allowed] });
+const allConversations = await client.conversations.list({
+  consentStates: [ConsentState.Allowed],
+});
+const allGroups = await client.conversations.listGroups({
+  consentStates: [ConsentState.Allowed],
+});
+const allDms = await client.conversations.listDms({
+  consentStates: [ConsentState.Allowed],
+});
 ```
 
 ```js [Node]
-const allConversations = await client.conversations.list({ consentStates: [ConsentState.Allowed] });
-const allGroups = await client.conversations.listGroups({ consentStates: [ConsentState.Allowed] });
-const allDms = await client.conversations.listDms({ consentStates: [ConsentState.Allowed] });
+const allConversations = await client.conversations.list({
+  consentStates: [ConsentState.Allowed],
+});
+const allGroups = await client.conversations.listGroups({
+  consentStates: [ConsentState.Allowed],
+});
+const allDms = await client.conversations.listDms({
+  consentStates: [ConsentState.Allowed],
+});
 ```
 
 ```tsx [React Native]
@@ -32,17 +44,15 @@ await alix.conversations.list(["allowed"]);
 
 // List Conversation items and return only the fields set to true. Optimize data transfer
 // by requesting only the fields the app needs.
-await alix.conversations.list(
-  {
-    members: false,
-    consentState: false,
-    description: false,
-    creatorInboxId: false,
-    addedByInboxId: false,
-    isActive: false,
-    lastMessage: true,
-  },
-);
+await alix.conversations.list({
+  members: false,
+  consentState: false,
+  description: false,
+  creatorInboxId: false,
+  addedByInboxId: false,
+  isActive: false,
+  lastMessage: true,
+});
 ```
 
 ```kotlin [Kotlin]

--- a/docs/pages/chat-apps/list-stream-sync/stream.mdx
+++ b/docs/pages/chat-apps/list-stream-sync/stream.mdx
@@ -18,7 +18,7 @@ const stream = await client.conversations.stream({
   },
   onFail: () => {
     console.log("Stream failed");
-  }
+  },
 });
 
 // Or use for-await loop
@@ -40,21 +40,21 @@ const stream = await client.conversations.stream({
   },
   onFail: () => {
     console.log("Stream failed");
-  }
+  },
 });
 
 // To stream only groups
 const groupStream = await client.conversations.streamGroups({
   onValue: (conversation) => {
     console.log("New group:", conversation);
-  }
+  },
 });
 
 // To stream only DMs
 const dmStream = await client.conversations.streamDms({
   onValue: (conversation) => {
     console.log("New DM:", conversation);
-  }
+  },
 });
 
 // Or use for-await loop
@@ -118,9 +118,9 @@ const stream = await client.conversations.streamAllMessages({
   },
   onFail: () => {
     console.log("Stream failed");
-  }
+  },
 });
- 
+
 // Or use for-await loop
 for await (const message of stream) {
   // Received a message
@@ -142,25 +142,25 @@ const stream = await client.conversations.streamAllMessages({
   },
   onFail: () => {
     console.log("Stream failed");
-  }
+  },
 });
- 
+
 // stream only group messages
 const groupMessageStream = await client.conversations.streamAllGroupMessages({
   consentStates: [ConsentState.Allowed],
   onValue: (message) => {
     console.log("New group message:", message);
-  }
+  },
 });
- 
+
 // stream only dm messages
 const dmMessageStream = await client.conversations.streamAllDmMessages({
   consentStates: [ConsentState.Allowed],
   onValue: (message) => {
     console.log("New DM message:", message);
-  }
+  },
 });
- 
+
 // Or use for-await loop
 for await (const message of stream) {
   // Received a message
@@ -173,7 +173,7 @@ await alix.conversations.streamAllMessages(
   async (message: DecodedMessage<any>) => {
     // Received a message
   },
-  { consentState: ["allowed"] }
+  { consentState: ["allowed"] },
 );
 ```
 
@@ -207,7 +207,7 @@ const stream = await client.conversations.streamAllMessages({
   retryOnFail: false,
   onValue: (message) => {
     console.log("New message:", message);
-  }
+  },
 });
 
 // use stream options with retry configuration
@@ -258,25 +258,25 @@ const stream = await client.conversations.streamAllMessages({
 ```
 
 ```tsx [React Native]
-const [messages, setMessages] = useState<DecodedMessage[]>([]); 
- 
-  const messageCallback = async (message: DecodedMessage<any>) => { 
-    setMessages(prev => [...prev, message]); 
-  }
-  const conversationFilterType: ConversationFilterType = 'all'
-  const consentStates: ConsentState[] = ['allowed']
-  const onCloseCallback = () => {
-    console.log("Message stream closed, handle retries here")
-  }
+const [messages, setMessages] = useState<DecodedMessage[]>([]);
 
-  const startMessageStream = async () => { 
-    await alix.conversations.streamAllMessages( 
-      messageCallback, 
-      conversationFilterType, 
-      consentStates, 
-      onCloseCallback 
-    ); 
-  };
+const messageCallback = async (message: DecodedMessage<any>) => {
+  setMessages((prev) => [...prev, message]);
+};
+const conversationFilterType: ConversationFilterType = "all";
+const consentStates: ConsentState[] = ["allowed"];
+const onCloseCallback = () => {
+  console.log("Message stream closed, handle retries here");
+};
+
+const startMessageStream = async () => {
+  await alix.conversations.streamAllMessages(
+    messageCallback,
+    conversationFilterType,
+    consentStates,
+    onCloseCallback,
+  );
+};
 ```
 
 ```kotlin [Kotlin]

--- a/docs/pages/chat-apps/list-stream-sync/sync-and-syncall.mdx
+++ b/docs/pages/chat-apps/list-stream-sync/sync-and-syncall.mdx
@@ -8,7 +8,15 @@ Syncing does not refetch existing conversations and messages. It also does not f
 
 This video provides a walkthrough of key concepts required to implement syncing correctly.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/jl7P0onApxw?si=YNafIHebx9Kxycos" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/jl7P0onApxw?si=YNafIHebx9Kxycos"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ## Sync a specific conversation
 

--- a/docs/pages/chat-apps/list-stream-sync/sync-preferences.mdx
+++ b/docs/pages/chat-apps/list-stream-sync/sync-preferences.mdx
@@ -13,7 +13,11 @@ Each XMTP node contains:
 - A **group messages database**: Keeps a ledger of all messages in the groups an inbox ID is a part of.
 
 <div>
-  <img alt="databases in each xmtpd node" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/xmtpd-dbs.png" width="300px" />
+  <img
+    alt="databases in each xmtpd node"
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/xmtpd-dbs.png"
+    width="300px"
+  />
 </div>
 
 In the welcomes database, the groups are of these types:
@@ -37,7 +41,11 @@ One-to-one chat, group chat, and preferences groups in the welcome database are 
   - `syncAll`
 
 <div>
-  <img alt="groups in the welcome database" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/welcomes-db-3.png" width="500px" />
+  <img
+    alt="groups in the welcome database"
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/welcomes-db-3.png"
+    width="500px"
+  />
 </div>
 
 ## Preferences group
@@ -49,19 +57,31 @@ To describe preference sync, let's first focus on how the preferences group work
 2. Let's say Inbox ID Alix has an Installation A of App A on their phone. At this time, Inbox ID Alix has a preferences group that looks like this:
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-1.png" width="300px" alt="Diagram showing preferences group with one member (Inbox ID Alix) and Installation A of App A" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-1.png"
+       width="300px"
+       alt="Diagram showing preferences group with one member (Inbox ID Alix) and Installation A of App A"
+     />
    </div>
 
 3. Inbox ID Alix then logs in to an Installation B of App B on their phone. The next time Installation A runs `preferences.sync` or `syncAll`, it updates the preferences group as follows:
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-2.png" width="300px" alt="Diagram showing preferences group updated to include Installation B of App B after Alix logs in to a second app" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-2.png"
+       width="300px"
+       alt="Diagram showing preferences group updated to include Installation B of App B after Alix logs in to a second app"
+     />
    </div>
 
 4. Then let's say Inbox ID Alix logs in to an Installation C of App A on their tablet. The next time Installation A or B runs `preferences.sync` or `syncAll`, it updates the preferences group as follows:
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-3.png" width="300px" alt="Diagram showing preferences group updated to include Installation C of App A on tablet after Alix logs in to a third installation" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pg-3.png"
+       width="300px"
+       alt="Diagram showing preferences group updated to include Installation C of App A on tablet after Alix logs in to a third installation"
+     />
    </div>
 
 ## Preferences sync worker
@@ -71,25 +91,41 @@ Now, let's describe how the preferences sync worker helps keep user consent pref
 1. Let's say Inbox ID Alix uses Installation A to block Inbox ID Bo.
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/a-block-bo.png" width="200px" alt="Diagram showing Installation A blocking Inbox ID Bo" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/a-block-bo.png"
+       width="200px"
+       alt="Diagram showing Installation A blocking Inbox ID Bo"
+     />
    </div>
 
 2. This sends a message to the preferences group in the group message database. This is not an actual chat message, but a serialized proto message that is not shown to app users.
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/gm-pg.png" width="300px" alt="Diagram showing serialized proto message sent to preferences group in the group message database" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/gm-pg.png"
+       width="300px"
+       alt="Diagram showing serialized proto message sent to preferences group in the group message database"
+     />
    </div>
 
 3. When Installation B calls `preferences.sync` or `syncAll`, it gets the message from the preferences group. The sync worker listens for these preferences group messages and processes the message to block Inbox ID Bo in Installation B.
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/b-block-bo.png" width="200px" alt="Diagram showing Installation B processing the sync message to block Inbox ID Bo" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/b-block-bo.png"
+       width="200px"
+       alt="Diagram showing Installation B processing the sync message to block Inbox ID Bo"
+     />
    </div>
 
 4. Likewise, when Installation C calls `preferences.sync` or `syncAll`, it gets the message from the preferences group, and the sync worker ensures Inbox ID Bo is blocked there as well.
 
    <div>
-      <img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/c-block-bo.png" width="200px" alt="Diagram showing Installation C processing the sync message to block Inbox ID Bo" />
+     <img
+       src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/c-block-bo.png"
+       width="200px"
+       alt="Diagram showing Installation C processing the sync message to block Inbox ID Bo"
+     />
    </div>
 
 Preferences sync handles HMAC keys in the same way.
@@ -113,7 +149,7 @@ await client.preferences.sync();
 ```
 
 ```tsx [React Native]
-await client.preferences.sync()
+await client.preferences.sync();
 ```
 
 ```kotlin [Kotlin]

--- a/docs/pages/chat-apps/push-notifs/ios-pn.mdx
+++ b/docs/pages/chat-apps/push-notifs/ios-pn.mdx
@@ -14,38 +14,38 @@ Perform this setup to understand how you can enable push notifications for your 
 For this tutorial, we'll use [Firebase Cloud Messaging](https://console.firebase.google.com/) (FCM) as a convenient way to set up a messaging server.
 
 1. Create an FCM project  
-Go to the [Firebase Console](https://console.firebase.google.com/), create a new project, and follow the setup instructions.
+   Go to the [Firebase Console](https://console.firebase.google.com/), create a new project, and follow the setup instructions.
 
 2. Add your app to the FCM project  
-Add your iOS app to the project by following the Firebase setup workflow. You'll need your app's bundle ID.
+   Add your iOS app to the project by following the Firebase setup workflow. You'll need your app's bundle ID.
 
 3. Download `GoogleService-Info.plist`  
-At the end of the setup, download the `GoogleService-Info.plist` file and add it to your Xcode project.
+   At the end of the setup, download the `GoogleService-Info.plist` file and add it to your Xcode project.
 
 4. Generate FCM credentials  
-In the Firebase console, navigate to your project settings, select the **Cloud Messaging** tab, and note your server key and sender ID. You'll need these for your notification server.
+   In the Firebase console, navigate to your project settings, select the **Cloud Messaging** tab, and note your server key and sender ID. You'll need these for your notification server.
 
 ## Configure the iOS example app for push notifications
 
 1. Enable push notifications  
-In Xcode, go to your project's target capabilities and enable push notifications.
+   In Xcode, go to your project's target capabilities and enable push notifications.
 
 2. Register for notifications  
-Modify the `AppDelegate` to register for remote notifications and handle the device token.
+   Modify the `AppDelegate` to register for remote notifications and handle the device token.
 
 3. Handle incoming notifications  
-Implement the necessary delegate methods to handle incoming notifications and foreground notification display.
+   Implement the necessary delegate methods to handle incoming notifications and foreground notification display.
 
 ## Run the notification server
 
 1. Clone and configure the notification server  
-If you're using the example notification server, clone the repository and follow the setup instructions. Make sure to configure it with your FCM server key.
+   If you're using the example notification server, clone the repository and follow the setup instructions. Make sure to configure it with your FCM server key.
 
 2. Run the server  
-Start the server locally or deploy it to a hosting service.
+   Start the server locally or deploy it to a hosting service.
 
 - Subscribe to push notifications in the app  
   When initializing the XMTP client in your app, subscribe to push notifications using the device token obtained during registration.
 
 - Decode a notification envelope  
-When you receive a push notification, you may want to decode the notification envelope to display a message preview or other information.
+  When you receive a push notification, you may want to decode the notification envelope to display a message preview or other information.

--- a/docs/pages/chat-apps/push-notifs/pn-server.mdx
+++ b/docs/pages/chat-apps/push-notifs/pn-server.mdx
@@ -12,7 +12,6 @@ This guide is for macOS users, but the steps should be similar for Linux users.
 ## Install Docker
 
 1. Install Docker Desktop:
-
    - [Mac](https://docs.docker.com/docker-for-mac/install/)
    - [Windows](https://docs.docker.com/docker-for-windows/install/)
    - [Linux](https://docs.docker.com/desktop/install/linux-install/)
@@ -115,52 +114,52 @@ You can now send notifications to your device using an [XMTP push notification c
 
 - Here is a piece of code that points to the ports and network. Be sure to use TLS like this `./dev/run --xmtp-listener-tls --api`.
 
-   :::code-group
+  :::code-group
 
-   ```tsx [Browser]
-   export const ApiUrls = {
-   local: "http://localhost:5555",
-   dev: "https://dev.xmtp.network",
-   production: "https://production.xmtp.network",
-   } as const;
+  ```tsx [Browser]
+  export const ApiUrls = {
+    local: "http://localhost:5555",
+    dev: "https://dev.xmtp.network",
+    production: "https://production.xmtp.network",
+  } as const;
 
-   export const HistorySyncUrls = {
-   local: "http://localhost:5558",
-   dev: "https://message-history.dev.ephemera.network",
-   production: "https://message-history.production.ephemera.network",
-   } as const;
-   ```
+  export const HistorySyncUrls = {
+    local: "http://localhost:5558",
+    dev: "https://message-history.dev.ephemera.network",
+    production: "https://message-history.production.ephemera.network",
+  } as const;
+  ```
 
-   ```tsx [Node]
-   export const ApiUrls = {
-   local: "http://localhost:5556",
-   dev: "https://grpc.dev.xmtp.network:443",
-   production: "https://grpc.production.xmtp.network:443",
-   } as const;
-   ```
+  ```tsx [Node]
+  export const ApiUrls = {
+    local: "http://localhost:5556",
+    dev: "https://grpc.dev.xmtp.network:443",
+    production: "https://grpc.production.xmtp.network:443",
+  } as const;
+  ```
 
-   ```tsx [React Native]
-   const ApiUrls = {
-   local: 'http://localhost:5556',
-   dev: 'https://grpc.dev.xmtp.network:443',
-   production: 'https://grpc.production.xmtp.network:443'
-   }
-   ```
+  ```tsx [React Native]
+  const ApiUrls = {
+    local: "http://localhost:5556",
+    dev: "https://grpc.dev.xmtp.network:443",
+    production: "https://grpc.production.xmtp.network:443",
+  };
+  ```
 
-   ```kotlin [Kotlin]
-   enum ApiUrls {
-      static let local = "http://localhost:5556"
-      static let dev = "https://grpc.dev.xmtp.network:443"
-      static let production = "https://grpc.production.xmtp.network:443"
-   }
-   ```
+  ```kotlin [Kotlin]
+  enum ApiUrls {
+     static let local = "http://localhost:5556"
+     static let dev = "https://grpc.dev.xmtp.network:443"
+     static let production = "https://grpc.production.xmtp.network:443"
+  }
+  ```
 
-   ```swift [Swift]
-   object ApiUrls {
-      const val local = "http://localhost:5556"
-      const val dev = "https://grpc.dev.xmtp.network:443"
-      const val production = "https://grpc.production.xmtp.network:443"
-   }
-   ```
+  ```swift [Swift]
+  object ApiUrls {
+     const val local = "http://localhost:5556"
+     const val dev = "https://grpc.dev.xmtp.network:443"
+     const val production = "https://grpc.production.xmtp.network:443"
+  }
+  ```
 
-   :::
+  :::

--- a/docs/pages/chat-apps/push-notifs/push-notifs.mdx
+++ b/docs/pages/chat-apps/push-notifs/push-notifs.mdx
@@ -8,6 +8,7 @@ Get the topic identifier for an app installation. This topic ID tells your app w
 
 :::code-group
 
+{/* prettier-ignore */}
 ```tsx [React Native]
 // Request
 alix.welcomeTopic()
@@ -40,6 +41,7 @@ Get the topic identifier for a group chat or DM conversation that's already in p
 
 :::code-group
 
+{/* prettier-ignore */}
 ```tsx [React Native]
 // Request
 conversation.topic
@@ -73,7 +75,7 @@ Lists topics for a specific DM conversation.
 :::code-group
 
 ```tsx [React Native]
-conversation.getPushTopics()
+conversation.getPushTopics();
 ```
 
 ```kotlin [Kotlin]
@@ -97,7 +99,7 @@ To learn more, see [Understand DM stitching and push notifications](/chat-apps/p
 :::code-group
 
 ```tsx [React Native]
-conversations.allPushTopics()
+conversations.allPushTopics();
 ```
 
 ```kotlin [Kotlin]
@@ -132,7 +134,7 @@ val topics = conversations.map { it.topic }.toMutableList()
 subscribeAll(topics.push(Topic.userWelcome(client.installationId).description))
 ```
 
-```swift [Swift]
+````swift [Swift]
 let conversations = try await alix.conversations.list()
 var topics = conversations.map { $0.topic }
 
@@ -148,7 +150,7 @@ On receipt of a push notification, decode it:
 
 ```tsx [React Native]
 const receivedBytes = Buffer.from(received.message, "base64").toString("utf-8");
-```
+````
 
 ```kotlin [Kotlin]
 val encryptedMessage = remoteMessage.data["encryptedMessage"]
@@ -169,9 +171,7 @@ Then determine whether it's for a new conversation or an existing one.
   :::code-group
 
   ```tsx [React Native]
-  const conversation = await alix.conversations.fromWelcome(
-    receivedBytes
-  );
+  const conversation = await alix.conversations.fromWelcome(receivedBytes);
   ```
 
   ```kotlin [Kotlin]
@@ -277,7 +277,7 @@ To learn more, see [Understand DM stitching and push notifications](/chat-apps/p
 :::code-group
 
 ```tsx [React Native]
-conversation.getHmacKeys()
+conversation.getHmacKeys();
 ```
 
 ```kotlin [Kotlin]

--- a/docs/pages/chat-apps/push-notifs/push-notifs.mdx
+++ b/docs/pages/chat-apps/push-notifs/push-notifs.mdx
@@ -8,7 +8,8 @@ Get the topic identifier for an app installation. This topic ID tells your app w
 
 :::code-group
 
-{/* prettier-ignore */}
+{/*prettier-ignore*/}
+
 ```tsx [React Native]
 // Request
 alix.welcomeTopic()
@@ -41,7 +42,8 @@ Get the topic identifier for a group chat or DM conversation that's already in p
 
 :::code-group
 
-{/* prettier-ignore */}
+{/*prettier-ignore*/}
+
 ```tsx [React Native]
 // Request
 conversation.topic

--- a/docs/pages/chat-apps/push-notifs/understand-push-notifs.mdx
+++ b/docs/pages/chat-apps/push-notifs/understand-push-notifs.mdx
@@ -19,21 +19,21 @@ Let's dive deeper into how the XMTP push notification server filters messages to
 ![XMTP push notification server filtering flow](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/pn-server-filtering.png)
 
 1. **Check if the server is subscribed to the message's topic**
-    - A topic is a way to organize messages, and each message has a topic. To support push notifications, your app must [subscribe the server to the topics](https://docs.xmtp.org/chat-apps/push-notifs/push-notifs#subscribe-to-topics) that are relevant to your users. For example, for a user Alix, you must subscribe to all topics associated with Alix's conversations. The XMTP push notification server has a list of these subscriptions. Your push notification server should expose functions to post the subscriptions to. The SDKs use protobufs as a universal language that allows the creation of these functions in any language. For example, [here are bufs](https://github.com/xmtp/xmtp-android/tree/main/library/src/main/java/org/xmtp/android/library/push) generated from the [XMTP example push notification server](/chat-apps/push-notifs/pn-server). You can use these directly if you clone and use the example server.
-    - If the arriving message's topic is **not on the list**, the server ignores it.
-    - If the arriving message's topic is **on the list**, the server proceeds to check the message with the next filter.
+   - A topic is a way to organize messages, and each message has a topic. To support push notifications, your app must [subscribe the server to the topics](https://docs.xmtp.org/chat-apps/push-notifs/push-notifs#subscribe-to-topics) that are relevant to your users. For example, for a user Alix, you must subscribe to all topics associated with Alix's conversations. The XMTP push notification server has a list of these subscriptions. Your push notification server should expose functions to post the subscriptions to. The SDKs use protobufs as a universal language that allows the creation of these functions in any language. For example, [here are bufs](https://github.com/xmtp/xmtp-android/tree/main/library/src/main/java/org/xmtp/android/library/push) generated from the [XMTP example push notification server](/chat-apps/push-notifs/pn-server). You can use these directly if you clone and use the example server.
+   - If the arriving message's topic is **not on the list**, the server ignores it.
+   - If the arriving message's topic is **on the list**, the server proceeds to check the message with the next filter.
 2. **Check the `shouldPush` field value**
-    - Each [content type](/chat-apps/content-types/content-types), such as text, attachment, or reply, can have
-    - A `shouldPush` boolean value is set at the content type level for each content type, such as text, attachment, or reply, so it can't be overwritten on send. By default, this value is set to ***true*** for all content types except read receipts and reactions.
-    - If the message's content type `shouldPush` value is ***false***, the server ignores the message.
-    - If the message's content type `shouldPush` value is ***true***, the server proceeds to check the message with the next filter.
+   - Each [content type](/chat-apps/content-types/content-types), such as text, attachment, or reply, can have
+   - A `shouldPush` boolean value is set at the content type level for each content type, such as text, attachment, or reply, so it can't be overwritten on send. By default, this value is set to **_true_** for all content types except read receipts and reactions.
+   - If the message's content type `shouldPush` value is **_false_**, the server ignores the message.
+   - If the message's content type `shouldPush` value is **_true_**, the server proceeds to check the message with the next filter.
 3. **Check the message's HMAC key**
-    - Each message sent with XMTP carries a single HMAC key. This key is updated with the encrypted message payload before being sent out.
-    - If the message is signed by an HMAC key that **matches** the user's HMAC key, the push notification server ignores the message. This match means that the message was sent by the user themself, and they should not receive a push notification about a message they sent.
-    - If the message is signed by an HMAC key that **does not match** the user's HMAC key, this means someone else sent the message and the user should be notified about it. At this point, the push notification server will send a notification.
+   - Each message sent with XMTP carries a single HMAC key. This key is updated with the encrypted message payload before being sent out.
+   - If the message is signed by an HMAC key that **matches** the user's HMAC key, the push notification server ignores the message. This match means that the message was sent by the user themself, and they should not receive a push notification about a message they sent.
+   - If the message is signed by an HMAC key that **does not match** the user's HMAC key, this means someone else sent the message and the user should be notified about it. At this point, the push notification server will send a notification.
 4. **Send to the push notification service**
-    - The server sends the message to the push notification service.
-    - Once the push notification service has the message, it can format it appropriately for the push notification. This includes extracting necessary information, such as the sender's identity and message content, to craft meaningful notifications. This is only possible with the push notifications service inside the app and not with the push notification server because the server doesn't have the notion of a client and, therefore, can't decrypt the message.
+   - The server sends the message to the push notification service.
+   - Once the push notification service has the message, it can format it appropriately for the push notification. This includes extracting necessary information, such as the sender's identity and message content, to craft meaningful notifications. This is only possible with the push notifications service inside the app and not with the push notification server because the server doesn't have the notion of a client and, therefore, can't decrypt the message.
 
 XMTP provides an example XMTP push notification server that implements the filtering described here. To learn more, see [Run a push notification server for an app built with XMTP](/chat-apps/push-notifs/pn-server).
 
@@ -78,11 +78,11 @@ After the push notification service sends the notification, the app must [receiv
 
 There are some nuances to how push notifications can be handled once received by the app. While it is useful for all of these app types to use the XMTP push notification server filtering capabilities, it is especially important for an iOS app without the user notification entitlement.
 
-|  | Can decrypt before displaying? |
-| --- | --- |
-| Android and web apps | Yes |
-| iOS app with user notification entitlement | Yes |
-| iOS app without user notification entitlement | No |
+|                                               | Can decrypt before displaying? |
+| --------------------------------------------- | ------------------------------ |
+| Android and web apps                          | Yes                            |
+| iOS app with user notification entitlement    | Yes                            |
+| iOS app without user notification entitlement | No                             |
 
 - If the app **can** **decrypt** the push notification before displaying it to the user, it can perform additional logic (should I display this?) before displaying the push notification. For example, the app can decrypt the push notification, see the topic type, and process it accordingly:
   - Is the message in a welcome topic?
@@ -91,7 +91,7 @@ There are some nuances to how push notifications can be handled once received by
     - `conversation.processMessage`
 - If the app **cannot** **decrypt** the push notification before displaying it to the user, it can't perform additional logic (should I display this?) before displaying the push notification.
 
-    For example, without the user notification entitlement, the app cannot decrypt and modify the push notification before displaying it to the user. The notification arrives on the device, and iOS handles displaying it automatically. You can decrypt the content after the notification is shown, but you cannot intercept it before display and decide not to show it, for example.
+  For example, without the user notification entitlement, the app cannot decrypt and modify the push notification before displaying it to the user. The notification arrives on the device, and iOS handles displaying it automatically. You can decrypt the content after the notification is shown, but you cannot intercept it before display and decide not to show it, for example.
 
 ## Understand HMAC keys and push notifications
 
@@ -107,7 +107,15 @@ This is one of the jobs of the [history sync](/chat-apps/list-stream-sync/histor
 
 This video provides a walkthrough of direct message (DM) stitching, covering the key ideas discussed in this section. After watching, feel free to continue reading for more details.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YF5m_mTY6mw?si=EH0S4eP0GPEAafIw" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/YF5m_mTY6mw?si=EH0S4eP0GPEAafIw"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 Consider a scenario where `alix.id` using an existing installation #1 to create a conversation with `bo.id` and sends them a DM. And then `alix.id` creates a new installation #2, and instead of waiting for [history sync](https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync) to bring in their existing conversations, `alix.id` creates a new conversation with `bo.id` and sends them a DM. Under the hood, this results in two DM conversations (or two MLS groups) with the same pair of identities, `alix.id` and `bo.id`, resulting in a confusing DM UX like this one:
 
@@ -122,17 +130,17 @@ For example, with DM stitching, instead of seeing two separate DM conversations 
 ### How DM stitching works
 
 1. When fetching messages from any of the MLS groups associated with a DM conversation, the XMTP SDK responds with messages from all of the groups associated with the DM conversation.
-    - For example, let's say you have three MLS groups associated with a DM conversation:
-        - alix-bo-1
-        - alix-bo-2
-        - alix-bo-3
+   - For example, let's say you have three MLS groups associated with a DM conversation:
+     - alix-bo-1
+     - alix-bo-2
+     - alix-bo-3
 
-        Any messages sent in any of these DM conversations will display in all of these DM conversations.
+     Any messages sent in any of these DM conversations will display in all of these DM conversations.
 
-        For example, `alix.id` sends a message in alix-bo-1. `bo.id` is on alix-bo-3, but can still see messages sent in alix-bo-1.
+     For example, `alix.id` sends a message in alix-bo-1. `bo.id` is on alix-bo-3, but can still see messages sent in alix-bo-1.
 
 2. When sending messages in a DM conversation, all installations in that DM will eventually converge to sending them to the same MLS group, even if they originally start off using different ones.
-    - For example, `bo.id` sends a message in alix-bo-3. `alix.id` is on alix-bo-1, but can still see messages from alix-bo-3. When `alix.id` sends a reply to `bo.id`, it uses the most recently used DM conversation, alix-bo-3. In this way, all messaging will eventually move to alix-bo-3, and 1 and 2 will slowly fade away due to non-use.
+   - For example, `bo.id` sends a message in alix-bo-3. `alix.id` is on alix-bo-1, but can still see messages from alix-bo-3. When `alix.id` sends a reply to `bo.id`, it uses the most recently used DM conversation, alix-bo-3. In this way, all messaging will eventually move to alix-bo-3, and 1 and 2 will slowly fade away due to non-use.
 
 ### DM stitching considerations for push notifications
 

--- a/docs/pages/chat-apps/sdks/android.mdx
+++ b/docs/pages/chat-apps/sdks/android.mdx
@@ -57,6 +57,6 @@ client.conversations.streamAllMessages(consentStates = listOf(ConsentState.ALLOW
     // Received a message
 }
 // Sync all new welcomes, preference updates, conversations,
-// and messages from allowed conversations 
+// and messages from allowed conversations
 client.conversations.syncAll(consentStates = ConsentState.ALLOWED)
 ```

--- a/docs/pages/chat-apps/sdks/browser.mdx
+++ b/docs/pages/chat-apps/sdks/browser.mdx
@@ -19,12 +19,12 @@ const signer: Signer = {
   type: "EOA",
   getIdentifier: () => ({
     identifier: "0x...", // Ethereum address as the identifier
-    identifierKind: "Ethereum"
+    identifierKind: "Ethereum",
   }),
   signMessage: async (message: string): Uint8Array => {
     // typically, signing methods return a hex string
     // this string must be converted to bytes and returned in this function
-  }
+  },
 };
 
 // 2. Create the XMTP client
@@ -36,7 +36,7 @@ const client = await Client.create(signer, {
 // 3. Start conversations
 const group = await client.conversations.newGroup(
   [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
+  createGroupOptions /* optional */,
 );
 
 // 4. Send messages
@@ -44,9 +44,15 @@ await group.send("Hello everyone");
 
 // 5. List, stream, and sync
 // List existing conversations
-const allConversations = await client.conversations.list({ consentStates: [ConsentState.Allowed] });
-const allGroups = await client.conversations.listGroups({ consentStates: [ConsentState.Allowed] });
-const allDms = await client.conversations.listDms({ consentStates: [ConsentState.Allowed] });
+const allConversations = await client.conversations.list({
+  consentStates: [ConsentState.Allowed],
+});
+const allGroups = await client.conversations.listGroups({
+  consentStates: [ConsentState.Allowed],
+});
+const allDms = await client.conversations.listDms({
+  consentStates: [ConsentState.Allowed],
+});
 // Stream new messages
 const stream = await client.conversations.streamAllMessages({
   consentStates: [ConsentState.Allowed],
@@ -55,7 +61,7 @@ const stream = await client.conversations.streamAllMessages({
   },
   onError: (error) => {
     console.error(error);
-  }
+  },
 });
 
 // Or use for-await loop
@@ -63,6 +69,6 @@ for await (const message of stream) {
   console.log("New message:", message);
 }
 // Sync all new welcomes, preference updates, conversations,
-// and messages from allowed conversations 
+// and messages from allowed conversations
 await client.conversations.syncAll(["allowed"]);
 ```

--- a/docs/pages/chat-apps/sdks/ios.mdx
+++ b/docs/pages/chat-apps/sdks/ios.mdx
@@ -55,6 +55,6 @@ for await message in try await client.conversations.streamAllMessages(type: /* O
     // Received a message
 }
 // Sync all new welcomes, preference updates, conversations,
-// and messages from allowed conversations 
+// and messages from allowed conversations
 try await client.conversations.syncAllConversations(consentState: [.allowed])
 ```

--- a/docs/pages/chat-apps/sdks/node.mdx
+++ b/docs/pages/chat-apps/sdks/node.mdx
@@ -25,7 +25,7 @@ const signer: Signer = {
   type: "EOA",
   getIdentifier: () => ({
     identifier: "0x...", // Ethereum address as the identifier
-    identifierKind: IdentifierKind.Ethereum
+    identifierKind: IdentifierKind.Ethereum,
   }),
   signMessage: async (message: string): Uint8Array => {
     // typically, signing methods return a hex string
@@ -43,7 +43,7 @@ const client = await Client.create(signer, { dbEncryptionKey });
 // 3. Start a new conversation
 const group = await client.conversations.newGroup(
   [bo.inboxId, caro.inboxId],
-  createGroupOptions /* optional */
+  createGroupOptions /* optional */,
 );
 
 // 4. Send messages
@@ -51,7 +51,9 @@ await group.send("Hello everyone");
 
 // 5. List, stream, and sync
 // List existing conversations
-const allConversations = await client.conversations.list({ consentStates: [ConsentState.Allowed] });
+const allConversations = await client.conversations.list({
+  consentStates: [ConsentState.Allowed],
+});
 // Stream new messages
 const stream = await client.conversations.streamAllMessages({
   consentStates: [ConsentState.Allowed],
@@ -60,7 +62,7 @@ const stream = await client.conversations.streamAllMessages({
   },
   onError: (error) => {
     console.error(error);
-  }
+  },
 });
 
 // Or use for-await loop
@@ -69,6 +71,6 @@ for await (const message of stream) {
   console.log("New message:", message);
 }
 // Sync all new welcomes, preference updates, conversations,
-// and messages from allowed conversations 
+// and messages from allowed conversations
 await client.conversations.syncAll(["allowed"]);
 ```

--- a/docs/pages/chat-apps/sdks/react-native.mdx
+++ b/docs/pages/chat-apps/sdks/react-native.mdx
@@ -15,11 +15,14 @@ The guide provides some quickstart code, as well as a map to building a [secure 
 // Details depend on your app's wallet implementation.
 export function convertEOAToSigner(eoaAccount: EOAAccount): Signer {
   return {
-    getIdentifier: async () => new PublicIdentity(eoaAccount.address, "ETHEREUM"),
+    getIdentifier: async () =>
+      new PublicIdentity(eoaAccount.address, "ETHEREUM"),
     getChainId: () => undefined,
     getBlockNumber: () => undefined,
     signerType: () => "EOA",
-    signMessage: async (message: string) => ({ signature: await eoaAccount.signMessage(message) }),
+    signMessage: async (message: string) => ({
+      signature: await eoaAccount.signMessage(message),
+    }),
   };
 }
 
@@ -31,12 +34,15 @@ const client = Client.create(signer, {
 
 // 3. Start conversations
 const group = await client.conversations.newGroup([bo.inboxId, caro.inboxId]);
-const groupWithMeta = await client.conversations.newGroup([bo.inboxId, caro.inboxId], {
-  name: "The Group Name",
-  imageUrl: "www.groupImage.com",
-  description: "The description of the group",
-  permissionLevel: "admin_only",
-});
+const groupWithMeta = await client.conversations.newGroup(
+  [bo.inboxId, caro.inboxId],
+  {
+    name: "The Group Name",
+    imageUrl: "www.groupImage.com",
+    description: "The description of the group",
+    permissionLevel: "admin_only",
+  },
+);
 
 // 4. Send messages
 const dm = await client.conversations.findOrCreateDm(recipientInboxId);
@@ -51,9 +57,9 @@ await client.conversations.streamAllMessages(
   async (message: DecodedMessage<any>) => {
     // Received a message
   },
-  { consentState: ["allowed"] }
+  { consentState: ["allowed"] },
 );
 // Sync all new welcomes, preference updates, conversations,
-// and messages from allowed conversations 
+// and messages from allowed conversations
 await client.conversations.syncAllConversations(["allowed"]);
 ```

--- a/docs/pages/chat-apps/use-signatures.mdx
+++ b/docs/pages/chat-apps/use-signatures.mdx
@@ -17,7 +17,7 @@ const signature = client.signWithInstallationKey(signatureText);
 ```
 
 ```jsx [React Native]
-const signature = await client.signWithInstallationKey(signatureText)
+const signature = await client.signWithInstallationKey(signatureText);
 ```
 
 ```kotlin [Kotlin]
@@ -32,16 +32,19 @@ let signature = try client.signWithInstallationKey(message: signatureText)
 
 ## Verify with the same installation that signed
 
- You can also sign with XMTP keys and verify that a payload was sent by the same client.
+You can also sign with XMTP keys and verify that a payload was sent by the same client.
 
 :::code-group
 
 ```js [Node]
-const isValidSignature = client.verifySignedWithInstallationKey(signatureText, signature);
+const isValidSignature = client.verifySignedWithInstallationKey(
+  signatureText,
+  signature,
+);
 ```
 
 ```jsx [React Native]
-const isVerified = await client.verifySignature(signatureText, signature)
+const isVerified = await client.verifySignature(signatureText, signature);
 ```
 
 ```kotlin [Kotlin]
@@ -50,7 +53,7 @@ val isVerified = client.verifySignature(signatureText, signature)
 
 ```swift [Swift]
 let isVerified = try client.verifySignature(
-            message: signatureText, 
+            message: signatureText,
             signature: signature
         )
 
@@ -65,13 +68,17 @@ You can use an XMTP key's `installationId` to create a signature, then pass both
 :::code-group
 
 ```js [Node]
-const isValidSignature = client.verifySignedWithPrivateKey(signatureText, signature, installationId);
+const isValidSignature = client.verifySignedWithPrivateKey(
+  signatureText,
+  signature,
+  installationId,
+);
 ```
 
 ```kotlin [Kotlin]
 val isVerified = client.verifySignatureWithInstallationId(
-            signatureText, 
-            signature, 
+            signatureText,
+            signature,
             installationId
       )
 ```

--- a/docs/pages/chat-apps/user-consent/support-user-consent.mdx
+++ b/docs/pages/chat-apps/user-consent/support-user-consent.mdx
@@ -24,13 +24,12 @@ import { ConsentEntityType } from "@xmtp/browser-sdk";
 // get consent state from the client
 const conversationConsentState = await client.getConsentState(
   ConsentEntityType.GroupId,
-  groupId
+  groupId,
 );
 
 // or get consent state directly from a conversation
-const groupConversation = await client.conversations.findConversationById(
-  groupId
-);
+const groupConversation =
+  await client.conversations.findConversationById(groupId);
 const groupConversationConsentState = await groupConversation.consentState();
 ```
 
@@ -40,13 +39,12 @@ import { ConsentEntityType } from "@xmtp/node-sdk";
 // get consent state from the client
 const conversationConsentState = await client.getConsentState(
   ConsentEntityType.GroupId,
-  groupId
+  groupId,
 );
 
 // or get consent state directly from a conversation
-const groupConversation = await client.conversations.findConversationById(
-  groupId
-);
+const groupConversation =
+  await client.conversations.findConversationById(groupId);
 const groupConversationConsentState = await groupConversation.consentState();
 ```
 
@@ -83,9 +81,8 @@ await client.setConsentStates([
 ]);
 
 // set consent state directly on a conversation
-const groupConversation = await client.conversations.findConversationById(
-  groupId
-);
+const groupConversation =
+  await client.conversations.findConversationById(groupId);
 await groupConversation.updateConsentState(ConsentState.Allowed);
 ```
 
@@ -102,9 +99,8 @@ await client.setConsentStates([
 ]);
 
 // set consent state directly on a conversation
-const groupConversation = await client.conversations.findConversationById(
-  groupId
-);
+const groupConversation =
+  await client.conversations.findConversationById(groupId);
 await groupConversation.updateConsentState(ConsentState.Allowed);
 ```
 
@@ -141,7 +137,7 @@ const stream = await client.preferences.streamConsent({
   },
   onFail: () => {
     console.log("Consent stream failed");
-  }
+  },
 });
 
 // Or use for-await loop
@@ -164,7 +160,7 @@ const stream = await client.preferences.streamConsent({
   },
   onFail: () => {
     console.log("Consent stream failed");
-  }
+  },
 });
 
 // Or use for-await loop
@@ -175,7 +171,7 @@ for await (const updates of stream) {
 ```
 
 ```tsx [React Native]
-await client.preferences.streamConsent()
+await client.preferences.streamConsent();
 ```
 
 ```kotlin [Kotlin]
@@ -229,8 +225,8 @@ await client.setConsentStates([
 
 ```tsx [React Native]
 await client.preferences.setConsentState(
-  new ConsentRecord(inboxId, 'inbox_id', 'denied')
-)
+  new ConsentRecord(inboxId, "inbox_id", "denied"),
+);
 ```
 
 ```kotlin [Kotlin]
@@ -249,7 +245,7 @@ client.preferences.setConsentState(
 try await client.preferences.setConsentState(
   entries: [
     ConsentRecord(
-      value: inboxID, 
+      value: inboxID,
       entryType: .inbox_id,
       consentType: .denied)
   ])
@@ -272,7 +268,7 @@ import { ConsentEntityType } from "@xmtp/browser-sdk";
 
 const inboxConsentState = await client.getConsentState(
   ConsentEntityType.InboxId,
-  inboxId
+  inboxId,
 );
 ```
 
@@ -281,18 +277,18 @@ import { ConsentEntityType } from "@xmtp/node-sdk";
 
 const inboxConsentState = await client.getConsentState(
   ConsentEntityType.InboxId,
-  inboxId
+  inboxId,
 );
 ```
 
 ```tsx [React Native]
 // Get consent directly on the member
-const memberConsentStates = (await group.members()).map(
-  (member) => member.consentState()
-)
+const memberConsentStates = (await group.members()).map((member) =>
+  member.consentState(),
+);
 
 // Get consent from the inboxId
-const inboxConsentState = await client.preferences.inboxIdConsentState(inboxId)
+const inboxConsentState = await client.preferences.inboxIdConsentState(inboxId);
 ```
 
 ```kotlin [Kotlin]
@@ -318,8 +314,8 @@ let inboxConsentState = try await client.preferences.inboxIdState(inboxId: inbox
 Get the inbox ID of the individual who added you to a group or created the group to check the consent state for it:
 
 ```tsx [React Native]
-group.addedByInboxId
-await group.creatorInboxId()
+group.addedByInboxId;
+await group.creatorInboxId();
 ```
 
 ```kotlin [Kotlin]
@@ -370,7 +366,11 @@ val ethAddresses = identities
 You can then display appropriate messages on a **You might know** tab, for example.
 
 <div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/you-might-know-tab.jpg" width="400" alt="Screenshot of a mobile chat app showing a 'You might know' tab with filtered conversation requests" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/you-might-know-tab.jpg"
+    width="400"
+    alt="Screenshot of a mobile chat app showing a 'You might know' tab with filtered conversation requests"
+  />
 </div>
 
 ### Identify contacts the user might not know, including spammy or scammy requests
@@ -378,7 +378,11 @@ You can then display appropriate messages on a **You might know** tab, for examp
 To identify contacts the user might not know or not want to know, which might include spam, you can consciously decide to scan messages in an unencrypted state to find messages that might contain spammy or scammy content. You can also look for an absence of onchain interaction data between the addresses, which might indicate that there is no affinity between addresses. You can then filter the appropriate messages to display on a **Hidden requests** tab, for example.
 
 <div>
-<img src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/hidden-requests-tab.jpg" width="400" alt="Screenshot of a mobile chat app showing a 'Hidden requests' tab with filtered messages from unknown contacts or potentially spammy content" />
+  <img
+    src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/hidden-requests-tab.jpg"
+    width="400"
+    alt="Screenshot of a mobile chat app showing a 'Hidden requests' tab with filtered messages from unknown contacts or potentially spammy content"
+  />
 </div>
 
 The decision to scan unencrypted messages is yours as the app developer. If you take this approach:

--- a/docs/pages/chat-apps/user-consent/user-consent.mdx
+++ b/docs/pages/chat-apps/user-consent/user-consent.mdx
@@ -8,7 +8,15 @@ However, with XMTP, you can give your users chats that are **spam-free spaces fo
 
 This video provides a walkthrough of consent, covering the key ideas discussed in this doc. After watching, feel free to continue reading for more details.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Qy_naNXYxmU?si=JEVL8Mruy_4Px4D5" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/Qy_naNXYxmU?si=JEVL8Mruy_4Px4D5"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 ## How user consent preferences work
 
@@ -23,7 +31,6 @@ For example:
 1. `alix.id` starts a conversation with `bo.id`. At this time, `alix.id` is unknown to `bo.id` and the conversation displays in a message requests UI.
 
 2. When `bo.id` views the message request, they express their user consent preference to **Block** or **Accept** `alix.id` as a contact.
-
    - If `bo.id` accepts `alix.id` as a contact, their conversation displays in `bo.id`'s main inbox. Because only contacts `bo.id` accepts display in their main inbox, their inbox remains spam-free.
 
    - If `bo.id` blocks contact with `alix.id`, remove the conversation from `bo.id`'s view. In an appropriate location in your app, give the user the option to unblock the contact.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -4,7 +4,7 @@ layout: landing
 showLogo: false
 ---
 
-import { CustomHomePage } from '../components/CustomHomePage'
+import { CustomHomePage } from "../components/CustomHomePage";
 
 <CustomHomePage.Root>
 
@@ -21,8 +21,16 @@ The largest and most secure decentralized messaging network
 </CustomHomePage.Subhead>
 
 <div className="custom-homepage-cta-container">
-  <a href="/agents/get-started/build-an-agent" className="custom-homepage-cta-button custom-homepage-cta-button--primary">Build an agent</a>
-  <a href="/chat-apps/intro/get-started" className="custom-homepage-cta-button custom-homepage-cta-button--secondary">Build a chat app</a>
+  <a
+    href="/agents/get-started/build-an-agent"
+    className="custom-homepage-cta-button custom-homepage-cta-button--primary">
+    Build an agent
+  </a>
+  <a
+    href="/chat-apps/intro/get-started"
+    className="custom-homepage-cta-button custom-homepage-cta-button--secondary">
+    Build a chat app
+  </a>
 </div>
 
 <CustomHomePage.TileGrid>

--- a/docs/pages/network/network-nodes.mdx
+++ b/docs/pages/network/network-nodes.mdx
@@ -3,28 +3,40 @@
 For real-time statuses of nodes in the XMTP testnet, see [XMTP Node Status](https://status.testnet.xmtp-partners.xyz/).
 The following table lists the nodes currently registered to power the XMTP testnet.
 
-|  | Node operator | Node address |
-|-----|---------------|--------------|
-| 1 | Artifact Capital | xmtp.artifact.systems:443 |
-| 2 | Crystal One | xmtp.node-op.com:443 |
-| 3 | Emerald Onion | xmtp.disobey.net:443 |
-| 4 | Encapsulate | lb.validator.xmtp.testnet.encapsulate.xyz:443 |
-| 5 | Ethereum Name Service (ENS) | grpc.ens-xmtp.com:443 |
-| 6 | Laminated Labs | xmtp.validators.laminatedlabs.net:443 |
-| 7 | Next.id | xmtp.nextnext.id:443 |
-| 8 | Nodle | xmtpd.nodleprotocol.io:443 |
-| 9 | Ephemera | grpc.testnet.xmtp.network:443 |
-| 10 | Ephemera | grpc2.testnet.xmtp.network:443 |
+|     | Node operator               | Node address                                  |
+| --- | --------------------------- | --------------------------------------------- |
+| 1   | Artifact Capital            | xmtp.artifact.systems:443                     |
+| 2   | Crystal One                 | xmtp.node-op.com:443                          |
+| 3   | Emerald Onion               | xmtp.disobey.net:443                          |
+| 4   | Encapsulate                 | lb.validator.xmtp.testnet.encapsulate.xyz:443 |
+| 5   | Ethereum Name Service (ENS) | grpc.ens-xmtp.com:443                         |
+| 6   | Laminated Labs              | xmtp.validators.laminatedlabs.net:443         |
+| 7   | Next.id                     | xmtp.nextnext.id:443                          |
+| 8   | Nodle                       | xmtpd.nodleprotocol.io:443                    |
+| 9   | Ephemera                    | grpc.testnet.xmtp.network:443                 |
+| 10  | Ephemera                    | grpc2.testnet.xmtp.network:443                |
 
 Here is a map of node locations:
 
-<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden" }}>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "56.25%",
+    height: 0,
+    overflow: "hidden",
+  }}>
   <iframe
     src="https://www.google.com/maps/d/embed?mid=18y4nFTXQKdgiSJCQbEGl5dojPoHL3LQ&ehbc=2E312F&noprof=1"
-    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+      border: 0,
+    }}
     allowFullScreen=""
-    loading="lazy"
-  ></iframe>
+    loading="lazy"></iframe>
 </div>
 
 A purple pin indicates that the node is operated by a non-profit organization.

--- a/docs/pages/protocol/cursors.mdx
+++ b/docs/pages/protocol/cursors.mdx
@@ -16,7 +16,7 @@ The primary role of a cursor becomes evident when you use the `sync()` functions
 
 1. **Initial sync**: The first time an app installation calls `sync()` for a specific conversation, it fetches all available messages and events from the network for that conversation's topic.
 2. **Cursor placement**: Once the sync is complete, the SDK places a cursor at the end of that batch of fetched messages.
-3. **Subsequent syncs**: On the next `sync()` call for that same conversation, the client sends its current cursor position to the network. The network then returns only the messages and events that have occurred *after* that cursor.
+3. **Subsequent syncs**: On the next `sync()` call for that same conversation, the client sends its current cursor position to the network. The network then returns only the messages and events that have occurred _after_ that cursor.
 4. **Cursor advancement**: After the new messages are successfully fetched, the SDK advances the cursor to the new latest point.
 
 This process ensures that each `sync()` call only retrieves what's new, making synchronization efficient by avoiding the re-downloading of messages the client already has.
@@ -38,8 +38,8 @@ The XMTP SDKs use cursors to make message synchronization highly efficient. The 
 Each `sync()` function corresponds to a different type of cursor:
 
 - `conversation.sync()`: This operates on the **group message topic** for a single conversation. It moves the cursor for that specific conversation, fetching new messages or group updates (like name changes).
-- `conversations.sync()`: This operates on the **welcome message topic**. It moves the cursor for welcome messages, fetching any new conversations the user has been invited to. It does *not* fetch the contents of those new conversations.
-- `conversations.syncAll()`: This is the most comprehensive sync. It effectively performs the actions of the other two syncs for all of the user's conversations. It moves the cursors for the welcome topic *and* for every individual group message topic, ensuring the client has fetched all new conversations and all new messages in existing conversations.
+- `conversations.sync()`: This operates on the **welcome message topic**. It moves the cursor for welcome messages, fetching any new conversations the user has been invited to. It does _not_ fetch the contents of those new conversations.
+- `conversations.syncAll()`: This is the most comprehensive sync. It effectively performs the actions of the other two syncs for all of the user's conversations. It moves the cursors for the welcome topic _and_ for every individual group message topic, ensuring the client has fetched all new conversations and all new messages in existing conversations.
 
 For example, here is a sequence diagram illustrating how cursors operate with `conversation.sync()`:
 

--- a/docs/pages/protocol/envelope-types.mdx
+++ b/docs/pages/protocol/envelope-types.mdx
@@ -57,7 +57,7 @@ Understanding commit messages is especially helpful when debugging and understan
 #### User-initiated commits
 
 - **Add member commits**: When a user explicitly adds someone to a group
-- **Remove member commits**: When a user removes someone from a group  
+- **Remove member commits**: When a user removes someone from a group
 - **Update metadata commits**: When a user changes group name, description, or permissions
 - **Update permissions commits**: When a user modifies group permission settings
 

--- a/docs/pages/protocol/identity.mdx
+++ b/docs/pages/protocol/identity.mdx
@@ -10,7 +10,7 @@ The identity model also allows XMTP to support any identity type, as long as it 
 
 ## Inbox ID
 
-An **inbox ID** is a user's stable destination for their messages. Their inbox ID remains constant even as they add or remove [identities](#identity) and [installations](#installations).
+An **inbox ID** is a user's stable destination for their messages. Their inbox ID remains constant even as they add or remove [identities](./#identity) and [installations](./#installations).
 
 The inbox ID is derived from the hash of the first associated wallet address and a nonce and acts as an opaque identifier that apps use for messaging.
 
@@ -35,7 +35,7 @@ An **installation** represents a specific app installation that can access an in
 
 **One inbox ID** → **multiple identities**: Users can receive messages as any of their identities, all flowing to the same inbox
 
-```
+```text
 Inbox ID (stable destination for messages)
 ├── Identity 1 (recovery identity, first identity added to an inbox)
 ├── Identity 2 (EOA wallet)
@@ -45,7 +45,7 @@ Inbox ID (stable destination for messages)
 
 **One identity** → **multiple installations**: Users can access their messages from different apps on the same or different devices
 
-```
+```text
 Each identity can authenticate new installations:
 ├── Installation A (phone app)
 ├── Installation B (web app)

--- a/docs/pages/protocol/identity.mdx
+++ b/docs/pages/protocol/identity.mdx
@@ -37,7 +37,7 @@ An **installation** represents a specific app installation that can access an in
 
 ```
 Inbox ID (stable destination for messages)
-├── Identity 1 (recovery identity, first identity added to an inbox) 
+├── Identity 1 (recovery identity, first identity added to an inbox)
 ├── Identity 2 (EOA wallet)
 ├── Identity 3 (SCW wallet)
 └── Any identity that can produce a verifiable cryptographic signature
@@ -48,8 +48,8 @@ Inbox ID (stable destination for messages)
 ```
 Each identity can authenticate new installations:
 ├── Installation A (phone app)
-├── Installation B (web app)  
-├── Installation C (desktop app)  
+├── Installation B (web app)
+├── Installation C (desktop app)
 └── Up to 10 installations
 ```
 

--- a/docs/pages/protocol/overview.mdx
+++ b/docs/pages/protocol/overview.mdx
@@ -26,8 +26,8 @@ For most developers, the [Build chat apps](/chat-apps/intro/get-started) and [Bu
 The encryption elements are mainly defined by MLS, with some additions by XMTP. To learn more, see:
 
 - [Security](/protocol/security)
-  
-  XMTP and MLS prioritize security, privacy, and message integrity through advanced cryptographic techniques, delivering end-to-end 
+
+  XMTP and MLS prioritize security, privacy, and message integrity through advanced cryptographic techniques, delivering end-to-end
   encryption for both 1:1 and group conversations
 
 - [Epochs](/protocol/epochs)
@@ -56,7 +56,7 @@ The delivery elements are mainly defined by XMTP. To learn more, see:
 
 - [Topics](/protocol/topics)
 
-  Messages are routed through topics, which are unique addresses that identify conversation channels. 
+  Messages are routed through topics, which are unique addresses that identify conversation channels.
 
 - [Cursors](/protocol/cursors)
 

--- a/docs/pages/protocol/security.mdx
+++ b/docs/pages/protocol/security.mdx
@@ -12,7 +12,15 @@ Specifically, XMTP messaging provides the comprehensive security properties cove
 
 This video provides a walkthrough of XMTP's implementation of MLS.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/g6I9qXOkDMo?si=o5pD2xwa_yynoP5s" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube.com/embed/g6I9qXOkDMo?si=o5pD2xwa_yynoP5s"
+  title="YouTube video player"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerPolicy="strict-origin-when-cross-origin"
+  allowFullScreen></iframe>
 
 To dive deeper into how XMTP implements MLS, see the [XMTP MLS protocol specification](https://github.com/xmtp/libxmtp/tree/main/xmtp_mls).
 
@@ -82,23 +90,23 @@ Here is a summary of individual cryptographic tools used to collectively ensure 
 
 - [HPKE](https://www.rfc-editor.org/rfc/rfc9180.html)
 
-    Used to encrypt Welcome messages, protect the identities of group invitees, and maintain the confidentiality of group membership. We use the ciphersuite HPKEX25519.
+  Used to encrypt Welcome messages, protect the identities of group invitees, and maintain the confidentiality of group membership. We use the ciphersuite HPKEX25519.
 
 - [AEAD](https://developers.google.com/tink/aead)
 
-    Used to ensure both confidentiality and integrity of messages. In particular, we use the ciphersuite CHACHA20POLY1305.
+  Used to ensure both confidentiality and integrity of messages. In particular, we use the ciphersuite CHACHA20POLY1305.
 
 - [SHA3_256 and SHA2_256](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)
 
-    XMTP uses two cryptographic hash functions to ensure data integrity and provide strong cryptographic binding. SHA3_256 is used in the multi-wallet identity structure. SHA2_256 is used in MLS. The ciphersuite is SHA256.
+  XMTP uses two cryptographic hash functions to ensure data integrity and provide strong cryptographic binding. SHA3_256 is used in the multi-wallet identity structure. SHA2_256 is used in MLS. The ciphersuite is SHA256.
 
 - [Ed25519](https://ed25519.cr.yp.to/ed25519-20110926.pdf)
 
-    Used for digital signatures to provide secure, high-performance signing and verification of messages. The ciphersuite is Ed25519.
+  Used for digital signatures to provide secure, high-performance signing and verification of messages. The ciphersuite is Ed25519.
 
 - [XWING KEM](https://www.ietf.org/archive/id/draft-connolly-cfrg-xwing-kem-02.html)
 
-    Used for quantum-resistant key encapsulation in Welcome messages. XWING is a hybrid post-quantum KEM that combines conventional cryptography with [ML-KEM](https://csrc.nist.gov/pubs/fips/203/final) (the NIST-standardized post-quantum component), providing protection against future quantum computer attacks while maintaining current security standards.
+  Used for quantum-resistant key encapsulation in Welcome messages. XWING is a hybrid post-quantum KEM that combines conventional cryptography with [ML-KEM](https://csrc.nist.gov/pubs/fips/203/final) (the NIST-standardized post-quantum component), providing protection against future quantum computer attacks while maintaining current security standards.
 
 ## FAQ about messaging security
 

--- a/docs/pages/protocol/signatures.mdx
+++ b/docs/pages/protocol/signatures.mdx
@@ -35,7 +35,11 @@ More specifically, the message will request that you sign:
 
 Sign the **XMTP : Authenticate to inbox** message with your wallet address to consent to the message requests.
 
-<img width="400" src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/authen-to-inbox.PNG" alt="MetaMask wallet browser extension Sign this message? window showing an XMTP: Authenticate to inbox message" />
+<img
+  width="400"
+  src="https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/authen-to-inbox.PNG"
+  alt="MetaMask wallet browser extension Sign this message? window showing an XMTP: Authenticate to inbox message"
+/>
 
 ## Sign to add another address to your inbox
 

--- a/docs/pages/protocol/topics.mdx
+++ b/docs/pages/protocol/topics.mdx
@@ -28,7 +28,7 @@ The group message topic is used to send and receive messages within a specific c
 - **Purpose**: Carries all ongoing communication for a conversation, including [application messages](/protocol/envelope-types#application-messages) (text, reactions, etc.) and [commit messages](/protocol/envelope-types#commit-messages) that modify the group state.
 - **Usage**: When an app wants to receive messages for a conversation, it subscribes to this topic. The `conversation.topic` property in the SDKs provides this value.
 
-> **Note on [DM stitching](/chat-apps/push-notifs/understand-push-notifs#understand-dm-stitching-and-push-notifications): For direct messages, multiple underlying conversations might be "stitched" together in the UI. For push notifications to be reliable, an app must subscribe to the group message topic for each of these underlying conversations.
+> \*\*Note on [DM stitching](/chat-apps/push-notifs/understand-push-notifs#understand-dm-stitching-and-push-notifications): For direct messages, multiple underlying conversations might be "stitched" together in the UI. For push notifications to be reliable, an app must subscribe to the group message topic for each of these underlying conversations.
 
 ### Welcome message topic
 

--- a/docs/pages/terms.md
+++ b/docs/pages/terms.md
@@ -38,7 +38,7 @@ There are several typical ways in which this might apply:
 
 If your online work _exactly reproduces_ text or images from this site, in whole or in part, please include a paragraph at the bottom of your page that reads:
 
->Portions of this page are reproduced from work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
+> Portions of this page are reproduced from work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
 Also, please link back to the original source page so that readers can refer to it for more information.
 
@@ -46,7 +46,7 @@ Also, please link back to the original source page so that readers can refer to 
 
 If your online work shows _modified_ text or images based on the content from this site, please include a paragraph at the bottom of your page that reads:
 
->Portions of this page are modifications based on work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
+> Portions of this page are modifications based on work created and shared by XMTP and used according to terms described in the [Creative Commons 4.0 Attribution License](https://creativecommons.org/licenses/by/4.0/).
 
 Again, please link back to the original source page so that readers can refer to it for more information. This is even more important when the content has been modified.
 

--- a/docs/public/popup.js
+++ b/docs/public/popup.js
@@ -1,7 +1,7 @@
 function shouldShowPopup() {
   // Testing mode - uncomment the line below to force popup to show immediately
   // localStorage.setItem("testingMode", "true");
-  
+
   // Check if testing mode is enabled
   if (localStorage.getItem("testingMode") === "true") {
     return true;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -151,21 +151,25 @@ html body .custom-homepage-sdk-grid {
 }
 
 .custom-homepage-cta-button--primary {
-  background: linear-gradient(135deg, #4F46E5 0%, #6366F1 100%);
+  background: linear-gradient(135deg, #4f46e5 0%, #6366f1 100%);
   color: white;
-  box-shadow: 0 8px 32px rgba(79, 70, 229, 0.3), 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow:
+    0 8px 32px rgba(79, 70, 229, 0.3),
+    0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .custom-homepage-cta-button--secondary {
   background: rgba(224, 231, 255, 0.8);
-  color: #4F46E5;
-  box-shadow: 0 8px 32px rgba(79, 70, 229, 0.1), 0 1px 3px rgba(0, 0, 0, 0.05);
+  color: #4f46e5;
+  box-shadow:
+    0 8px 32px rgba(79, 70, 229, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 /* Dark mode button adjustments */
 .dark .custom-homepage-cta-button--secondary {
   background: rgba(224, 231, 255, 0.15);
-  color: #A5B4FC;
+  color: #a5b4fc;
 }
 
 .custom-homepage-cta-button:hover {
@@ -173,18 +177,24 @@ html body .custom-homepage-sdk-grid {
 }
 
 .custom-homepage-cta-button--primary:hover {
-  box-shadow: 0 12px 40px rgba(79, 70, 229, 0.4), 0 2px 8px rgba(0, 0, 0, 0.1);
-  background: linear-gradient(135deg, #4338CA 0%, #5B21B6 100%);
+  box-shadow:
+    0 12px 40px rgba(79, 70, 229, 0.4),
+    0 2px 8px rgba(0, 0, 0, 0.1);
+  background: linear-gradient(135deg, #4338ca 0%, #5b21b6 100%);
 }
 
 .custom-homepage-cta-button--secondary:hover {
   background: rgba(199, 210, 254, 0.9);
-  box-shadow: 0 12px 40px rgba(79, 70, 229, 0.2), 0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow:
+    0 12px 40px rgba(79, 70, 229, 0.2),
+    0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .dark .custom-homepage-cta-button--secondary:hover {
   background: rgba(199, 210, 254, 0.2);
-  box-shadow: 0 12px 40px rgba(165, 180, 252, 0.3), 0 2px 8px rgba(255, 255, 255, 0.1);
+  box-shadow:
+    0 12px 40px rgba(165, 180, 252, 0.3),
+    0 2px 8px rgba(255, 255, 255, 0.1);
 }
 
 .custom-homepage {
@@ -260,7 +270,7 @@ html body .custom-homepage-sdk-grid {
   .custom-homepage {
     padding: 2rem 1.5rem;
   }
-  
+
   .custom-homepage-headline-text {
     font-size: 2.5rem;
     line-height: 1.2;
@@ -373,7 +383,9 @@ html body .custom-homepage-sdk-grid {
   border-radius: 16px;
   padding: 2rem;
   color: var(--vocs-color-text);
-  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.06), 0 1px 2px -1px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 2px 4px -1px rgba(0, 0, 0, 0.06),
+    0 1px 2px -1px rgba(0, 0, 0, 0.06);
   display: block;
 }
 
@@ -396,7 +408,12 @@ html body .custom-homepage-sdk-grid {
 
 /* Dark mode adjustments */
 .dark .custom-homepage-tile {
-  background-color: rgba(255, 255, 255, 0.01); /* Slightly lighter than the background */
+  background-color: rgba(
+    255,
+    255,
+    255,
+    0.01
+  ); /* Slightly lighter than the background */
   border-color: rgba(255, 255, 255, 0.1);
   box-shadow: 0 1px 3px rgba(255, 255, 255, 0.05);
 }
@@ -442,19 +459,27 @@ li ol ~ p {
 
 /* Reduce section header padding */
 .vocs_Sidebar_sectionHeader {
-  padding-top: var(--vocs-space_6) !important; /* Reduced from space_12. Space above section heading. */
+  padding-top: var(
+    --vocs-space_6
+  ) !important; /* Reduced from space_12. Space above section heading. */
 }
 
 /* Reduce level items padding */
 .vocs_Sidebar_level .vocs_Sidebar_items {
-  padding-top: var(--vocs-space_8) !important; /* Reduced from space_6. Space above l2 items in section. */
+  padding-top: var(
+    --vocs-space_8
+  ) !important; /* Reduced from space_6. Space above l2 items in section. */
 }
 
 /* Reduce main items container padding and gap */
 .vocs_Sidebar_items {
   gap: 0.5em !important; /* Reduced from 0.625em. Space between each l1 item in section. */
-  padding-top: var(--vocs-space_6) !important; /* Reduced from space_16. Space above block of l1 items in section. */
-  padding-bottom: var(--vocs-space_6) !important; /* Reduced from space_16. Space below block of l1 items in section. */
+  padding-top: var(
+    --vocs-space_6
+  ) !important; /* Reduced from space_16. Space above block of l1 items in section. */
+  padding-bottom: var(
+    --vocs-space_6
+  ) !important; /* Reduced from space_16. Space below block of l1 items in section. */
 }
 
 /* Custom Homepage SDK grid */
@@ -493,7 +518,9 @@ li ol ~ p {
   text-decoration: none;
   color: var(--vocs-color-text);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
   height: auto;
   text-align: center;
   min-height: 120px;
@@ -502,8 +529,10 @@ li ol ~ p {
 
 .custom-homepage-sdk-tile:hover {
   transform: translateY(-1px);
-  box-shadow: 0 20px 25px -5px rgba(79, 70, 229, 0.1), 0 10px 10px -5px rgba(79, 70, 229, 0.04);
-  border-color: #4F46E5;
+  box-shadow:
+    0 20px 25px -5px rgba(79, 70, 229, 0.1),
+    0 10px 10px -5px rgba(79, 70, 229, 0.04);
+  border-color: #4f46e5;
 }
 
 .custom-homepage-sdk-icon {
@@ -520,13 +549,13 @@ li ol ~ p {
 
 /* Add indigo accent bar to SDK tiles */
 .custom-homepage-sdk-tile::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, #4F46E5, #6366F1);
+  background: linear-gradient(90deg, #4f46e5, #6366f1);
   opacity: 0;
   transition: opacity 0.3s ease;
   border-radius: 12px 12px 0 0;
@@ -565,7 +594,7 @@ li ol ~ p {
   transform: translateY(-4px);
   background-color: rgba(255, 255, 255, 0.03);
   box-shadow: 0 8px 16px rgba(79, 70, 229, 0.2);
-  border-color: #6366F1;
+  border-color: #6366f1;
 }
 
 .custom-homepage-section-title {
@@ -592,8 +621,6 @@ li ol ~ p {
   }
 }
 
-
-
 .description {
   font-size: 1.1rem;
   line-height: 1.6;
@@ -613,14 +640,13 @@ li ol ~ p {
 .vocs_NavigationMenu_link {
   font-size: 1rem !important;
   font-weight: 500 !important;
-  margin-right: .75rem !important;
+  margin-right: 0.75rem !important;
 }
 
 /* Remove margin from the last link to prevent overflow */
 .vocs_NavigationMenu_link:last-child {
   margin-right: 0 !important;
 }
-
 
 /* Center the footer properly */
 .vocs_Footer {
@@ -644,13 +670,13 @@ li ol ~ p {
   .vocs_MobileTopNav_navigation:not(.vocs_MobileTopNav_navigation_compact) {
     display: none !important;
   }
-  
+
   /* Hide compact navigation initially */
   .vocs_MobileTopNav_navigation_compact {
     display: block !important;
     position: relative;
   }
-  
+
   /* Style the compact nav as a dropdown trigger */
   .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem {
     display: flex !important;
@@ -663,13 +689,13 @@ li ol ~ p {
     cursor: pointer !important;
     text-decoration: none !important;
   }
-  
 
-  
-    /* Only inject logo when Vocs doesn't generate the real one */
-  .vocs_MobileTopNav_section:first-child:not(:has(.vocs_MobileTopNav_logo))::before {
-    content: '';
-    background-image: url('/logomark-light-purple.png');
+  /* Only inject logo when Vocs doesn't generate the real one */
+  .vocs_MobileTopNav_section:first-child:not(
+      :has(.vocs_MobileTopNav_logo)
+    )::before {
+    content: "";
+    background-image: url("/logomark-light-purple.png");
     background-size: contain;
     background-repeat: no-repeat;
     background-position: left center;
@@ -681,8 +707,11 @@ li ol ~ p {
   }
 
   /* Dark mode logo - only when no real logo */
-  .dark .vocs_MobileTopNav_section:first-child:not(:has(.vocs_MobileTopNav_logo))::before {
-    background-image: url('/logomark-dark-purple.png');
+  .dark
+    .vocs_MobileTopNav_section:first-child:not(
+      :has(.vocs_MobileTopNav_logo)
+    )::before {
+    background-image: url("/logomark-dark-purple.png");
   }
 
   /* Make the first section a flexbox to align logo and nav */
@@ -692,7 +721,7 @@ li ol ~ p {
   }
 
   /* Homepage mobile navigation with working dropdown */
-  
+
   /* Style the real menu trigger consistently on ALL pages */
   .vocs_MobileTopNav_menuTrigger {
     display: flex !important;
@@ -704,13 +733,15 @@ li ol ~ p {
     border: none !important;
     cursor: pointer !important;
   }
-  
+
   /* Style homepage compact nav button - use presence of custom homepage instead of data-layout */
   body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact {
     position: relative !important;
   }
-  
-  body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem {
+
+  body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem {
     display: flex !important;
     align-items: center !important;
     gap: 0.5rem !important;
@@ -724,29 +755,38 @@ li ol ~ p {
     pointer-events: auto !important;
     transition: all 0.2s ease !important;
   }
-  
-  
+
   /* Dark mode specific styling for the button */
-  .dark body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem {
+  .dark
+    body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem {
     background: rgba(155, 152, 255, 0.15) !important;
     border: 1px solid rgba(155, 152, 255, 0.3) !important;
     color: #e5e5e5 !important;
   }
-  
+
   /* Hover effects for both light and dark modes */
-  body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem:hover {
+  body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem:hover {
     background: rgba(86, 83, 198, 0.2) !important;
     border-color: rgba(86, 83, 198, 0.4) !important;
   }
-  
-  .dark body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem:hover {
+
+  .dark
+    body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem:hover {
     background: rgba(155, 152, 255, 0.25) !important;
     border-color: rgba(155, 152, 255, 0.5) !important;
   }
-  
+
   /* Add dropdown arrow */
-  body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem::after {
-    content: '';
+  body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem::after {
+    content: "";
     width: 12px;
     height: 7px;
     margin-left: 0.5rem;
@@ -758,23 +798,28 @@ li ol ~ p {
     opacity: 0.8;
     transition: opacity 0.2s ease;
   }
-  
+
   /* Dark mode arrow - more visible */
-  .dark body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem::after {
+  .dark
+    body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem::after {
     background-image: url("data:image/svg+xml,%3Csvg width='12' height='7' viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L6 6L11 1' stroke='%23e5e5e5' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
     opacity: 0.9;
   }
-  
+
   /* Make arrow more visible on hover */
-  body:has(.custom-homepage) .vocs_MobileTopNav_navigation_compact .vocs_MobileTopNav_navigationItem:hover::after {
+  body:has(.custom-homepage)
+    .vocs_MobileTopNav_navigation_compact
+    .vocs_MobileTopNav_navigationItem:hover::after {
     opacity: 1;
   }
-  
+
   /* Hide the original navigation menu on homepage to prevent conflicts */
   body:has(.custom-homepage) .vocs_MobileTopNav_navigation.vocs_NavigationMenu {
     display: none !important;
   }
-  
+
   /* Style interior page mobile dropdown to match homepage styling */
   .vocs_MobileTopNav_menuTrigger {
     display: flex !important;
@@ -787,24 +832,24 @@ li ol ~ p {
     cursor: pointer !important;
     transition: all 0.2s ease !important;
   }
-  
+
   /* Dark mode for interior page button */
   .dark .vocs_MobileTopNav_menuTrigger {
     background: rgba(155, 152, 255, 0.15) !important;
     border: 1px solid rgba(155, 152, 255, 0.3) !important;
   }
-  
+
   /* Hover effects for interior page button */
   .vocs_MobileTopNav_menuTrigger:hover {
     background: rgba(86, 83, 198, 0.2) !important;
     border-color: rgba(86, 83, 198, 0.4) !important;
   }
-  
+
   .dark .vocs_MobileTopNav_menuTrigger:hover {
     background: rgba(155, 152, 255, 0.25) !important;
     border-color: rgba(155, 152, 255, 0.5) !important;
   }
-  
+
   /* Style the interior page dropdown content to match homepage */
   .vocs_MobileTopNav_topNavPopover,
   .vocs_MobileTopNav_sidebarPopover {
@@ -816,7 +861,7 @@ li ol ~ p {
     max-width: 280px !important;
     min-width: 200px !important;
   }
-  
+
   /* Dark mode for interior page dropdown content */
   .dark .vocs_MobileTopNav_topNavPopover,
   .dark .vocs_MobileTopNav_sidebarPopover {
@@ -824,7 +869,7 @@ li ol ~ p {
     border: 1px solid var(--vocs-color-border, #404040) !important;
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.3) !important;
   }
-  
+
   /* Style the navigation links in interior page dropdown */
   .vocs_MobileTopNav_topNavPopover .vocs_NavigationMenu_link,
   .vocs_MobileTopNav_sidebarPopover .vocs_NavigationMenu_link,
@@ -846,7 +891,7 @@ li ol ~ p {
     width: 100% !important;
     margin: 0 !important;
   }
-  
+
   /* Remove border from last link */
   .vocs_MobileTopNav_topNavPopover .vocs_NavigationMenu_link:last-child,
   .vocs_MobileTopNav_sidebarPopover .vocs_NavigationMenu_link:last-child,
@@ -854,32 +899,35 @@ li ol ~ p {
   .vocs_MobileTopNav_sidebarPopover a:last-child {
     border-bottom: none !important;
   }
-  
+
   /* Dark mode for navigation links */
   .dark .vocs_MobileTopNav_topNavPopover .vocs_NavigationMenu_link,
   .dark .vocs_MobileTopNav_sidebarPopover .vocs_NavigationMenu_link,
   .dark .vocs_MobileTopNav_topNavPopover a,
   .dark .vocs_MobileTopNav_sidebarPopover a {
     color: var(--vocs-color-text, #e5e5e5) !important;
-    border-bottom-color: var(--vocs-color-border, rgba(255,255,255,0.1)) !important;
+    border-bottom-color: var(
+      --vocs-color-border,
+      rgba(255, 255, 255, 0.1)
+    ) !important;
   }
-  
+
   /* Hover effects for navigation links */
   .vocs_MobileTopNav_topNavPopover .vocs_NavigationMenu_link:hover,
   .vocs_MobileTopNav_sidebarPopover .vocs_NavigationMenu_link:hover,
   .vocs_MobileTopNav_topNavPopover a:hover,
   .vocs_MobileTopNav_sidebarPopover a:hover {
-    color: var(--vocs-color-text-accent, #4338CA) !important;
+    color: var(--vocs-color-text-accent, #4338ca) !important;
     background-color: transparent !important;
   }
-  
+
   .dark .vocs_MobileTopNav_topNavPopover .vocs_NavigationMenu_link:hover,
   .dark .vocs_MobileTopNav_sidebarPopover .vocs_NavigationMenu_link:hover,
   .dark .vocs_MobileTopNav_topNavPopover a:hover,
   .dark .vocs_MobileTopNav_sidebarPopover a:hover {
-    color: var(--vocs-color-text-accent, #9B98FF) !important;
+    color: var(--vocs-color-text-accent, #9b98ff) !important;
   }
-  
+
   /* Remove any extra spacing or margins from the list */
   .vocs_MobileTopNav_topNavPopover .vocs_NavigationMenu_list,
   .vocs_MobileTopNav_sidebarPopover .vocs_NavigationMenu_list,
@@ -926,63 +974,75 @@ li ol ~ p {
 /* Add prominent section headers at the top of the navigation area based on current page */
 
 /* Agents section - only when on agents pages */
-body:has([data-active="true"][href*="/agents/"]) .vocs_Sidebar_navigation::before {
+body:has([data-active="true"][href*="/agents/"])
+  .vocs_Sidebar_navigation::before {
   content: "Build agents";
   display: block;
   font-size: 1rem;
   font-weight: 600;
   color: var(--vocs-color-text);
-  padding: 0 0 .25rem 0;
-  margin: 0 0 .5rem 0;
-  border-bottom: 2px solid #4F46E5;
+  padding: 0 0 0.25rem 0;
+  margin: 0 0 0.5rem 0;
+  border-bottom: 2px solid #4f46e5;
   text-align: left;
 }
 
 /* Chat apps section - only when on chat apps pages */
-body:has([data-active="true"][href*="/chat-apps/"]) .vocs_Sidebar_navigation::before {
+body:has([data-active="true"][href*="/chat-apps/"])
+  .vocs_Sidebar_navigation::before {
   content: "Build chat apps";
   display: block;
   font-size: 1rem;
   font-weight: 600;
   color: var(--vocs-color-text);
-  padding: 0 0 .25rem 0;
-  margin: 0 0 .5rem 0;
-  border-bottom: 2px solid #4F46E5;
+  padding: 0 0 0.25rem 0;
+  margin: 0 0 0.5rem 0;
+  border-bottom: 2px solid #4f46e5;
   text-align: left;
 }
 
 /* Protocol section - only when on protocol pages */
-body:has([data-active="true"][href*="/protocol/"]) .vocs_Sidebar_navigation::before {
+body:has([data-active="true"][href*="/protocol/"])
+  .vocs_Sidebar_navigation::before {
   content: "Protocol";
   display: block;
   font-size: 1rem;
   font-weight: 600;
   color: var(--vocs-color-text);
-  padding: 0 0 .25rem 0;
-  margin: 0 0 .5rem 0;
-  border-bottom: 2px solid #4F46E5;
+  padding: 0 0 0.25rem 0;
+  margin: 0 0 0.5rem 0;
+  border-bottom: 2px solid #4f46e5;
   text-align: left;
 }
 
 /* Network section - only when on network pages */
-body:has([data-active="true"][href*="/network/"]) .vocs_Sidebar_navigation::before {
+body:has([data-active="true"][href*="/network/"])
+  .vocs_Sidebar_navigation::before {
   content: "Network";
   display: block;
   font-size: 1rem;
   font-weight: 600;
   color: var(--vocs-color-text);
-  padding: 0 0 .25rem 0;
-  margin: 0 0 .5rem 0;
-  border-bottom: 2px solid #4F46E5;
+  padding: 0 0 0.25rem 0;
+  margin: 0 0 0.5rem 0;
+  border-bottom: 2px solid #4f46e5;
   text-align: left;
 }
 
 /* Dark mode border colors for sidebar section headers */
-.dark body:has([data-active="true"][href*="/agents/"]) .vocs_Sidebar_navigation::before,
-.dark body:has([data-active="true"][href*="/chat-apps/"]) .vocs_Sidebar_navigation::before,
-.dark body:has([data-active="true"][href*="/protocol/"]) .vocs_Sidebar_navigation::before,
-.dark body:has([data-active="true"][href*="/network/"]) .vocs_Sidebar_navigation::before {
-  border-bottom-color: #A5B4FC;
+.dark
+  body:has([data-active="true"][href*="/agents/"])
+  .vocs_Sidebar_navigation::before,
+.dark
+  body:has([data-active="true"][href*="/chat-apps/"])
+  .vocs_Sidebar_navigation::before,
+.dark
+  body:has([data-active="true"][href*="/protocol/"])
+  .vocs_Sidebar_navigation::before,
+.dark
+  body:has([data-active="true"][href*="/network/"])
+  .vocs_Sidebar_navigation::before {
+  border-bottom-color: #a5b4fc;
 }
 
 /* Hide social links on homepage (they appear awkwardly above footer) */
@@ -991,31 +1051,38 @@ body:has(.custom-homepage) .vocs_Socials {
 }
 
 /* Add section context to search results */
-.vocs_SearchDialog_result a[href*="/agents/"] .vocs_SearchDialog_titles::before {
+.vocs_SearchDialog_result
+  a[href*="/agents/"]
+  .vocs_SearchDialog_titles::before {
   content: "Build agents • ";
   color: var(--vocs-color-text-accent);
   font-weight: 500;
   font-size: 0.8em;
 }
 
-.vocs_SearchDialog_result a[href*="/chat-apps/"] .vocs_SearchDialog_titles::before {
+.vocs_SearchDialog_result
+  a[href*="/chat-apps/"]
+  .vocs_SearchDialog_titles::before {
   content: "Build chat apps • ";
   color: var(--vocs-color-text-accent);
   font-weight: 500;
   font-size: 0.8em;
 }
 
-.vocs_SearchDialog_result a[href*="/protocol/"] .vocs_SearchDialog_titles::before {
+.vocs_SearchDialog_result
+  a[href*="/protocol/"]
+  .vocs_SearchDialog_titles::before {
   content: "Protocol • ";
   color: var(--vocs-color-text-accent);
   font-weight: 500;
   font-size: 0.8em;
 }
 
-.vocs_SearchDialog_result a[href*="/network/"] .vocs_SearchDialog_titles::before {
+.vocs_SearchDialog_result
+  a[href*="/network/"]
+  .vocs_SearchDialog_titles::before {
   content: "Network • ";
   color: var(--vocs-color-text-accent);
   font-weight: 500;
   font-size: 0.8em;
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "cspell": "^9.1.3",
         "markdownlint-cli": "^0.45.0",
         "markdownlint-rule-search-replace": "^1.2.0",
+        "prettier": "^3.6.2",
         "typescript": "latest"
       }
     },
@@ -41,6 +42,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
       "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
       "dependencies": {
         "package-manager-detector": "^1.3.0",
         "tinyexec": "^1.0.1"
@@ -50,9 +52,10 @@
       }
     },
     "node_modules/@antfu/utils": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
-      "integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-9.2.0.tgz",
+      "integrity": "sha512-Oq1d9BGZakE/FyoEtcNeSwM7MpDO2vUBi11RWBZXf75zPsbUVWmUs03EqkRFrcgbXyKTas0BdZWC1wcuSoqSAw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -1445,32 +1448,23 @@
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
-      "integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.0.2.tgz",
+      "integrity": "sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==",
+      "license": "MIT",
       "dependencies": {
-        "@antfu/install-pkg": "^1.0.0",
-        "@antfu/utils": "^8.1.0",
+        "@antfu/install-pkg": "^1.1.0",
+        "@antfu/utils": "^9.2.0",
         "@iconify/types": "^2.0.0",
-        "debug": "^4.4.0",
-        "globals": "^15.14.0",
+        "debug": "^4.4.1",
+        "globals": "^15.15.0",
         "kolorist": "^1.8.0",
-        "local-pkg": "^1.0.0",
+        "local-pkg": "^1.1.1",
         "mlly": "^1.7.4"
-      }
-    },
-    "node_modules/@iconify/utils/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@isaacs/balanced-match": {
@@ -4805,7 +4799,8 @@
     "node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6084,7 +6079,8 @@
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
-      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6408,6 +6404,18 @@
       "dependencies": {
         "ini": "4.1.1"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -6810,9 +6818,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.4.tgz",
-      "integrity": "sha512-61hl6MF6ojTl/8QSRu5ran6GXt+6zsngIUN95KzF5v5UjiX/xnrLR358BNRawwIRO49JwUqJqQe3Rb2v559R8Q==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.7.tgz",
+      "integrity": "sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7237,7 +7245,8 @@
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "license": "MIT"
     },
     "node_modules/langium": {
       "version": "3.3.1",
@@ -7503,13 +7512,14 @@
       }
     },
     "node_modules/local-pkg": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.1.tgz",
-      "integrity": "sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.4",
-        "pkg-types": "^2.0.1",
-        "quansync": "^0.2.8"
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
       },
       "engines": {
         "node": ">=14"
@@ -7772,14 +7782,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.1.tgz",
-      "integrity": "sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==",
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-directive": {
@@ -8136,12 +8147,13 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.9.0.tgz",
-      "integrity": "sha512-YdPXn9slEwO0omQfQIsW6vS84weVQftIyyTGAZCwM//MGhPzL1+l6vO6bkf0wnP4tHigH1alZ5Ooy3HXI2gOag==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.11.0.tgz",
+      "integrity": "sha512-9lb/VNkZqWTRjVgCV+l1N+t4kyi94y+l5xrmBmbbxZYkfRl5hEDaTPMOcaWKCl1McG8nBEaMlWwkcAEEgjhBgg==",
+      "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.0.4",
-        "@iconify/utils": "^2.1.33",
+        "@iconify/utils": "^3.0.1",
         "@mermaid-js/parser": "^0.6.2",
         "@types/d3": "^7.4.3",
         "cytoscape": "^3.29.3",
@@ -8155,7 +8167,7 @@
         "katex": "^0.16.22",
         "khroma": "^2.1.0",
         "lodash-es": "^4.17.21",
-        "marked": "^16.0.0",
+        "marked": "^15.0.7",
         "roughjs": "^4.6.6",
         "stylis": "^4.3.6",
         "ts-dedent": "^2.2.0",
@@ -9286,7 +9298,8 @@
     "node_modules/package-manager-detector": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
-      "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ=="
+      "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "2.0.0",
@@ -9432,9 +9445,10 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
-      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
@@ -9532,6 +9546,22 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/property-information": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
@@ -9552,9 +9582,9 @@
       }
     },
     "node_modules/quansync": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
       "funding": [
         {
           "type": "individual",
@@ -9564,7 +9594,8 @@
           "type": "individual",
           "url": "https://github.com/sponsors/sxzz"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -10690,7 +10721,8 @@
     "node_modules/tinyexec": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -11139,9 +11171,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "vocs build",
     "dev": "vocs dev",
-    "lint:md:fix": "markdownlint --fix 'docs/**/*.md' 'docs/**/*.mdx'",
-    "lint:md": "markdownlint 'docs/**/*.md' 'docs/**/*.mdx'",
+    "lint:md:fix": "npm run prettier:fix && markdownlint --fix 'docs/**/*.md' 'docs/**/*.mdx'",
+    "lint:md": "npm run prettier:lint && markdownlint 'docs/**/*.md' 'docs/**/*.mdx'",
     "prettier:lint": "prettier --ignore-path .gitignore docs",
     "prettier:fix": "npm run prettier:lint -- --write",
     "preview": "vocs preview",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vocs dev",
     "build": "vocs build",
-    "preview": "vocs preview",
-    "spell": "cspell",
+    "dev": "vocs dev",
+    "lint:md:fix": "markdownlint --fix 'docs/**/*.md' 'docs/**/*.mdx'",
     "lint:md": "markdownlint 'docs/**/*.md' 'docs/**/*.mdx'",
-    "lint:md:fix": "markdownlint --fix 'docs/**/*.md' 'docs/**/*.mdx'"
+    "prettier:lint": "prettier --ignore-path .gitignore docs",
+    "prettier:fix": "npm run prettier:lint -- --write",
+    "preview": "vocs preview",
+    "spell": "cspell"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
### Add Prettier and enforce repository-wide formatting across docs, components, styles, and scripts with new npm scripts in [package.json](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and config in [.prettierrc](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2)
This change introduces Prettier configuration and integrates formatting into the docs build workflow. It adds Prettier scripts, updates markdown lint scripts to run Prettier, and reformats markdown, MDX, TS/TSX, CSS, and JS files across the docs codebase to the new style. Key updates include:

- Add `.prettierrc` with formatting rules and update `package.json` scripts to include `prettier:lint`, `prettier:fix`, and run Prettier before `markdownlint` ([.prettierrc](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2), [package.json](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)).
- Reformat MDX content, embedded code samples, and HTML/JSX blocks across docs pages, including list indentation, tables, `iframe` and `img` tags, and JSON/TypeScript snippets (for example: [docs/pages/chat-apps/core-messaging/support-group-invite-links.mdx](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-f66583412093f45391a81ce25e0ccd86beacc13569b3946cc5d6b83d76250932), [docs/pages/chat-apps/intro/get-started.mdx](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-78ea9155961c217a1696187a847cb6f839a8e45638ed52124928fce3f19733cd)).
- Apply consistent TypeScript/JavaScript style in code samples and site components, including trailing commas, semicolons, and quote normalization (for example: [docs/components/AutoBreadcrumb.tsx](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-33104d491fc0dcc8228aacc430b0f935a382fa34d0333034008f8698ca37b88e), [docs/pages/chat-apps/sdks/browser.mdx](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-694c3016907543bfd67dfba9b2618f1bf9f34bdd831814cd796f062974bd40b3)).
- Normalize CSS formatting in site styles ([docs/styles.css](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-642dd6b337eceefea97f017b0bac03ef7601bde8c4986a6022db316aab7b3c5c)).
- Update lockfile to reflect script/config changes ([package-lock.json](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519)).

#### 📍Where to Start
Start with the Prettier configuration and script changes in [.prettierrc](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2) and [package.json](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), then spot-check representative reformats such as [docs/pages/chat-apps/intro/get-started.mdx](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-78ea9155961c217a1696187a847cb6f839a8e45638ed52124928fce3f19733cd) and [docs/components/AutoBreadcrumb.tsx](https://github.com/xmtp/docs-xmtp-org/pull/379/files#diff-33104d491fc0dcc8228aacc430b0f935a382fa34d0333034008f8698ca37b88e).

----

_[Macroscope](https://app.macroscope.com) summarized 1da8ea9._