### PR TITLE
Quickstart tweak

### DIFF
--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -2,24 +2,33 @@
 
 This documentation provides examples of agents that use the XMTP network. These agents are built with the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk).
 
-## Prerequisites
-
-- Node.js v20 or higher
-- Any package manager
 
 ## Installation
 
-Choose your package manager to install the XMTP Agent SDK:
 
-```bash
-npm install @xmtp/agent-sdk
-# or
-pnpm add @xmtp/agent-sdk
-# or
+First, we will install `@xmtp/agent-sdk` as a dependency in our project.
+
+:::code-group
+
+```bash [npm]
+npm i @xmtp/agent-sdk
+```
+
+```bash [pnpm]
+pnpm i @xmtp/agent-sdk
+```
+
+```bash [yarn]
 yarn add @xmtp/agent-sdk
 ```
 
-## Quickstart
+```bash [bun]
+bun i @xmtp/agent-sdk
+```
+
+:::
+
+## Usage
 
 This example shows how to create an agent that sends a message when it receives a text message.
 
@@ -30,7 +39,6 @@ import { getTestUrl } from '@xmtp/agent-sdk/debug';
 // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
   env: 'dev', // or 'production'
-  dbPath: './xmtp.db3',
 });
 
 // 3. Respond to text messages


### PR DESCRIPTION
### Refactor agent SDK install docs in file:docs/pages/agents/get-started/build-an-agent.mdx to update installation options and usage example
This updates the installation and usage sections in [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/395/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1). It replaces a single install command with a code-group covering `npm`, `pnpm`, `yarn`, and `bun` using the short `i` form, removes the `Prerequisites` section, renames `Quickstart` to `Usage`, and updates the agent creation example by removing the `dbPath: './xmtp.db3',` option from `Agent.createFromEnv`.

- Replace single install command with a code-group for `npm`, `pnpm`, `yarn`, and `bun` using `i`
- Remove the `Prerequisites` section
- Rename `Quickstart` to `Usage`
- Update `Agent.createFromEnv` example to omit `dbPath: './xmtp.db3',`

#### 📍Where to Start
Start with the installation and usage sections in [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/395/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1).

----

_[Macroscope](https://app.macroscope.com) summarized 4a0ce56._