### PR TITLE
Fix code block padding

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -433,9 +433,9 @@ li ol ~ p {
   margin-top: 0.5rem !important;
 }
 
-/* Code groups */
-.vocs_CodeBlock {
-  margin: 0.5rem 0;
+/* Remove padding from tab content panels */
+.vocs_Tabs_content {
+  padding: 0 !important;
 }
 
 /* ====== SIDEBAR SPACING REDUCTION ====== */


### PR DESCRIPTION
### Remove vertical margins from `.vocs_CodeBlock` and clear padding from `.vocs_Tabs_content` in docs to fix code block padding
Update styles in [docs/styles.css](https://github.com/xmtp/docs-xmtp-org/pull/396/files#diff-642dd6b337eceefea97f017b0bac03ef7601bde8c4986a6022db316aab7b3c5c) to adjust spacing for code blocks and tab content.

- Delete the rule that adds vertical margins to `.vocs_CodeBlock`
- Add an overriding rule that removes padding from `.vocs_Tabs_content`

#### 📍Where to Start
Start with the CSS rule changes in [docs/styles.css](https://github.com/xmtp/docs-xmtp-org/pull/396/files#diff-642dd6b337eceefea97f017b0bac03ef7601bde8c4986a6022db316aab7b3c5c), focusing on the `.vocs_CodeBlock` removal and the new `.vocs_Tabs_content` override.

----

_[Macroscope](https://app.macroscope.com) summarized 0cdde5f._