### PR TITLE
Add group updates streaming

### DIFF
--- a/docs/pages/agents/content-types/group-updates.mdx
+++ b/docs/pages/agents/content-types/group-updates.mdx
@@ -1,8 +1,7 @@
 # Streaming Group Changes with XMTP
 
-## Overview
 
-Stream group metadata changes (name, description, members) in real-time using the `group_updated` content type via XMTP's `streamAllMessages()`.
+Stream group metadata changes (name, description, members) in real-time using the `group_updated` native content type via XMTP's `streamAllMessages()`.
 
 
 ## Stream Group Updates
@@ -111,10 +110,3 @@ for await (const message of stream) {
 }
 ```
 
-## Key Points
-
-- Use `streamAllMessages()` to receive all message types including group updates
-- Filter by `contentType.typeId === "group_updated"` to get only group changes
-- Group updates contain metadata changes and member additions
-- Stream runs continuously until explicitly stopped
-- Filter by `conversationId` to monitor specific groups

--- a/docs/pages/agents/content-types/group-updates.mdx
+++ b/docs/pages/agents/content-types/group-updates.mdx
@@ -1,0 +1,120 @@
+# Streaming Group Changes with XMTP
+
+## Overview
+
+Stream group metadata changes (name, description, members) in real-time using the `group_updated` content type via XMTP's `streamAllMessages()`.
+
+
+## Stream Group Updates
+
+```typescript
+// Start streaming all messages
+const stream = await client.conversations.streamAllMessages();
+
+for await (const message of stream) {
+  // Check if message is a group update
+  if (message.contentType?.typeId === "group_updated") {
+    console.log("Group updated:", message.content);
+  }
+}
+```
+
+## Group Update Message Structure
+
+```typescript
+{
+  conversationId: string,
+  contentType: { typeId: "group_updated" },
+  content: {
+    metadataFieldChanges?: Array<{
+      fieldName: string,        // "group_name", "group_description", etc.
+      oldValue: string,
+      newValue: string
+    }>,
+    addedInboxes?: Array<{     // New members added
+      inboxId: string
+    }>,
+    initiatedByInboxId?: string // Who triggered the update
+  }
+}
+```
+
+## Usage Examples
+
+### Monitor Group Name Changes
+
+```typescript
+const stream = await client.conversations.streamAllMessages();
+
+for await (const message of stream) {
+  if (message.contentType?.typeId === "group_updated") {
+    const content = message.content as any;
+
+    const nameChange = content.metadataFieldChanges?.find(
+      (change) => change.fieldName === "group_name",
+    );
+
+    if (nameChange) {
+      console.log(
+        `Group renamed: ${nameChange.oldValue} → ${nameChange.newValue}`,
+      );
+    }
+  }
+}
+```
+
+### Track Member Additions
+
+```typescript
+const stream = await client.conversations.streamAllMessages();
+
+for await (const message of stream) {
+  if (message.contentType?.typeId === "group_updated") {
+    const content = message.content as any;
+
+    if (content.addedInboxes?.length > 0) {
+      console.log(`New members added:`, content.addedInboxes);
+    }
+  }
+}
+```
+
+### Track Member Removals
+
+```typescript
+const stream = await client.conversations.streamAllMessages();
+
+for await (const message of stream) {
+  if (message.contentType?.typeId === "group_updated") {
+    const content = message.content as any;
+
+    if (content.removedInboxes?.length > 0) {
+      console.log(`Members removed:`, content.removedInboxes);
+    }
+  }
+}
+```
+
+### Filter by Specific Group
+
+```typescript
+const targetGroupId = "your-group-conversation-id";
+const stream = await client.conversations.streamAllMessages();
+
+for await (const message of stream) {
+  if (
+    message.contentType?.typeId === "group_updated" &&
+    message.conversationId === targetGroupId
+  ) {
+    console.log("Target group updated:", message.content);
+  }
+}
+```
+
+## Key Points
+
+- Use `streamAllMessages()` to receive all message types including group updates
+- Filter by `contentType.typeId === "group_updated"` to get only group changes
+- Group updates contain metadata changes and member additions
+- Stream runs continuously until explicitly stopped
+- Filter by `conversationId` to monitor specific groups

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -2,24 +2,33 @@
 
 This documentation provides examples of agents that use the XMTP network. These agents are built with the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk).
 
-## Prerequisites
-
-- Node.js v20 or higher
-- Any package manager
 
 ## Installation
 
-Choose your package manager to install the XMTP Agent SDK:
 
-```bash
-npm install @xmtp/agent-sdk
-# or
-pnpm add @xmtp/agent-sdk
-# or
+First, we will install `@xmtp/agent-sdk` as a dependency in our project.
+
+:::code-group
+
+```bash [npm]
+npm i @xmtp/agent-sdk
+```
+
+```bash [pnpm]
+pnpm i @xmtp/agent-sdk
+```
+
+```bash [yarn]
 yarn add @xmtp/agent-sdk
 ```
 
-## Quickstart
+```bash [bun]
+bun i @xmtp/agent-sdk
+```
+
+:::
+
+## Usage
 
 This example shows how to create an agent that sends a message when it receives a text message.
 
@@ -30,7 +39,6 @@ import { getTestUrl } from '@xmtp/agent-sdk/debug';
 // 2. Spin up the agent
 const agent = await Agent.createFromEnv({
   env: 'dev', // or 'production'
-  dbPath: './xmtp.db3',
 });
 
 // 3. Respond to text messages


### PR DESCRIPTION
### Add documentation for streaming group metadata updates in Agents docs to support group updates streaming
This change adds a new Agents documentation page that covers streaming group metadata changes using `XMTP.streamAllMessages()` with the `group_updated` content type and updates the getting started guide to adjust installation and usage instructions.

- Add [group-updates.mdx](https://github.com/xmtp/docs-xmtp-org/pull/397/files#diff-0a3a84fa77c78685a5448b4fa541ec387e005f84e0a753f1fd2818238d5adc66) with examples for streaming updates, monitoring name changes, tracking member additions/removals, filtering by `conversationId`, and message payload structure
- Update [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/397/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1) to use package-manager-specific install commands, rename Quickstart to Usage, introduce installing `@xmtp/agent-sdk`, and remove the `dbPath` option from the `Agent.createFromEnv` example

#### 📍Where to Start
Start with the new streaming examples and payload description in [docs/pages/agents/content-types/group-updates.mdx](https://github.com/xmtp/docs-xmtp-org/pull/397/files#diff-0a3a84fa77c78685a5448b4fa541ec387e005f84e0a753f1fd2818238d5adc66), then review installation and snippet changes in [docs/pages/agents/get-started/build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/397/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1).

----

_[Macroscope](https://app.macroscope.com) summarized 45a0ccc._