### PR TITLE
Fix Agent SDK examples

### DIFF
--- a/docs/pages/agents/build-agents/create-a-client.mdx
+++ b/docs/pages/agents/build-agents/create-a-client.mdx
@@ -10,8 +10,8 @@ import { createSigner, createUser } from '@xmtp/agent-sdk/user';
 import { getRandomValues } from 'node:crypto';
 
 // Option 1: Create a local user + signer
-const user = createUser(privateKey);
-const signer = createSigner();
+const user = createUser('0xprivateKey');
+const signer = createSigner(user);
 
 const agent = await Agent.create(signer, {
   env: 'dev', // or 'production'

--- a/docs/pages/agents/build-agents/create-conversations.mdx
+++ b/docs/pages/agents/build-agents/create-conversations.mdx
@@ -78,9 +78,14 @@ The first step to creating a conversation is to verify that participants' identi
 
 ```js [Node]
 import { Agent, IdentifierKind } from '@xmtp/agent-sdk';
+
+const agent = await Agent.createFromEnv();
+
 // response is a Map of string (identifier) => boolean (is reachable)
-const response = await Agent.canMessage({
-  identifier: '0xcaroAddress',
-  identifierKind: IdentifierKind.Ethereum,
-});
+const response = await agent.client.canMessage([
+  {
+    identifier: '0xcaroAddress',
+    identifierKind: IdentifierKind.Ethereum,
+  },
+]);
 ```

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -27,6 +27,8 @@ agent.on('reply', async (ctx) => {
 ```js [Node]
 import { filter } from '@xmtp/agent-sdk';
 
+const agent = await Agent.createFromEnv();
+
 agent.on('message', async (ctx) => {
   // Filter for specific message types
   if (filter.isText(ctx.message)) {

--- a/docs/pages/agents/concepts/event-driven.mdx
+++ b/docs/pages/agents/concepts/event-driven.mdx
@@ -51,6 +51,8 @@ The `"message"` event fires for **every** incoming message, regardless of type. 
 ```ts
 import { filter } from '@xmtp/agent-sdk';
 
+const agent = await Agent.createFromEnv();
+
 agent.on('message', async (ctx) => {
   // Filter for specific message types
   if (filter.isText(ctx.message)) {

--- a/docs/pages/agents/concepts/filters.mdx
+++ b/docs/pages/agents/concepts/filters.mdx
@@ -5,7 +5,9 @@ Instead of manually checking every incoming message, you can use the provided fi
 ## Example
 
 ```ts
-import { filter } from '@xmtp/agent-sdk';
+import { Agent, filter } from '@xmtp/agent-sdk';
+
+const agent = await Agent.createFromEnv();
 
 // Using filter in message handler
 agent.on('text', async (ctx) => {
@@ -17,7 +19,7 @@ agent.on('text', async (ctx) => {
 // Combine multiple conditions
 agent.on('text', async (ctx) => {
   if (
-    filter.hasDefinedContent(ctx.message) &&
+    filter.hasContent(ctx.message) &&
     !filter.fromSelf(ctx.message, ctx.client) &&
     filter.isText(ctx.message)
   ) {


### PR DESCRIPTION
### Fix Agent SDK documentation examples by updating client creation, signer usage, agent initialization, and filter API references across docs/pages/agents/*.mdx
Update Agent SDK documentation examples to align with current APIs across multiple MDX pages.

- Modify [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-e1eeca1eb166325425b064d0ba6cb2efa6ee209e96775225ac4362188dc91451) to create the user with literal `'0xprivateKey'` and invoke `createSigner(user)` instead of no-arg `createSigner()`
- Initialize an agent via `await Agent.createFromEnv()` in [create-conversations.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-7608f0666311a094b6ef92e774fae65295b64527a0223e8a22b8468f3b778a84), replace `Agent.canMessage` with instance-based `agent.client.canMessage`, and update parameters to an array of identifier objects
- Insert agent initialization using `await Agent.createFromEnv()` before message handlers in [stream.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-4d1e7d80f4ba047848f804ad3e49238ea02c9e8d9d6dff87fb2fbcc79f41dedc)
- Add agent initialization using `await Agent.createFromEnv()` before message event handling in [event-driven.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-f778f56ad351e369e28b1257db515a72155cda9a50a0302145bbd2820c054d0b)
- Update [filters.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-fdb5ba0e34473fe50b4710007ea0e11492fb701a9a6ff861f8746020cd1223d7) to import `Agent`, initialize with `await Agent.createFromEnv()`, and replace `filter.hasDefinedContent` with `filter.hasContent`

#### 📍Where to Start
Start with the client creation example in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-e1eeca1eb166325425b064d0ba6cb2efa6ee209e96775225ac4362188dc91451), then review the initialization and API usage changes in [create-conversations.mdx](https://github.com/xmtp/docs-xmtp-org/pull/399/files#diff-7608f0666311a094b6ef92e774fae65295b64527a0223e8a22b8468f3b778a84).

----

_[Macroscope](https://app.macroscope.com) summarized d53223e._