### PR TITLE
Tweak agent build intro

### DIFF
--- a/docs/pages/agents/build-agents/create-a-client.mdx
+++ b/docs/pages/agents/build-agents/create-a-client.mdx
@@ -52,7 +52,7 @@ Use this [script to generate](https://github.com/ephemeraHQ/xmtp-agent-examples)
 yarn gen:keys
 ```
 
-> Running the gen:keys command will append keys to your existing .env file.
+> Running the command will append keys to your existing .env file.
 
 ### Use environment variables
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -68,11 +68,6 @@ XMTP_ENV=dev # local, dev, production
 
 See these [Cursor rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc) for vibe coding agents with XMTP using best practices.
 
-Prompt example:
-
-```bash 
-lets create an example that gets a number and returns its 2x multiple (use claude max)
-```
 
 ## Talk to your agent
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -1,10 +1,10 @@
 # Build XMTP agents
 
-This documentation provides examples of agents that use the XMTP network. These agents are built with the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk).
+Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk) to build agents that interact with the XMTP network.
 
 ## Installation
 
-First, we will install `@xmtp/agent-sdk` as a dependency in our project.
+Install `@xmtp/agent-sdk` as a dependency in your project.
 
 :::code-group
 
@@ -68,8 +68,10 @@ XMTP_ENV=dev # local, dev, production
 
 See these [Cursor rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc) for vibe coding agents with XMTP using best practices.
 
-```bash
-Prompt: lets create an example that gets a number and returns its 2x multiple (use claude max)
+Prompt example:
+
+```bash 
+lets create an example that gets a number and returns its 2x multiple (use claude max)
 ```
 
 ## Talk to your agent
@@ -88,4 +90,4 @@ To learn more, see [Deploy an agent](/agents/deploy/deploy-agent).
 
 ## Agent examples
 
-See the [examples](https://github.com/ephemeraHQ/xmtp-agent-examples) for more agent examples.
+Visit the [examples](https://github.com/ephemeraHQ/xmtp-agent-examples) repository for more agent examples.

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -68,6 +68,10 @@ XMTP_ENV=dev # local, dev, production
 
 See these [Cursor rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc) for vibe coding agents with XMTP using best practices.
 
+```bash
+Prompt: lets create an example that gets a number and returns its 2x multiple (use claude max)
+```
+
 ## Talk to your agent
 
 Try out the example agents using [xmtp.chat](https://xmtp.chat), the official playground for agents.

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -68,7 +68,6 @@ XMTP_ENV=dev # local, dev, production
 
 See these [Cursor rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc) for vibe coding agents with XMTP using best practices.
 
-
 ## Talk to your agent
 
 Try out the example agents using [xmtp.chat](https://xmtp.chat), the official playground for agents.


### PR DESCRIPTION
### Update agent build documentation wording in docs/pages/agents to improve clarity per “Update agent build docs”
This pull request updates wording in two documentation pages under `docs/pages/agents`.

- Reword notes and instructions in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/406/files#diff-e1eeca1eb166325425b064d0ba6cb2efa6ee209e96775225ac4362188dc91451) by changing the note to say “Running the command will append keys to your existing .env file.”
- Revise introductory and instruction phrasing in [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/406/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1), including the intro sentence, installation instruction wording, and the examples link line.

#### 📍Where to Start
Start with the wording changes in [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/406/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1), then review the note update in [create-a-client.mdx](https://github.com/xmtp/docs-xmtp-org/pull/406/files#diff-e1eeca1eb166325425b064d0ba6cb2efa6ee209e96775225ac4362188dc91451).

----

_[Macroscope](https://app.macroscope.com) summarized 26feee3._