### PR TITLE
Tweak group-update docs

### DIFF
--- a/docs/pages/agents/concepts/context.mdx
+++ b/docs/pages/agents/concepts/context.mdx
@@ -2,144 +2,72 @@
 
 Every XMTP agent event handler receives a rich `MessageContext` object that provides access to the message, conversation, client, and powerful helper methods. This context makes it easy to build responsive agents without repetitive boilerplate code.
 
-## MessageContext overview
+## Message handling
 
-The `MessageContext` object contains everything you need to handle messages effectively:
+### Type-safe content access
 
-```typescript
-interface MessageContext {
-  message: DecodedMessage; // The decoded message object
-  conversation: Conversation; // The active conversation
-  client: Client; // The underlying XMTP client
-
-  // Helper methods
-  sendTextReply(text: string): Promise<void>;
-  sendReaction(emoji: string): Promise<void>;
-  getSenderAddress(): string;
-  // ... and more
-}
-```
-
-## Message object
-
-The `message` property contains the decoded message with all its metadata:
+Use type guards to safely access different content types:
 
 ```typescript
-agent.on('text', async (ctx) => {
-  const message = ctx.message;
-
-  console.log('Content:', message.content);
-  console.log('Sender:', message.senderInboxId);
-  console.log('Sent at:', message.sentAt);
-  console.log('Message ID:', message.id);
-  console.log('Conversation ID:', message.conversationId);
-  console.log('Content type:', message.contentType);
-});
-```
-
-### Access different content types
-
-```typescript
-// Text messages
-agent.on('text', async (ctx) => {
-  const textContent: string = ctx.message.content;
-  console.log('User said:', textContent);
-});
-
-// Reactions
-agent.on('reaction', async (ctx) => {
-  const reaction = ctx.message.content;
-  console.log('Reaction:', reaction.content);
-  console.log('Reference:', reaction.reference);
-});
-
-// Replies
-agent.on('reply', async (ctx) => {
-  const reply = ctx.message.content;
-  console.log('Reply text:', reply.content);
-  console.log('Original message:', reply.reference);
-});
-```
-
-## Conversation object
-
-The `conversation` property provides access to the current conversation and its methods:
-
-```typescript
-agent.on('text', async (ctx) => {
-  const conversation = ctx.conversation;
-
-  console.log('Conversation ID:', conversation.id);
-
-  // Send a message
-  await ctx.sendText('Hello from the conversation!');
-
-  // Get conversation members
-  const members = await ctx.conversation.members();
-  console.log('Member count:', members.length);
-
-  // Check conversation type
-  if (conversation.peerInboxId) {
-    console.log('This is a DM with:', conversation.peerInboxId);
-  } else {
-    console.log('This is a group conversation');
+agent.on('message', async (ctx) => {
+  if (ctx.isText()) {
+    // ctx.message.content is now typed as string
+    console.log('Text message:', ctx.message.content);
+  } else if (ctx.isReply()) {
+    // ctx.message.content is now typed as Reply
+    console.log('Reply to:', ctx.message.content.reference);
+    console.log('Reply content:', ctx.message.content.content);
+  } else if (ctx.isReaction()) {
+    // ctx.message.content is now typed as Reaction
+    console.log('Reaction:', ctx.message.content.content);
+    console.log('Reference:', ctx.message.content.reference);
   }
 });
 ```
 
-## Client object
+### Message metadata
 
-The `client` property gives you access to the underlying XMTP client:
+Access message properties directly:
 
 ```typescript
-agent.on('text', async (ctx) => {
-  const client = ctx.client;
-
-  console.log('Agent inbox ID:', client.inboxId);
-  console.log('Installation ID:', client.installationId);
-
-  // Access conversations manager
-  const conversations = client.conversations;
-
-  // Create new conversations
-  const newDM = await client.conversations.newDm('target-inbox-id');
-  const newGroup = await client.conversations.newGroup(['inbox1', 'inbox2'], {
-    groupName: 'New Group',
-  });
+agent.on('message', async (ctx) => {
+  const message = ctx.message;
+  
+  console.log('Message ID:', message.id);
+  console.log('Sender inbox ID:', message.senderInboxId);
+  console.log('Sent at:', message.sentAt);
+  console.log('Content type:', message.contentType);
 });
 ```
 
 ## Helper methods
 
-The context provides convenient helper methods for common operations:
+### sendText() and sendTextReply()
 
-### sendTextReply()
-
-Send a text reply in one line:
+Send messages and replies:
 
 ```typescript
 agent.on('text', async (ctx) => {
+  // Send a regular message
+  await ctx.sendText('Hello!');
+  
+  // Send a reply to the current message
   await ctx.sendTextReply('Thanks for your message!');
-
-  // Equivalent to:
-  // await ctx.sendText("Thanks for your message!");
 });
 ```
 
 ### sendReaction()
 
-Add reactions to messages easily:
+Add reactions to messages:
 
 ```typescript
 agent.on('text', async (ctx) => {
   const content = ctx.message.content.toLowerCase();
-
+  
   if (content.includes('good')) {
     await ctx.sendReaction('👍');
   } else if (content.includes('bad')) {
     await ctx.sendReaction('👎');
-  } else {
-    await ctx.sendReaction('🤔');
   }
 });
 ```
@@ -150,9 +78,9 @@ Get the Ethereum address of the message sender:
 
 ```typescript
 agent.on('text', async (ctx) => {
-  const senderAddress = ctx.getSenderAddress();
+  const senderAddress = await ctx.getSenderAddress();
   console.log('Message from:', senderAddress);
-
+  
   // Use for authorization
   if (senderAddress === '0x1234...') {
     await ctx.sendTextReply('Hello, admin!');
@@ -160,26 +88,66 @@ agent.on('text', async (ctx) => {
 });
 ```
 
-## Advanced context usage
+## Conversation and client access
+
+### Conversation operations
+
+```typescript
+agent.on('text', async (ctx) => {
+  const conversation = ctx.conversation;
+  
+  // Get conversation members
+  const members = await conversation.members();
+  console.log('Member count:', members.length);
+  
+  // Check conversation type
+  if (conversation.peerInboxId) {
+    console.log('DM with:', conversation.peerInboxId);
+  } else {
+    console.log('Group conversation');
+  }
+});
+```
+
+### Client operations
+
+```typescript
+agent.on('text', async (ctx) => {
+  const client = ctx.client;
+  
+  // Get client address
+  const clientAddress = ctx.getClientAddress();
+  console.log('Agent address:', clientAddress);
+  
+  // Access conversations manager
+  const conversations = client.conversations;
+  
+  // Create new conversations
+  const newDM = await client.conversations.newDm('target-inbox-id');
+  const newGroup = await client.conversations.newGroup(['inbox1', 'inbox2'], {
+    groupName: 'New Group',
+  });
+});
+```
+
+## Advanced usage
 
 ### Member information
-
-Get detailed information about conversation members:
 
 ```typescript
 agent.on('text', async (ctx) => {
   const members = await ctx.conversation.members();
-
+  
   for (const member of members) {
     console.log('Member inbox ID:', member.inboxId);
     console.log('Permission level:', member.permissionLevel);
     console.log('Consent state:', member.consentState);
-
+    
     // Get Ethereum address
     const ethIdentifier = member.accountIdentifiers.find(
       (id) => id.identifierKind === IdentifierKind.Ethereum
     );
-
+    
     if (ethIdentifier) {
       console.log('Ethereum address:', ethIdentifier.identifier);
     }
@@ -189,17 +157,15 @@ agent.on('text', async (ctx) => {
 
 ### Message history
 
-Access conversation message history:
-
 ```typescript
 agent.on('text', async (ctx) => {
   // Get all messages
   const messages = await ctx.conversation.messages();
   console.log('Total messages:', messages.length);
-
+  
   // Get recent messages
-  const recentMessages = messages.slice(-10); // Last 10 messages
-
+  const recentMessages = messages.slice(-10);
+  
   for (const msg of recentMessages) {
     console.log(`${msg.senderInboxId}: ${msg.content}`);
   }
@@ -208,13 +174,13 @@ agent.on('text', async (ctx) => {
 
 ### Custom context extensions
 
-You can extend the context in middleware:
+Extend the context in middleware:
 
 ```typescript
 const databaseMiddleware: AgentMiddleware = async (ctx, next) => {
   // Add database connection to context
   (ctx as any).db = await getDatabaseConnection();
-
+  
   try {
     await next();
   } finally {
@@ -226,12 +192,12 @@ agent.use(databaseMiddleware);
 
 agent.on('text', async (ctx: any) => {
   // Use the extended context
-  const user = await ctx.db.findUser(ctx.getSenderAddress());
+  const user = await ctx.db.findUser(await ctx.getSenderAddress());
   await ctx.sendTextReply(`Hello ${user.name}!`);
 });
 ```
 
-## Error handling with context
+## Error handling
 
 Use context information for better error handling:
 
@@ -243,10 +209,10 @@ agent.on('text', async (ctx) => {
     console.error('Error processing message:', {
       messageId: ctx.message.id,
       conversationId: ctx.conversation.id,
-      sender: ctx.getSenderAddress(),
+      sender: await ctx.getSenderAddress(),
       error: error.message,
     });
-
+    
     await ctx.sendTextReply(
       'Sorry, I encountered an error processing your message.'
     );
@@ -254,23 +220,19 @@ agent.on('text', async (ctx) => {
 });
 ```
 
-## Context in different event types
+## Event-specific context
 
-### New conversation context
+### New conversation events
 
 ```typescript
 agent.on('dm', async (ctx) => {
-  // Context for new DM conversations
   console.log('New DM started');
   console.log('Peer:', ctx.conversation.peerInboxId);
-
   await ctx.sendTextReply('Welcome to our DM! How can I help?');
 });
 
 agent.on('group', async (ctx) => {
-  // Context for new group conversations
   console.log('Added to group:', ctx.conversation.name);
-
   const members = await ctx.conversation.members();
   await ctx.sendTextReply(
     `Hello everyone! I see there are ${members.length} members here.`
@@ -278,7 +240,7 @@ agent.on('group', async (ctx) => {
 });
 ```
 
-### Unknown message context
+### Unknown message handling
 
 ```typescript
 agent.on('unknownMessage', async (ctx) => {

--- a/docs/pages/agents/concepts/context.mdx
+++ b/docs/pages/agents/concepts/context.mdx
@@ -2,7 +2,7 @@
 
 Every XMTP agent event handler receives a rich `MessageContext` object that provides access to the message, conversation, client, and powerful helper methods. This context makes it easy to build responsive agents without repetitive boilerplate code.
 
-## Message handling
+## Message context
 
 ### Type-safe content access
 
@@ -21,6 +21,9 @@ agent.on('message', async (ctx) => {
     // ctx.message.content is now typed as Reaction
     console.log('Reaction:', ctx.message.content.content);
     console.log('Reference:', ctx.message.content.reference);
+  } else if (ctx.isRemoteAttachment()) {
+    // ctx.message.content is now typed as RemoteAttachment
+    console.log('Attachment:', ctx.message.content.filename);
   }
 });
 ```
@@ -39,8 +42,6 @@ agent.on('message', async (ctx) => {
   console.log('Content type:', message.contentType);
 });
 ```
-
-## Helper methods
 
 ### sendText() and sendTextReply()
 
@@ -88,7 +89,18 @@ agent.on('text', async (ctx) => {
 });
 ```
 
-## Conversation and client access
+### getClientAddress()
+
+Get the Ethereum address of your agent:
+
+```typescript
+agent.on('text', async (ctx) => {
+  const agentAddress = ctx.getClientAddress();
+  console.log(`Agent address: ${agentAddress}`);
+});
+```
+
+## Conversation context
 
 ### Conversation operations
 
@@ -101,36 +113,29 @@ agent.on('text', async (ctx) => {
   console.log('Member count:', members.length);
   
   // Check conversation type
-  if (conversation.peerInboxId) {
-    console.log('DM with:', conversation.peerInboxId);
-  } else {
-    console.log('Group conversation');
+  if (ctx.isDm()) {
+    console.log(`DM with: ${conversation.peerInboxId}`);
+  } else if (ctx.isGroup()) {
+    console.log('Group conversation:', conversation.name);
   }
 });
 ```
 
-### Client operations
+### Consent state
+
+Check conversation consent states:
 
 ```typescript
 agent.on('text', async (ctx) => {
-  const client = ctx.client;
-  
-  // Get client address
-  const clientAddress = ctx.getClientAddress();
-  console.log('Agent address:', clientAddress);
-  
-  // Access conversations manager
-  const conversations = client.conversations;
-  
-  // Create new conversations
-  const newDM = await client.conversations.newDm('target-inbox-id');
-  const newGroup = await client.conversations.newGroup(['inbox1', 'inbox2'], {
-    groupName: 'New Group',
-  });
+  if (ctx.isAllowed) {
+    console.log('Messages allowed in this conversation');
+  } else if (ctx.isDenied) {
+    console.log('Messages denied in this conversation');
+  } else if (ctx.isUnknown) {
+    console.log('Consent state unknown');
+  }
 });
 ```
-
-## Advanced usage
 
 ### Member information
 
@@ -172,79 +177,14 @@ agent.on('text', async (ctx) => {
 });
 ```
 
-### Custom context extensions
+## Client context
 
-Extend the context in middleware:
-
-```typescript
-const databaseMiddleware: AgentMiddleware = async (ctx, next) => {
-  // Add database connection to context
-  (ctx as any).db = await getDatabaseConnection();
-  
-  try {
-    await next();
-  } finally {
-    await (ctx as any).db.close();
-  }
-};
-
-agent.use(databaseMiddleware);
-
-agent.on('text', async (ctx: any) => {
-  // Use the extended context
-  const user = await ctx.db.findUser(await ctx.getSenderAddress());
-  await ctx.sendTextReply(`Hello ${user.name}!`);
-});
-```
-
-## Error handling
-
-Use context information for better error handling:
+### address
 
 ```typescript
-agent.on('text', async (ctx) => {
-  try {
-    await processMessage(ctx);
-  } catch (error) {
-    console.error('Error processing message:', {
-      messageId: ctx.message.id,
-      conversationId: ctx.conversation.id,
-      sender: await ctx.getSenderAddress(),
-      error: error.message,
-    });
-    
-    await ctx.sendTextReply(
-      'Sorry, I encountered an error processing your message.'
-    );
-  }
-});
-```
-
-## Event-specific context
-
-### New conversation events
-
-```typescript
-agent.on('dm', async (ctx) => {
-  console.log('New DM started');
-  console.log('Peer:', ctx.conversation.peerInboxId);
-  await ctx.sendTextReply('Welcome to our DM! How can I help?');
-});
-
-agent.on('group', async (ctx) => {
-  console.log('Added to group:', ctx.conversation.name);
-  const members = await ctx.conversation.members();
-  await ctx.sendTextReply(
-    `Hello everyone! I see there are ${members.length} members here.`
-  );
-});
-```
-
-### Unknown message handling
-
-```typescript
-agent.on('unknownMessage', async (ctx) => {
-  console.log('Unknown content type:', ctx.message.contentType);
-  await ctx.sendTextReply("I received a message type I don't understand yet.");
+agent.on('start', () => {
+  console.log(`Waiting for messages...`);
+  console.log(`Address: ${agent.address}`);
+  console.log(`🔗 ${getTestUrl(agent.client)}`);
 });
 ```

--- a/docs/pages/agents/content-types/group-update.mdx
+++ b/docs/pages/agents/content-types/group-update.mdx
@@ -1,8 +1,12 @@
 # Stream group updates with XMTP
 
-Stream group metadata changes (name, description, members) in real-time using the `group_updated` native content type.
+Stream group metadata changes (name, description, members) in real-time using the `group_updated` native content type. Group updates allow you to monitor changes to group conversations including member additions/removals, name changes, and description updates.
 
-## Stream group updates
+:::tip[Quickstart]
+The `group_updated` content type is a native XMTP content type, so no additional packages need to be installed. Simply listen for the `group-update` event to receive real-time updates.
+:::
+
+## Listen for group updates
 
 ```typescript
 on('group-update', async (ctx) => {
@@ -10,11 +14,6 @@ on('group-update', async (ctx) => {
 });
 ```
 
-Conversation type will show as `group_updated`.
-
-```tsx
-const type = ctx.message.contentType;
-```
 
 ## Group update message structure
 


### PR DESCRIPTION
### Update group-update documentation in docs/pages/agents/content-types/group-update.mdx to clarify update types and align terminology per "Tweak group-update docs"
- Expand the introductory sentence to enumerate member additions/removals, name changes, and description updates in [group-update.mdx](https://github.com/xmtp/docs-xmtp-org/pull/408/files#diff-c02c26a8ee8e12836b1099aafad7c0393ff492eaa301cf4a70fa6e7a289a406a)
- Add a Quickstart tip noting `group_updated` is a native XMTP content type and to listen for the `group-update` event in [group-update.mdx](https://github.com/xmtp/docs-xmtp-org/pull/408/files#diff-c02c26a8ee8e12836b1099aafad7c0393ff492eaa301cf4a70fa6e7a289a406a)
- Rename the section header from "Stream group updates" to "Listen for group updates" in [group-update.mdx](https://github.com/xmtp/docs-xmtp-org/pull/408/files#diff-c02c26a8ee8e12836b1099aafad7c0393ff492eaa301cf4a70fa6e7a289a406a)
- Remove the note about conversation type showing as `group_updated` and the code snippet accessing `ctx.message.contentType` in [group-update.mdx](https://github.com/xmtp/docs-xmtp-org/pull/408/files#diff-c02c26a8ee8e12836b1099aafad7c0393ff492eaa301cf4a70fa6e7a289a406a)

#### 📍Where to Start
Start with the updated introduction and Quickstart callout in [group-update.mdx](https://github.com/xmtp/docs-xmtp-org/pull/408/files#diff-c02c26a8ee8e12836b1099aafad7c0393ff492eaa301cf4a70fa6e7a289a406a).

----

_[Macroscope](https://app.macroscope.com) summarized 2a1d108._