### PR TITLE
Add conversation streaming

### DIFF
--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -52,7 +52,7 @@ The `message` event fires for every incoming message, regardless of type. When u
 
 With the Agent SDK, you can listen for new conversations using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
 
-```tsx
+```ts
 // Listen for new DM conversations
 agent.on("dm", async (ctx) => {
   console.log("New DM conversation:", ctx.conversation.id);

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -56,12 +56,10 @@ With the agent-sdk, you can listen for new conversations using event handlers. T
 // Listen for new DM conversations
 agent.on("dm", async (ctx) => {
   console.log("New DM conversation:", ctx.conversation.id);
-  await ctx.sendText("Welcome to our DM!");
 });
 // Listen for new group conversations
 agent.on("group", async (ctx) => {
   console.log("New group conversation:", ctx.conversation.id);
-  await ctx.sendText("Hello group!");
 });
 ``` 
 

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -65,7 +65,7 @@ agent.on("group", async (ctx) => {
 
 ##  Handle unhandled messages
 
-The `unhandledMessage` event is triggered for messages that don't match any of the support content types.
+The `unhandledMessage` event is triggered for messages that don't match any of the [default content types](https://docs.xmtp.org/agents/content-types/content-types#standards-track-content-types).
 
 ```js [Node]
 agent.on('unhandledMessage', (ctx) => {

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -63,7 +63,17 @@ agent.on("group", async (ctx) => {
 });
 ``` 
 
-## Handle errors and failures
+##  Handle unhandled messages
+
+The `unhandledMessage` event is triggered for messages that don't match any of the support content types.
+
+```js [Node]
+agent.on('unhandledMessage', (ctx) => {
+  console.error('Unhandled message:', ctx);
+});
+```
+
+## Handle errors 
 
 The agent-sdk automatically handles connection failures and reconnections. You can listen for errors using the error handler:
 

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -50,7 +50,7 @@ The `message` event fires for every incoming message, regardless of type. When u
 
 ## Stream new group chat and DM conversations
 
-With the agent-sdk, you can listen for new conversations using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
+With the Agent SDK, you can listen for new conversations using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
 
 ```tsx
 // Listen for new DM conversations

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -48,6 +48,23 @@ The `message` event fires for every incoming message, regardless of type. When u
 
 :::
 
+## Stream new group chat and DM conversations
+
+With the agent-sdk, you can listen for new conversations using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
+
+```tsx
+// Listen for new DM conversations
+agent.on("dm", async (ctx) => {
+  console.log("New DM conversation:", ctx.conversation.id);
+  await ctx.sendText("Welcome to our DM!");
+});
+// Listen for new group conversations
+agent.on("group", async (ctx) => {
+  console.log("New group conversation:", ctx.conversation.id);
+  await ctx.sendText("Hello group!");
+});
+``` 
+
 ## Handle errors and failures
 
 The agent-sdk automatically handles connection failures and reconnections. You can listen for errors using the error handler:

--- a/docs/pages/agents/build-agents/stream.mdx
+++ b/docs/pages/agents/build-agents/stream.mdx
@@ -2,7 +2,7 @@
 
 ## Stream messages
 
-With the agent-sdk, you can listen for different types of messages using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
+You can listen for different types of messages using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
 
 ```js [Node]
 // Listen for text messages
@@ -50,22 +50,22 @@ The `message` event fires for every incoming message, regardless of type. When u
 
 ## Stream new group chat and DM conversations
 
-With the Agent SDK, you can listen for new conversations using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
+You can listen for new conversations using event handlers. The agent automatically handles streaming and provides simple event-based APIs.
 
 ```ts
 // Listen for new DM conversations
-agent.on("dm", async (ctx) => {
-  console.log("New DM conversation:", ctx.conversation.id);
+agent.on('dm', async (ctx) => {
+  console.log('New DM conversation:', ctx.conversation.id);
 });
 // Listen for new group conversations
-agent.on("group", async (ctx) => {
-  console.log("New group conversation:", ctx.conversation.id);
+agent.on('group', async (ctx) => {
+  console.log('New group conversation:', ctx.conversation.id);
 });
-``` 
+```
 
-##  Handle unhandled messages
+## Handle unhandled messages
 
-The `unhandledMessage` event is triggered for messages that don't match any of the [default content types](https://docs.xmtp.org/agents/content-types/content-types#standards-track-content-types).
+The `unhandledMessage` event is triggered for messages that don't match any of the [default content types](/agents/content-types/content-types#standards-track-content-types).
 
 ```js [Node]
 agent.on('unhandledMessage', (ctx) => {
@@ -73,9 +73,9 @@ agent.on('unhandledMessage', (ctx) => {
 });
 ```
 
-## Handle errors 
+## Handle errors
 
-The agent-sdk automatically handles connection failures and reconnections. You can listen for errors using the error handler:
+The XMTP Agent SDK automatically handles connection failures and reconnections. You can listen for errors using the error handler:
 
 ```js [Node]
 // Handle uncaught errors


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update agents streaming documentation to add conversation streaming examples for DM and group chats in [stream.mdx](https://github.com/xmtp/docs-xmtp-org/pull/409/files#diff-4d1e7d80f4ba047848f804ad3e49238ea02c9e8d9d6dff87fb2fbcc79f41dedc)
Update the streaming documentation to cover conversation streaming scenarios with concrete TypeScript and Node examples, adjust section titles and wording, and add guidance for unhandled messages. The changes are contained in [stream.mdx](https://github.com/xmtp/docs-xmtp-org/pull/409/files#diff-4d1e7d80f4ba047848f804ad3e49238ea02c9e8d9d6dff87fb2fbcc79f41dedc). • Replace the previous errors and failures section with a section describing streaming for new group chat and DM conversations, including TypeScript examples for handling `dm` and `group` events
• Add a section documenting the `unhandledMessage` event with a Node handler example
• Rename the errors section to “Handle errors” and update wording to reference “XMTP Agent SDK” while retaining the existing error handler example
• Update the introductory sentence to remove “With the agent-sdk” phrasing

#### 📍Where to Start
Start with the new conversation streaming sections in [stream.mdx](https://github.com/xmtp/docs-xmtp-org/pull/409/files#diff-4d1e7d80f4ba047848f804ad3e49238ea02c9e8d9d6dff87fb2fbcc79f41dedc), focusing on the TypeScript examples for `dm` and `group` events and the `unhandledMessage` handler example.

----

_[Macroscope](https://app.macroscope.com) summarized c0f1aa5._
<!-- Macroscope's pull request summary ends here -->