### PR TITLE
Document custom content types for agents

### DIFF
--- a/docs/pages/agents/content-types/content-types.mdx
+++ b/docs/pages/agents/content-types/content-types.mdx
@@ -65,3 +65,7 @@ Here are standards-track content types that you can review, test, and adopt in y
 - [Reply content type](/agents/content-types/replies): Use a reply to send a direct response to a specific message in a conversation. Users can select and reply to a particular message instead of sending a new one.
 - [Onchain transaction reference content type](/agents/content-types/transaction-refs): Use to send references to onchain transactions, such as crypto payments.
 - [Onchain transaction content type](/agents/content-types/transactions): Use to support sending transactions to a wallet for execution.
+
+## Custom content types
+
+Custom content types allow you to define your own schemas for messages that go beyond what is covered by standard or standards-track types. These are useful for experiments, domain-specific features, or app-specific behaviors.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add 'Custom content types' section to agents content types documentation to document custom content types for agents
Add a new section to the agents content types documentation describing custom content types and their purpose within message schemas.

- Introduce a 'Custom content types' section outlining user-defined schemas beyond standard or standards-track types in [content-types.mdx](https://github.com/xmtp/docs-xmtp-org/pull/414/files#diff-42734fd08fb2f113c13a53cadd5ea9c0bdfd90f0bb230b02fa567a453c5ef40b)

#### 📍Where to Start
Start with the new 'Custom content types' section in [content-types.mdx](https://github.com/xmtp/docs-xmtp-org/pull/414/files#diff-42734fd08fb2f113c13a53cadd5ea9c0bdfd90f0bb230b02fa567a453c5ef40b).

----

_[Macroscope](https://app.macroscope.com) summarized 78ab9d4._
<!-- Macroscope's pull request summary ends here -->