### PR TITLE
Local database + warning

### DIFF
--- a/docs/pages/agents/build-agents/local-database.mdx
+++ b/docs/pages/agents/build-agents/local-database.mdx
@@ -7,7 +7,12 @@ XMTP creates local database files in the `dbPath` (default is `'/'`) directory. 
 **Database file naming:**
 Database files follow this pattern: `xmtp-{environment}-{inbox-id}.db3`
 
-Example: `xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3`
+Example:
+ 
+```bash
+xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3
+```
+
 - `xmtp-production`: Environment prefix
 - `62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688`: Inbox ID (Your xmtp identity)
 - `.db3`: SQLite database file extension

--- a/docs/pages/agents/build-agents/local-database.mdx
+++ b/docs/pages/agents/build-agents/local-database.mdx
@@ -1,14 +1,15 @@
-# Manage agent installations
+# Manage agent local database files and installations
 
-## Understanding local database files
+## Understand local database files
 
 XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history.
 
 **Database file naming:**
+
 Database files follow this pattern: `xmtp-{environment}-{inbox-id}.db3`
 
 Example:
- 
+
 ```bash
 xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3
 ```
@@ -18,21 +19,23 @@ xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688
 - `.db3`: SQLite database file extension
 
 **Keep these files between deployments:**
+
 - Deleting them creates a new installation each time
 - Reusing them maintains the same installation
 - Each inbox can have up to 10 installations
 
 **For production deployments:**
+
 - Use persistent volumes (Railway volumes, Render disks, etc.)
 - The database needs to persist across restarts
 
-:::warning 
+:::warning[Note]
 
-**Note:** If you hit the 10 installation limit, use this [script](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations).
+If you hit the 10 installation limit, use [this script](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations) to revoke installations.
 
 :::
 
-## Understanding installations
+## Understand installations
 
 With XMTP, your agent has an inbox that you use to access its messages. An inbox can have multiple identities associated with it. Your agent's identity has a kind (such as EOA or SCW) and a string, which in the case of an EOA or SCW, is an Ethereum address. All messages associated with your agent's identity flow through the one inbox ID.
 

--- a/docs/pages/agents/concepts/installations.mdx
+++ b/docs/pages/agents/concepts/installations.mdx
@@ -5,7 +5,7 @@
 XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history.
 
 **Database file naming:**
-Database files follow this pattern: `xmtp-{environment}-{wallet-address-hash}.db3`
+Database files follow this pattern: `xmtp-{environment}-{inbox-id}.db3`
 
 Example: `xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3`
 - `xmtp-production`: Environment prefix
@@ -15,7 +15,7 @@ Example: `xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792
 **Keep these files between deployments:**
 - Deleting them creates a new installation each time
 - Reusing them maintains the same installation
-- Each wallet can have up to 10 installations
+- Each inbox can have up to 10 installations
 
 **For production deployments:**
 - Use persistent volumes (Railway volumes, Render disks, etc.)

--- a/docs/pages/agents/concepts/installations.mdx
+++ b/docs/pages/agents/concepts/installations.mdx
@@ -1,5 +1,34 @@
 # Manage agent installations
 
+## Understanding local database files
+
+XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history.
+
+**Database file naming:**
+Database files follow this pattern: `xmtp-{environment}-{wallet-address-hash}.db3`
+
+Example: `xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3`
+- `xmtp-production`: Environment prefix
+- `62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688`: Inbox ID (Your xmtp identity)
+- `.db3`: SQLite database file extension
+
+**Keep these files between deployments:**
+- Deleting them creates a new installation each time
+- Reusing them maintains the same installation
+- Each wallet can have up to 10 installations
+
+**For production deployments:**
+- Use persistent volumes (Railway volumes, Render disks, etc.)
+- The database needs to persist across restarts
+
+:::warning 
+
+**Note:** If you hit the 10 installation limit, use this [script](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations).
+
+:::
+
+## Understanding installations
+
 With XMTP, your agent has an inbox that you use to access its messages. An inbox can have multiple identities associated with it. Your agent's identity has a kind (such as EOA or SCW) and a string, which in the case of an EOA or SCW, is an Ethereum address. All messages associated with your agent's identity flow through the one inbox ID.
 
 When you deploy your agent to a platform, you create an XMTP client for your agent. The client creates an inbox ID and installation ID associated with your agent's identity. Each time you deploy your agent to a new platform, it creates a new installation for the same inbox ID. The installation represents your agent running on that specific platform.

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -17,7 +17,7 @@ XMTP creates local database files in the `dbPath` (default is '/') directory. Th
 - Use persistent volumes (Railway volumes, Render disks, etc.)
 - The database needs to persist across restarts
 
-**Note:** If you hit the 10 installation limit, you can revoke unused installations. See the revoke installations section in the [xmtp-agent-examples](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations) for details.
+**Note:** If you hit the 10 installation limit, use this [script](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations).
 
 :::
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -4,7 +4,9 @@ Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sd
 
 
 
-:::warning Understanding local database files
+:::warning 
+
+### Understanding local database files
 
 XMTP creates local database files in the `dbPath` (default is '/') directory. These files store your device identity and message history.
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -58,9 +58,7 @@ await agent.start();
 
 :::danger
 
-XMTP creates local database files that must persist between deployments. Without persistent volumes, each deployment creates a new installation.
-
-**You're limited to 10 installations per inbox.** Use persistent volumes (Railway volumes, Render disks, etc.) to avoid hitting this limit.
+XMTP creates local database files that must persist between deployments - without persistent volumes, each deployment creates a new installation and you're limited **to 10 installations per inbox**.
 
 :::
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -58,7 +58,7 @@ await agent.start();
 
 :::danger
 
-XMTP creates local database files that must persist between deployments - without persistent volumes, each deployment creates a new installation and you're limited **to 10 installations per inbox**.
+XMTP creates local database files that must persist between deployments - without persistent volumes, each deployment creates a new installation and you're **limited to 10 installations per inbox**.
 
 :::
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -56,6 +56,14 @@ await agent.start();
 
 ### Local database
 
+:::danger
+
+XMTP creates local database files that must persist between deployments. Without persistent volumes, each deployment creates a new installation.
+
+**You're limited to 10 installations per inbox.** Use persistent volumes (Railway volumes, Render disks, etc.) to avoid hitting this limit.
+
+:::
+
 XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history. To learn more, see [Manage agent local database](/agents/build-agents/local-database).
 
 ### Set environment variables

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -4,9 +4,7 @@ Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sd
 
 
 
-:::warning
-
-Understanding local database files
+:::warning Understanding local database files
 
 XMTP creates local database files in the `dbPath` (default is '/') directory. These files store your device identity and message history.
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -2,6 +2,26 @@
 
 Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk) to build agents that interact with the XMTP network.
 
+
+
+:::warning
+
+## Understanding local database files
+
+XMTP creates local database files in the `.data/xmtp/` directory. These files store your installation identity and message history.
+
+**Keep these files between deployments:**
+- Deleting them creates a new installation each time
+- Reusing them maintains the same installation
+- Each wallet can have up to 10 installations
+
+**For production deployments:**
+- Use persistent volumes (Railway volumes, Render disks, etc.)
+- The database needs to persist across restarts
+- Add `.data/` to `.gitignore` to keep it out of version control
+
+**Note:** If you hit the 10 installation limit, you can revoke unused installations. See the installation management guide for details.
+
 ## Installation
 
 Install `@xmtp/agent-sdk` as a dependency in your project.

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -8,7 +8,7 @@ Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sd
 
 ## Understanding local database files
 
-XMTP creates local database files in the `.data/xmtp/` directory. These files store your installation identity and message history.
+XMTP creates local database files in the `dbPath` (default is '/') directory. These files store your device identity and message history.
 
 **Keep these files between deployments:**
 - Deleting them creates a new installation each time
@@ -18,9 +18,8 @@ XMTP creates local database files in the `.data/xmtp/` directory. These files st
 **For production deployments:**
 - Use persistent volumes (Railway volumes, Render disks, etc.)
 - The database needs to persist across restarts
-- Add `.data/` to `.gitignore` to keep it out of version control
 
-**Note:** If you hit the 10 installation limit, you can revoke unused installations. See the installation management guide for details.
+**Note:** If you hit the 10 installation limit, you can revoke unused installations. See the revoke installations section in the [xmtp-agent-examples](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations) for details.
 
 ## Installation
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -8,7 +8,15 @@ Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sd
 
 ### Understanding local database files
 
-XMTP creates local database files in the `dbPath` (default is '/') directory. These files store your device identity and message history.
+XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history.
+
+**Database file naming:**
+Database files follow this pattern: `xmtp-{environment}-{wallet-address-hash}.db3`
+
+Example: `xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3`
+- `xmtp-production`: Environment prefix
+- `62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688`: Inbox ID (Your xmtp identity)
+- `.db3`: SQLite database file extension
 
 **Keep these files between deployments:**
 - Deleting them creates a new installation each time

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -2,35 +2,6 @@
 
 Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sdk) to build agents that interact with the XMTP network.
 
-
-
-:::warning 
-
-### Understanding local database files
-
-XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history.
-
-**Database file naming:**
-Database files follow this pattern: `xmtp-{environment}-{wallet-address-hash}.db3`
-
-Example: `xmtp-production-62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688.db3`
-- `xmtp-production`: Environment prefix
-- `62ff7c82fa2e8c9a0a0c9e58e7247704d102c41e5ceb4dc3573792d7d7a1c688`: Inbox ID (Your xmtp identity)
-- `.db3`: SQLite database file extension
-
-**Keep these files between deployments:**
-- Deleting them creates a new installation each time
-- Reusing them maintains the same installation
-- Each wallet can have up to 10 installations
-
-**For production deployments:**
-- Use persistent volumes (Railway volumes, Render disks, etc.)
-- The database needs to persist across restarts
-
-**Note:** If you hit the 10 installation limit, use this [script](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations).
-
-:::
-
 ## Installation
 
 Install `@xmtp/agent-sdk` as a dependency in your project.
@@ -82,6 +53,10 @@ agent.on('start', () => {
 
 await agent.start();
 ```
+
+### Local database
+
+XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history. To learn more, see [Manage agent local database](/agents/build-agents/local-database).
 
 ### Set environment variables
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -58,7 +58,7 @@ await agent.start();
 
 :::danger
 
-XMTP creates local database files that must persist between deployments - without persistent volumes, each deployment creates a new installation and you're **limited to 10 installations per inbox**.
+Each time you run your agent, XMTP creates local database files that must be **kept between restarts and between deployments** - without persistent volumes, each restart creates a new installation and you're **limited to 10 installations per inbox**.
 
 :::
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -6,7 +6,7 @@ Use the [XMTP Agent SDK](https://github.com/xmtp/xmtp-js/tree/main/sdks/agent-sd
 
 :::warning
 
-## Understanding local database files
+Understanding local database files
 
 XMTP creates local database files in the `dbPath` (default is '/') directory. These files store your device identity and message history.
 
@@ -20,6 +20,8 @@ XMTP creates local database files in the `dbPath` (default is '/') directory. Th
 - The database needs to persist across restarts
 
 **Note:** If you hit the 10 installation limit, you can revoke unused installations. See the revoke installations section in the [xmtp-agent-examples](https://github.com/ephemeraHQ/xmtp-agent-examples?tab=readme-ov-file#revoke-installations) for details.
+
+:::
 
 ## Installation
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -58,11 +58,11 @@ await agent.start();
 
 :::danger
 
-Each time you run your agent, XMTP creates local database files that must be **kept between restarts and between deployments** - without persistent volumes, each restart creates a new installation and you're **limited to 10 installations per inbox**.
+Each time you run your agent, XMTP creates local database files that must be **kept between restarts and between deployments**. Without persistent volumes, each restart creates a new installation and you're **limited to 10 installations per inbox**.
 
 :::
 
-XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history. To learn more, see [Manage agent local database](/agents/build-agents/local-database).
+XMTP creates local database files in the `dbPath` (default is `'/'`) directory. These files store your device identity and message history. To learn more, see [Manage agent local database files and installations](/agents/build-agents/local-database).
 
 ### Set environment variables
 

--- a/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
+++ b/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
@@ -12,7 +12,7 @@ The first time someone uses your app with an identity they've never used with an
 
 The installation concepts described in this document apply to both inbox apps and agents. However, the context differs. **Inbox apps** typically have installations across different devices and apps (phone, laptop, different XMTP apps), while **agents** typically have installations across different deployment environments (local development, Railway, production servers).
 
-For more agent-specific guidance, see [Manage agent installations](/agents/concepts/installations).
+For more agent-specific guidance, see [Manage agent local database](/agents/build-agents/local-database).
 :::
 
 The client creates an inbox ID and installation ID associated with the identity. By default, this identity is designated as the recovery identity. A recovery identity will always have the same inbox ID and cannot be reassigned to a different inbox ID.

--- a/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
+++ b/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
@@ -12,7 +12,7 @@ The first time someone uses your app with an identity they've never used with an
 
 The installation concepts described in this document apply to both inbox apps and agents. However, the context differs. **Inbox apps** typically have installations across different devices and apps (phone, laptop, different XMTP apps), while **agents** typically have installations across different deployment environments (local development, Railway, production servers).
 
-For more agent-specific guidance, see [Manage agent local database](/agents/build-agents/local-database).
+For more agent-specific guidance, see [Manage agent local database files and installations](/agents/build-agents/local-database).
 :::
 
 The client creates an inbox ID and installation ID associated with the identity. By default, this identity is designated as the recovery identity. A recovery identity will always have the same inbox ID and cannot be reassigned to a different inbox ID.

--- a/docs/pages/protocol/identity.mdx
+++ b/docs/pages/protocol/identity.mdx
@@ -55,6 +55,6 @@ Each identity can authenticate new installations:
 
 ## Identity actions
 
-To learn how to build agents with identity actions, see [Manage XMTP inboxes, identities, and installations](/agents/concepts/installations).
+To learn how to build agents with identity actions, see [Manage XMTP inboxes, identities, and installations](/agents/build-agents/local-database).
 
 To learn how to build chat apps with identity actions, see [Manage XMTP inboxes, identities, and installations](/chat-apps/core-messaging/manage-inboxes).

--- a/docs/pages/protocol/identity.mdx
+++ b/docs/pages/protocol/identity.mdx
@@ -55,6 +55,6 @@ Each identity can authenticate new installations:
 
 ## Identity actions
 
-To learn how to build agents with identity actions, see [Manage XMTP inboxes, identities, and installations](/agents/build-agents/local-database).
+To learn how to build agents with identity actions, see [Manage agent local database files and installations](/agents/build-agents/local-database).
 
 To learn how to build chat apps with identity actions, see [Manage XMTP inboxes, identities, and installations](/chat-apps/core-messaging/manage-inboxes).

--- a/shared-sidebar.config.ts
+++ b/shared-sidebar.config.ts
@@ -30,6 +30,10 @@ export const sidebarConfig = {
           link: "/agents/build-agents/create-a-client",
         },
         {
+          text: "Local database",
+          link: "/agents/build-agents/local-database",
+        },
+        {
           text: "Stream messages",
           link: "/agents/build-agents/stream",
         },
@@ -54,10 +58,6 @@ export const sidebarConfig = {
         {
           text: "Identity",
           link: "/agents/concepts/identity",
-        },
-        {
-          text: "Installations",
-          link: "/agents/concepts/installations",
         },
         {
           text: "Events",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add local database guidance and warning across docs and relocate installations content to /agents/build-agents/local-database with a 10-installation limit per inbox
Introduce a dedicated local database and installations documentation page and update related references across the docs. The changes add persistence guidance, filename conventions, and a warning about installation limits, and update the sidebar navigation accordingly.

- Create and populate the local database and installations page at [local-database.mdx](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-0857e349329aa4d866669e0ce14dc5257e12f67cf2043ce2f63f780ec6a2d64e), including `dbPath` defaults, filename pattern details, persistence requirements, production deployment notes, and a link to a revocation script
- Insert a warning and brief `dbPath` explanation in the quickstart at [build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1), referencing the new local database page
- Update cross-references in [manage-inboxes.mdx](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-47b385d9203d073787193f689ad5a37f062985c5cc9bf0d7291620b0d64222d2) and [identity.mdx](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-052c6b79575584ec3a731fb4725d38960215d4f1a236998e87a351dc301f62bd) to point to the new local database page
- Adjust the docs sidebar in [shared-sidebar.config.ts](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-0e509f89309309d8f1f8e3c9fce55b0723f108444b3e29b0157de22be0252ab5) by adding the Local database item under Build agents and removing the Installations item under Core concepts

#### 📍Where to Start
Start with the new local database documentation in [local-database.mdx](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-0857e349329aa4d866669e0ce14dc5257e12f67cf2043ce2f63f780ec6a2d64e) to review the added sections, then confirm cross-references and sidebar changes in [shared-sidebar.config.ts](https://github.com/xmtp/docs-xmtp-org/pull/417/files#diff-0e509f89309309d8f1f8e3c9fce55b0723f108444b3e29b0157de22be0252ab5).

----

_[Macroscope](https://app.macroscope.com) summarized fd2a004._
<!-- Macroscope's pull request summary ends here -->