### PR TITLE
Surface withdrawal waiting periods

### DIFF
--- a/docs/pages/fund-agents-apps/fund-your-app.mdx
+++ b/docs/pages/fund-agents-apps/fund-your-app.mdx
@@ -266,7 +266,7 @@ To get USDC on Base Sepolia for use with XMTP testnet, you can use [https://fauc
 
 :::warning
 
-Once you self-fund a payer wallet, only the payer wallet can [withdraw](#step-6-withdraw-and-claim-funds) USDC from the messaging and gas fee allowance.
+Once you fund a payer wallet, only the payer wallet can [withdraw](#step-6-withdraw-and-claim-funds) USDC from the messaging and gas fee allowance.
 
 - Withdrawals from the Payer Registry will be available after 48 hours and require a second transaction to claim.
 - Withdrawals from the XMTP App Chain that require bridging to Base will be available after 7 days and require a second transaction to claim.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update fund-your-app docs to surface withdrawal waiting periods and clarify payer-only USDC withdrawals with 48-hour Payer Registry and 7-day XMTP App Chain bridged timelines
The fund-your-app documentation is updated to clarify withdrawal rules and timing for USDC allowances. The changes add a warning in Step 4 stating that only the payer wallet can withdraw from both messaging and gas fee allowances, and specify distinct availability windows and claim requirements for Payer Registry versus XMTP App Chain withdrawals. Step 6 is revised to state withdrawals apply to both allowances and replaces generic timing bullets with explicit durations and the need for a second claim transaction in both cases. See [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/432/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb).

#### 📍Where to Start
Start with the updated admonition and Step 6 sections in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/432/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb).



#### Changes since #432 opened

- Modified warning text in funding documentation [ba6de94]
----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized ba6de94.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->