### PR TITLE
Add agent configuration guide

### DIFF
--- a/docs/pages/fund-agents-apps/configure-agent.mdx
+++ b/docs/pages/fund-agents-apps/configure-agent.mdx
@@ -1,0 +1,63 @@
+# Configure your agent
+
+Your agent needs to pay for the messages it sends on the XMTP network. To get started, you'll need.
+
+1. An agent built using our Node or Agent SDK
+2. A payer wallet that has been [funded through the XMTP Funding Portal](./fund-your-app.mdx)
+
+## Setup your Signer
+
+When you create a client, you already specify a `Signer` that is used to link your XMTP identity to a wallet. You can choose to use the same `Signer` to pay for messages, or create a new one purely for this purpose.
+
+This Signer must be of type `eoa`. The `messagePayer` may not be a smart contract wallet, since the signatures need to be able to be verified offchain.
+
+:::code-group
+
+```js [Agent]
+import { Agent } from '@xmtp/agent-sdk';
+import { createSigner, createUser } from '@xmtp/agent-sdk/user';
+import { getRandomValues } from 'node:crypto';
+
+// Option 1: Create a local user + signer
+const user = createUser('0xprivateKey');
+const xmtpChainRPCUrl = 'https://xmtp-testnet.my-rpc-provider.com/1234'
+const baseRPCUrl = 'https://base-sepolia.my-rpc-provider.com/1234'
+const signer = createSigner(user);
+
+const agent = await Agent.create(signer, {
+  env: 'testnet', // or 'production'
+  dbEncryptionKey: getRandomValues(new Uint8Array(32)), // save it for later
+  rpcUrls: {
+    xmtp: xmtpChainRPCUrl,
+    base: baseRPCUrl,
+  },
+  messagePayer: signer, // use the same signer to pay for messages or use a different wallet
+});
+```
+:::
+
+## Specify a RPC URL
+
+In order to connect to the XMTP Chain, your client needs to set a blockchain RPC URL to a provider that supports XMTP, as well as a RPC URL for Base (or Base Sepolia for testnet).
+
+For example, you can use [Alchemy](https://alchemy.com/) and create an app with XMTP and Base enabled.
+
+:::code-group
+```js [Agent]
+import { Agent } from '@xmtp/agent-sdk';
+
+const user = createUser('0xprivateKey');
+const xmtpChainRPCUrl = 'https://xmtp-testnet.my-rpc-provider.com/1234'
+const baseRPCUrl = 'https://base-sepolia.my-rpc-provider.com/1234'
+const signer = createSigner(user);
+
+const agent = await Agent.create(signer, {
+  // ... other config options
+  rpcUrls: {
+    xmtp: xmtpChainRPCUrl,
+    base: baseRPCUrl,
+  }
+})
+````
+
+:::


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->

<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->

<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->

### Add XMTP agent configuration guide to document how to configure an agent to pay for messages in [configure-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/451/files#diff-7e173e01292bdd1d77e34d402e7b1939ec988d2f2257c38d15982fdcfc2223f6)

Add a new documentation page that outlines XMTP agent setup for message payments, including signer and payer requirements, RPC configuration, and a TypeScript example using `Agent.create`.

- Add configuration steps and constraints for signer (EOA only) and `messagePayer`
- Specify XMTP Chain RPC URL requirements and environment options
- Provide TypeScript example for `Agent.create` with `signer`, `rpcUrls.xmtp`, `dbEncryptionKey`, `env`, and `messagePayer` in [configure-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/451/files#diff-7e173e01292bdd1d77e34d402e7b1939ec988d2f2257c38d15982fdcfc2223f6)

#### 📍Where to Start

Start with the new documentation content in [configure-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/451/files#diff-7e173e01292bdd1d77e34d402e7b1939ec988d2f2257c38d15982fdcfc2223f6), focusing on the `Agent.create` example and the signer and `messagePayer` requirements section.

---

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 Macroscope summarized a2e048f. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues

No issues evaluated.

</details>

\<!-- MACROSCOPE_FOOTER_END -->\\\<!-- Macroscope's pull request summary ends here -->