### PR TITLE
Acknowledge USDC for fees

### DIFF
--- a/docs/pages/fund-agents-apps/calculate-fees.mdx
+++ b/docs/pages/fund-agents-apps/calculate-fees.mdx
@@ -47,11 +47,11 @@ To support a decentralized and sustainable network, XMTP operates on a usage-bas
 
 :::tip[How to estimate your costs]
 
-Network fees are estimated to cost $5 per 100,000 chat messages, inclusive of all fee types. 
+Network fees are estimated to cost $5 per 100,000 chat messages, inclusive of all fee types.
 
-- **If you know your message volume**, multiply by $5 per 100,000 to estimate your costs. For example, if your app or agent's message volume is 100,000 messages per day, your estimated cost is $5 per day or $150 per month. 
+- **If you know your message volume**, multiply by $5 per 100,000 to estimate your costs. For example, if your app or agent's message volume is 100,000 messages per day, your estimated cost is $5 per day or $150 per month.
 
-- **If you have not launched messaging**, we recommend assuming each monthly active messaging user sends 500 messages per month. For example, 10,000 monthly active messaging users sending an average of 500 messages per month per user will generate an estimated $250 per month in fees. 
+- **If you have not launched messaging**, we recommend assuming each monthly active messaging user sends 500 messages per month. For example, 10,000 monthly active messaging users sending an average of 500 messages per month per user will generate an estimated $250 per month in fees.
 
 :::
 
@@ -127,11 +127,11 @@ Collected gas fees are paid directly to the XMTP App Chain. Fees are used to mai
 
 ## Calculate estimated XMTP fees
 
-As a rough estimate, an app or agent can expect to pay about **$5 per 100,000 messages** ($0.00005/message). This all-in fee for typical usage is based on the following key assumptions: 
+As a rough estimate, an app or agent can expect to pay about **$5 per 100,000 messages** ($0.00005/message). This all-in fee for typical usage is based on the following key assumptions:
 
-- A 95/5 split between messaging and gas fees. Meaning, for every $5 in total fees: 
-  - $4.75 is for XMTP Broadcast Network messaging fees 
-  - $0.25 is for XMTP App Chain gas fees 
+- A 95/5 split between messaging and gas fees. Meaning, for every $5 in total fees:
+  - $4.75 is for XMTP Broadcast Network messaging fees
+  - $0.25 is for XMTP App Chain gas fees
 - An average message size of 1 KB (1024 bytes).
 - A message retention period of 90 days.
 - Normal network conditions (no congestion fees).
@@ -174,6 +174,6 @@ The network is designed for sustainability, not to accumulate profit. Fee revenu
 
 The messaging fee per message is expected to step down as the network achieves and sustains global message volume milestones. For example, at a volume of 1 billion messages per month, revenue is expected to cover operational costs.
 
-The specific schedule for these milestones is managed by protocol governance, with a current effective floor fee target of $5 per 100,000 messages. 
+The specific schedule for these milestones is managed by protocol governance, with a current effective floor fee target of $5 per 100,000 messages.
 
 While the system is designed for fees to decrease over time, the global messaging fee can rise if network volume drops significantly, ensuring node operator sustainability.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Clarify USDC as the currency for XMTP network fees in [calculate-fees.mdx](https://github.com/xmtp/docs-xmtp-org/pull/458/files#diff-589d44f946b7d4dc0f3a19af2168d9132a6d32c449599cc87a3089d3c77ef927)
Update the fee documentation to state fees are paid in USDC and adjust references from dollars to USDC.

- Specify USDC as the denomination for all XMTP network fees in [calculate-fees.mdx](https://github.com/xmtp/docs-xmtp-org/pull/458/files#diff-589d44f946b7d4dc0f3a19af2168d9132a6d32c449599cc87a3089d3c77ef927)
- Revise examples and text to replace "dollars" with "USDC" while retaining numeric estimates
- Apply minor punctuation and spacing edits

#### 📍Where to Start
Start with the currency denomination section in [calculate-fees.mdx](https://github.com/xmtp/docs-xmtp-org/pull/458/files#diff-589d44f946b7d4dc0f3a19af2168d9132a6d32c449599cc87a3089d3c77ef927).



#### Changes since #458 opened

- Removed trailing whitespace from documentation content [6ada2c7]
----
<!-- MACROSCOPE_FOOTER_START -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6ada2c7.

<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->