### PR TITLE
Document self-removal

### DIFF
--- a/docs/pages/chat-apps/core-messaging/group-permissions.mdx
+++ b/docs/pages/chat-apps/core-messaging/group-permissions.mdx
@@ -361,6 +361,8 @@ try await group.removeMembers(inboxIds: [inboxId])
 
 A member can remove themselves from a group by calling `leaveGroup()`. After leaving, the group becomes inactive for that member.
 
+A member who is the super admin of the group cannot leave the group. By default, the group creator is a super admin.
+
 :::code-group
 
 ```tsx [React Native]


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add documentation for member self-removal by calling `leaveGroup()` and note super admin cannot leave in [group-permissions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/481/files#diff-0ab0c719c2bdce81b901abdae7070bb0304c2814ed3a9a8892d044519a9b178c)
Add a "Leave a group" section with React Native, Kotlin, and Swift examples showing `leaveGroup()`, followed by group sync and `isActive` check, and document the super admin restriction.

#### 📍Where to Start
Start with the new "Leave a group" section in [group-permissions.mdx](https://github.com/xmtp/docs-xmtp-org/pull/481/files#diff-0ab0c719c2bdce81b901abdae7070bb0304c2814ed3a9a8892d044519a9b178c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f9fc59f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->