### PR TITLE
Update GH org URLs

### DIFF
--- a/docs/pages/agents/build-agents/create-a-client.mdx
+++ b/docs/pages/agents/build-agents/create-a-client.mdx
@@ -46,7 +46,7 @@ console.log(`Wallet key: ${walletKey}`);
 console.log(`Encryption key: ${encryptionKeyHex}`);
 ```
 
-Use this [script to generate](https://github.com/ephemeraHQ/xmtp-agent-examples) random XMTP keys:
+Use this [script to generate](https://github.com/xmtplabs/xmtp-agent-examples) random XMTP keys:
 
 ```bash
 yarn gen:keys

--- a/docs/pages/agents/build-agents/groups.mdx
+++ b/docs/pages/agents/build-agents/groups.mdx
@@ -3,7 +3,7 @@
 Group chats can have metadata like names, descriptions, and images to help users identify them. You can set metadata when [creating a group chat](/agents/build-agents/create-conversations) or update it later.
 
 :::tip[Quickstart]
-To learn more, see the [Gated group example](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-gated-group) in the xmtp-agents-examples repo.
+To learn more, see the [Gated group example](https://github.com/xmtplabs/xmtp-agent-examples/tree/main/examples/xmtp-gated-group) in the xmtp-agents-examples repo.
 :::
 
 ## Group metadata

--- a/docs/pages/agents/build-agents/local-database.mdx
+++ b/docs/pages/agents/build-agents/local-database.mdx
@@ -87,7 +87,7 @@ Revoking an installation is permanent. You cannot recover access to a revoked in
 :::
 
 1. Web tool: [xmtp.chat/inbox-tools](https://xmtp.chat/inbox-tools)
-2. CLI script: [revokeInstallations.ts](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/eb1dc17e99570b77de906ba0d58094586a4af844/scripts/revokeInstallations.ts) in the xmtp-agent-examples repo
+2. CLI script: [revokeInstallations.ts](https://github.com/xmtplabs/xmtp-agent-examples/blob/eb1dc17e99570b77de906ba0d58094586a4af844/scripts/revokeInstallations.ts) in the xmtp-agent-examples repo
 
 ```bash
 yarn revoke <inbox-id> <installations-to-exclude>

--- a/docs/pages/agents/content-types/attachments.mdx
+++ b/docs/pages/agents/content-types/attachments.mdx
@@ -3,7 +3,7 @@
 Use the remote attachment content type (`RemoteAttachmentCodec`) and a storage provider to send one remote attachment of any size.
 
 ::::tip[Quickstart]
-To learn more, see the [Attachment example](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-attachments) in the xmtp-agent-examples repo.
+To learn more, see the [Attachment example](https://github.com/xmtplabs/xmtp-agent-examples/tree/main/examples/xmtp-attachments) in the xmtp-agent-examples repo.
 ::::
 
 ## Install the package

--- a/docs/pages/agents/content-types/reactions.mdx
+++ b/docs/pages/agents/content-types/reactions.mdx
@@ -3,7 +3,7 @@
 Use the reaction content type to support reactions with your agent. A reaction is a quick and often emoji-based way to respond to a message. Reactions are usually limited to a predefined set of emojis or symbols provided by the chat app.
 
 :::tip[Quickstart]
-To learn more, see the [Reaction example](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-thinking-reaction) in the xmtp-agents-examples repo.
+To learn more, see the [Reaction example](https://github.com/xmtplabs/xmtp-agent-examples/tree/main/examples/xmtp-thinking-reaction) in the xmtp-agents-examples repo.
 :::
 
 ## Install the package

--- a/docs/pages/agents/content-types/transaction-refs.mdx
+++ b/docs/pages/agents/content-types/transaction-refs.mdx
@@ -3,7 +3,7 @@
 This package provides an XMTP content type to support onchain transaction references. It is a reference to an onchain transaction sent as a message. This content type facilitates sharing transaction hashes or IDs, thereby providing a direct link to onchain activities. Transaction references serve to display transaction details, facilitating the sharing of onchain activities, such as token transfers, between users.
 
 :::tip[Quickstart]
-To learn more, see the [Transaction reference example](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) in the xmtp-agent-examples repo.
+To learn more, see the [Transaction reference example](https://github.com/xmtplabs/xmtp-agent-examples/tree/main/examples/xmtp-transactions) in the xmtp-agent-examples repo.
 :::
 
 ## Install the package

--- a/docs/pages/agents/content-types/transactions.mdx
+++ b/docs/pages/agents/content-types/transactions.mdx
@@ -3,7 +3,7 @@
 This package provides an XMTP content type to support sending transactions to a wallet for execution.
 
 ::::tip[Quickstart]
-To learn more, see the [Transactions example](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions) in the xmtp-agent-examples repo.
+To learn more, see the [Transactions example](https://github.com/xmtplabs/xmtp-agent-examples/tree/main/examples/xmtp-transactions) in the xmtp-agent-examples repo.
 ::::
 
 ## Install the package

--- a/docs/pages/agents/deploy/debug-agents.mdx
+++ b/docs/pages/agents/deploy/debug-agents.mdx
@@ -24,7 +24,7 @@ Be sure to point xmtp.chat to the XMTP environment set in your agent's `.env` fi
 
 4. Try out the example agents using [xmtp.chat](https://xmtp.chat), the official web inbox for developers.
 
-   ![xmtp.chat DM screenshot](https://raw.githubusercontent.com/ephemeraHQ/xmtp-agent-examples/refs/heads/main/examples/xmtp-gm/screenshot.png)
+   ![xmtp.chat DM screenshot](https://raw.githubusercontent.com/xmtplabs/xmtp-agent-examples/refs/heads/main/examples/xmtp-gm/screenshot.png)
 
 ## Enable debug logging
 

--- a/docs/pages/agents/get-started/build-an-agent.mdx
+++ b/docs/pages/agents/get-started/build-an-agent.mdx
@@ -78,7 +78,7 @@ XMTP_ENV=dev # local, dev, production
 
 ## Vibe coding
 
-See these [Cursor rules](https://github.com/ephemeraHQ/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc) for vibe coding agents with XMTP using best practices.
+See these [Cursor rules](https://github.com/xmtplabs/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc) for vibe coding agents with XMTP using best practices.
 
 ```bash
 Prompt: lets create an example that gets a number and returns its 2x multiple (use claude max)
@@ -88,7 +88,7 @@ Prompt: lets create an example that gets a number and returns its 2x multiple (u
 
 Try out the example agents using [xmtp.chat](https://xmtp.chat), the official playground for agents.
 
-![xmtp.chat DM screenshot](https://github.com/ephemeraHQ/xmtp-agent-examples/raw/main/examples/xmtp-gm/screenshot.png)
+![xmtp.chat DM screenshot](https://github.com/xmtplabs/xmtp-agent-examples/raw/main/examples/xmtp-gm/screenshot.png)
 
 ## Debug an agent
 
@@ -100,4 +100,4 @@ To learn more, see [Deploy an agent](/agents/deploy/deploy-agent).
 
 ## Agent examples
 
-Visit the [examples](https://github.com/ephemeraHQ/xmtp-agent-examples) repository for more agent examples.
+Visit the [examples](https://github.com/xmtplabs/xmtp-agent-examples) repository for more agent examples.

--- a/docs/pages/chat-apps/content-types/transactions.mdx
+++ b/docs/pages/chat-apps/content-types/transactions.mdx
@@ -4,7 +4,7 @@ This package provides an XMTP content type to support sending transactions to a 
 
 Currently, this content type is supported in the Browser, Node, and React Native SDKs only.
 
-For an example of an agent that implements the transaction content type, see [xmtp-transactions](https://github.com/ephemeraHQ/xmtp-agent-examples/tree/main/examples/xmtp-transactions).
+For an example of an agent that implements the transaction content type, see [xmtp-transactions](https://github.com/xmtplabs/xmtp-agent-examples/tree/main/examples/xmtp-transactions).
 
 :::tip[Open for feedback]
 

--- a/docs/pages/chat-apps/debug-your-app.mdx
+++ b/docs/pages/chat-apps/debug-your-app.mdx
@@ -107,7 +107,7 @@ To use file logging, call the following static functions:
   - `readXMTPLogFile()`
   - `clearXMTPLogs()`
 
-For an example UI implementation, see PR to [add new persistent log debug menu options](https://github.com/ephemeraHQ/convos-app/pull/6) to the Convos app, built with XMTP.
+For an example UI implementation, see PR to [add new persistent log debug menu options](https://github.com/xmtplabs/convos-app/pull/6) to the Convos app, built with XMTP.
 
 ## Network statistics
 

--- a/docs/pages/chat-apps/intro/faq.mdx
+++ b/docs/pages/chat-apps/intro/faq.mdx
@@ -178,4 +178,4 @@ Ephemera employees work alongside other XMTP community members to build with and
 
 Ephemera focuses on serving developers. We build [SDKs](https://docs.xmtp.org/#start-building), developer tools, and example apps that help developers build great experiences with XMTP.
 
-Ephemera [acquired Converse](https://paragraph.xyz/@ephemera/converse) in June 2024. Converse is now [Convos](https://github.com/ephemeraHQ/convos-app), open-sourced for the entire XMTP network.
+Ephemera [acquired Converse](https://paragraph.xyz/@ephemera/converse) in June 2024. Converse is now [Convos](https://github.com/xmtplabs/convos-app), open-sourced for the entire XMTP network.

--- a/shared-sidebar.config.ts
+++ b/shared-sidebar.config.ts
@@ -147,7 +147,7 @@ export const sidebarConfig = {
     },
     {
       text: "Examples",
-      link: "https://github.com/ephemeraHQ/xmtp-agent-examples",
+      link: "https://github.com/xmtplabs/xmtp-agent-examples",
       items: [],
     },
     {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update documentation links to point GitHub URLs from ephemeraHQ to xmtplabs across agents and chat-apps docs and sidebar navigation
Replace ephemeraHQ GitHub org links with xmtplabs in agent and chat-app docs and in the sidebar "Examples" nav, including code example links and embedded image sources.

#### 📍Where to Start
Start with the sidebar update in [shared-sidebar.config.ts](https://github.com/xmtp/docs-xmtp-org/pull/490/files#diff-0e509f89309309d8f1f8e3c9fce55b0723f108444b3e29b0157de22be0252ab5), then spot-check one docs page such as [docs/pages/agents/get-started/build-an-agent.mdx](https://github.com/xmtp/docs-xmtp-org/pull/490/files#diff-111c939f0da17321fba00fd8aa3f1feb67089e9afafcad0a5fe4e3803dcda5e1) to verify link and image URL changes.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 975bef3.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->