### PR TITLE
Update forum name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can contribute by submitting:
   
 If you submit a pull request (PR), include a link to the bug report or feature request your PR addresses. If a documentation issue doesn't exist, please [open one](https://github.com/xmtp/docs-xmtp-org/issues) before you start contributing.
 
-Have a question about contributing? Post to the [XMTP Community Forums](https://community.xmtp.org/).
+Have a question about contributing? Post to the [XMTP Technical Forums](https://community.xmtp.org/).
 
 And lastly, when contributing, please follow the XMTP community code of conduct to help create a safe and positive experience for all.
 

--- a/docs/pages/chat-apps/core-messaging/create-a-client.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-client.mdx
@@ -528,7 +528,7 @@ For example, an XMTP identity on the `dev` network is completely distinct from t
 When you create a client, it connects to the XMTP `dev` network by default. Set your client's network environment using the appropriate [client option](#configure-an-xmtp-client).
 :::
 
-The `production` network is configured to store messages indefinitely. XMTP may occasionally delete messages and identities from the `dev` network, and will provide advance notice in the [XMTP Community Forums](https://community.xmtp.org/).
+The `production` network is configured to store messages indefinitely. XMTP may occasionally delete messages and identities from the `dev` network, and will provide advance notice in the [XMTP Technical Forums](https://community.xmtp.org/).
 
 You can use a `local` network environment to have a client communicate with an XMTP node you are running locally. During development, using `local` is a great option for speed and reliability. Use the [xmtp-local-node](https://github.com/xmtp/xmtp-local-node/tree/main) repo to easily run a local XMTP node.
 

--- a/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
@@ -113,7 +113,7 @@ Here is a list of supported chain IDs:
 - chain_rpc_59144 = string
 - chain_rpc_480 = string
 
-Need support for a different chain ID? Please post your request to the [XMTP Community Forums](https://community.xmtp.org/c/general/ideas/54).
+Need support for a different chain ID? Please post your request to the [XMTP Technical Forums](https://community.xmtp.org/c/general/ideas/54).
 
 The details of creating an SCW signer are highly dependent on the wallet provider and the library you're using to interact with it. Here are some general guidelines to consider:
 

--- a/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
+++ b/docs/pages/chat-apps/core-messaging/manage-inboxes.mdx
@@ -109,7 +109,7 @@ If you're developing or testing and frequently creating new installations, you c
 3. Use different wallets for testing: Create separate test wallets rather than repeatedly creating installations with the same wallet
 4. Monitor your usage: Regularly check your inbox state to track how many updates you've used
 
-Have feedback about the inbox update and installation limits? We'd love to hear it. Post to the [XMTP Community Forums](https://community.xmtp.org/).
+Have feedback about the inbox update and installation limits? We'd love to hear it. Post to the [XMTP Technical Forums](https://community.xmtp.org/).
 
 ### Rotate an inbox ID
 
@@ -630,4 +630,4 @@ If the identity is then added as an associated identity to inbox ID 1, the ident
 
 To enable the user of the identity with address 0xd0e4...DCe8 to log into inbox ID 2 again, you can use the recovery identity for inbox ID 2 to add a different identity to inbox ID 2 and have the user use that identity access it.
 
-If you are interested in providing this functionality in your app and want some guidance, post to the [XMTP Community Forums](https://community.xmtp.org).
+If you are interested in providing this functionality in your app and want some guidance, post to the [XMTP Technical Forums](https://community.xmtp.org).

--- a/docs/pages/chat-apps/intro/dev-support.mdx
+++ b/docs/pages/chat-apps/intro/dev-support.mdx
@@ -10,4 +10,4 @@ Please open an issue in the relevant repo:
 - [Android SDK](https://github.com/xmtp/xmtp-android/issues)
 - [iOS SDK](https://github.com/xmtp/xmtp-ios/issues)
 
-For all other topics, post to the [XMTP Community Forums](https://community.xmtp.org/).
+For all other topics, post to the [XMTP Technical Forums](https://community.xmtp.org/).

--- a/docs/pages/chat-apps/intro/faq.mdx
+++ b/docs/pages/chat-apps/intro/faq.mdx
@@ -101,7 +101,7 @@ XMTP core developers and researchers are working on a specific fee model for XMT
 - Infrastructure costs for the network must remain low even when decentralized, and comparable to the costs for an equivalent centralized messaging service.
 - There must be a low "take rate": the biggest driver of cost must be infrastructure costs, with any remaining cost returned to the network.
 
-Have questions or feedback about the fee model for XMTP? See [XIP-57: Messaging fee collection](https://community.xmtp.org/t/xip-57-messaging-fee-collection/876) in the XMTP Community Forums.
+Have questions or feedback about the fee model for XMTP? See [XIP-57: Messaging fee collection](https://community.xmtp.org/t/xip-57-messaging-fee-collection/876) in the XMTP Technical Forums.
 
 ## Security
 
@@ -164,7 +164,7 @@ For this reason, XMTP supports [remote attachments](/chat-apps/content-types/att
 
 Not currently. However, Ephemera is exploring ways to support message deletion and editing.
 
-Have ideas about message deletion and editing? Post to the [XMTP Community Forums](https://community.xmtp.org/c/development/ideas/54).
+Have ideas about message deletion and editing? Post to the [XMTP Technical Forums](https://community.xmtp.org/c/development/ideas/54).
 
 ### Is XMTP more like email or chat?
 

--- a/docs/pages/chat-apps/list-stream-sync/history-sync.mdx
+++ b/docs/pages/chat-apps/list-stream-sync/history-sync.mdx
@@ -2,7 +2,7 @@
 
 :::warning[This feature is in beta]
 
-History sync is still in active development as we work on its reliability and performance. To provide feedback on this feature, please post to [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Community Forums.
+History sync is still in active development as we work on its reliability and performance. To provide feedback on this feature, please post to [Ideas & Improvements](https://community.xmtp.org/c/general/ideas/54) in the XMTP Technical Forums.
 
 :::
 

--- a/docs/pages/privacy.md
+++ b/docs/pages/privacy.md
@@ -8,4 +8,4 @@ The site uses Plausible analytics for the sole purpose of helping site contribut
 
 To learn more about the data Plausible tracks, see the [Plausible Data Policy](https://plausible.io/data-policy).
 
-If you have any questions about this privacy policy, post to the [XMTP Community Forums](https://community.xmtp.org/).
+If you have any questions about this privacy policy, post to the [XMTP Technical Forums](https://community.xmtp.org/).

--- a/docs/pages/terms.md
+++ b/docs/pages/terms.md
@@ -16,7 +16,7 @@ This means that except as otherwise noted, page content is licensed under the [C
 
 When you see a page with this notice, you are free to use [nearly everything](#what-is-not-licensed) on the page in your own creations. For example, you could quote the text in a book, cut-and-paste sections to your blog, record it as an audiobook for the visually impaired, or even translate it into Swahili. Really. That's what open content licenses are all about. We just ask that you give us [attribution](#attribution) when you reuse our work.
 
-If you have any questions about these terms of service, post to the [XMTP Community Forums](https://community.xmtp.org/).
+If you have any questions about these terms of service, post to the [XMTP Technical Forums](https://community.xmtp.org/).
 
 ## What is _not_ licensed?
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update documentation references to use the name XMTP Technical Forums across README and docs pages
Rename the displayed forum link text from XMTP Community Forums to XMTP Technical Forums across README and multiple docs pages while keeping URLs unchanged.

#### 📍Where to Start
Start with the top-level change in [README.md](https://github.com/xmtp/docs-xmtp-org/pull/493/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to confirm the new forum name usage, then spot-check a representative docs page such as [docs/pages/chat-apps/intro/dev-support.mdx](https://github.com/xmtp/docs-xmtp-org/pull/493/files#diff-b4907c732f434ef44e895a3b2f5c2ddab4dad6d26e7429d046111f1a996d2cec).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0e68937.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->