### PR TITLE
Add Cursor rules to sidebar

### DIFF
--- a/shared-sidebar.config.ts
+++ b/shared-sidebar.config.ts
@@ -19,6 +19,10 @@ export const sidebarConfig = {
           text: "FAQ",
           link: "/agents/get-started/faq",
         },
+        {
+          text: "Cursor rules",
+          link: "https://github.com/xmtplabs/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc",
+        },
       ],
     },
     {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add a 'Cursor rules' external link to the '/agents/' → 'Get started' sidebar in `shared-sidebar.config.ts`
Update the `sidebarConfig` to include a 'Cursor rules' item under '/agents/' → 'Get started' that links to https://github.com/xmtplabs/xmtp-agent-examples/blob/main/.cursor/rules/xmtp.mdc.

#### 📍Where to Start
Start with the `sidebarConfig` object in [shared-sidebar.config.ts](https://github.com/xmtp/docs-xmtp-org/pull/505/files#diff-0e509f89309309d8f1f8e3c9fce55b0723f108444b3e29b0157de22be0252ab5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 1b13148.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->