### PR TITLE
Surface message fee info in FAQ

### DIFF
--- a/docs/pages/agents/get-started/faq.mdx
+++ b/docs/pages/agents/get-started/faq.mdx
@@ -96,6 +96,12 @@ Yes, messages are limited to just under 1MB. For larger content, use [remote att
 
 No messaging fees currently. Messages are stored off-chain on the XMTP network.
 
+Mainnet of the decentralized XMTP Network is expected to launch in early 2026. Specifically, Mainnet launch will occur 60 days after the release of an SDK version that meets production standards for performance and reliability on Testnet.
+
+With Mainnet launch, all message traffic will be automatically routed from the current production network to Mainnet. At this time, agents and apps will begin paying fees to send messages on Mainnet.
+
+To learn more, see [Get started with funding an agent to send messages with XMTP](/fund-agents-apps/get-started).
+
 ## Domains
 
 ### How do I register a domain for my agent?

--- a/shared-sidebar.config.ts
+++ b/shared-sidebar.config.ts
@@ -56,36 +56,6 @@ export const sidebarConfig = {
       ],
     },
     {
-      text: "Fund an agent",
-      collapsed: false,
-      items: [
-        {
-          text: "Get started",
-          link: "/fund-agents-apps/get-started",
-        },
-        {
-          text: "Calculate fees",
-          link: "/fund-agents-apps/calculate-fees",
-        },
-        {
-          text: "Fund an agent",
-          link: "/fund-agents-apps/fund-your-app",
-        },
-        {
-          text: "Get your XMTP Gateway Service",
-          link: "/fund-agents-apps/run-gateway",
-        },
-        {
-          text: "Update your SDK",
-          link: "/fund-agents-apps/update-sdk",
-        },
-        {
-          text: "Glossary",
-          link: "/fund-agents-apps/glossary",
-        },
-      ],
-    },
-    {
       text: "Core concepts",
       collapsed: false,
       items: [


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add FAQ entries about Mainnet launch timing and automatic message fee routing and remove the 'Fund an agent' sidebar section in [shared-sidebar.config.ts](https://github.com/xmtp/docs-xmtp-org/pull/506/files#diff-0e509f89309309d8f1f8e3c9fce55b0723f108444b3e29b0157de22be0252ab5) and [faq.mdx](https://github.com/xmtp/docs-xmtp-org/pull/506/files#diff-799be6d3da6d00ee972247a5e23e44664b2fd130e68e2af6c920f4e323b4ee2b)
Update the agents FAQ to include Mainnet timing, automatic routing to Mainnet with fees, and a link to funding guidance, and remove the 'Fund an agent' group from the /agents/ sidebar.

#### 📍Where to Start
Start with the FAQ updates in [faq.mdx](https://github.com/xmtp/docs-xmtp-org/pull/506/files#diff-799be6d3da6d00ee972247a5e23e44664b2fd130e68e2af6c920f4e323b4ee2b), then review sidebar changes in [shared-sidebar.config.ts](https://github.com/xmtp/docs-xmtp-org/pull/506/files#diff-0e509f89309309d8f1f8e3c9fce55b0723f108444b3e29b0157de22be0252ab5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 12b0f4d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->