### PR TITLE
Remove specific date from update SDK doc

### DIFF
--- a/docs/pages/fund-agents-apps/update-sdk.md
+++ b/docs/pages/fund-agents-apps/update-sdk.md
@@ -1,6 +1,6 @@
 # Update your app or agent to use an XMTP SDK with Gateway Service support
 
-Starting on November 15, 2025, you'll be able to update your app or agent to use an XMTP SDK version that supports XMTP Gateway Service helpers, enabling your app or agent to communicate with your XMTP Gateway Service.
+Once [Testnet- and Mainnet-compatible XMTP SDKs are delivered](/fund-agents-apps/get-started#key-milestones-and-actions), you can update your app or agent to a compatible SDK version that includes helpers that enable it to communicate with your XMTP Gateway Service.
 
 The minimum supported SDK version for each platform will be:
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove specific date from Update SDK doc and reference Testnet/Mainnet-compatible XMTP SDK milestones in [update-sdk.md](https://github.com/xmtp/docs-xmtp-org/pull/530/files#diff-85e77744ffb0a59a169ddc2e0a25aa670e0af095af20330ba7fce4eff59d0554)
Rewrite the opening sentence in [update-sdk.md](https://github.com/xmtp/docs-xmtp-org/pull/530/files#diff-85e77744ffb0a59a169ddc2e0a25aa670e0af095af20330ba7fce4eff59d0554) to drop a specific date and link to XMTP SDK Testnet/Mainnet milestones, noting that apps/agents should update to a compatible SDK version with Gateway Service helpers.

#### 📍Where to Start
Start with the opening paragraph of [update-sdk.md](https://github.com/xmtp/docs-xmtp-org/pull/530/files#diff-85e77744ffb0a59a169ddc2e0a25aa670e0af095af20330ba7fce4eff59d0554).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized d039235.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->