### PR TITLE
Provide more details about disappearing messages

### DIFF
--- a/docs/pages/chat-apps/core-messaging/disappearing-messages.mdx
+++ b/docs/pages/chat-apps/core-messaging/disappearing-messages.mdx
@@ -6,7 +6,7 @@ Disappearing messages are messages that are intended to be visible to users for 
 
 Disappearing message behavior is enforced by apps, meaning that apps are responsible for removing messages from their UIs and local storage based on conditions set at the conversation level. As a feature, disappearing messages doesn't delete messages from the XMTP network.
 
-Starting with XMTP mainnet, the network will enforce message expiration to delete messages from the network after a retention period currently targeted at 6 months. This message expiration is a general condition of the network and is not related to the disappearing messages feature.
+Starting with XMTP Mainnet, the network will enforce message expiration to delete messages from the network after a retention period currently targeted at 6 months. This message expiration is a general condition of the network and is not related to the disappearing messages feature.
 
 To learn more, see [Message expiry](https://community.xmtp.org/t/xip-49-decentralized-backend-for-mls-messages/856) in XIP-49: Decentralized backend for MLS messages.
 
@@ -18,12 +18,21 @@ Conversation participants using apps that support disappearing messages will hav
 
 Messages abide by the disappearing message settings for the conversation.
 
-When creating or updating a conversation, only group admins and DM participants can set disappearing message expiration conditions.
+### Permissions for setting disappearing message conditions
 
-This includes setting the following conditions expressed in nanoseconds (ns):
+Who can set or change disappearing message settings depends on the conversation type:
+
+- **Group chats**: Only group admins can set or change disappearing message settings
+- **DMs**: Both participants can set or change disappearing message settings
+
+### Disappearing message settings
+
+Disappearing message expiration conditions are expressed in nanoseconds (ns):
 
 - `disappearStartingAtNs`: Starting timestamp from which the message lifespan is calculated
+  - In protocol messages, this appears as `message_disappear_from_ns`
 - `retentionDurationInNs`: Duration of time during which the message should remain visible to conversation participants
+  - In protocol messages, this appears as `message_disappear_in_ns`
 
 For example:
 
@@ -31,11 +40,9 @@ For example:
 2. Set `retentionDurationInNs` to the message lifespan, such as 1800000000000000 (30 minutes).
 3. Use `disappearStartingAtNs` and `retentionDurationInNs` to calculate the message expiration time of `1738620126404999936 + 1800000000000000 = 1740420126404999936`.
 
-To learn more see [conversation.rs](https://github.com/xmtp/libxmtp/blob/main/bindings_node/src/conversation.rs#L49).
+To learn more, see [conversation.rs](https://github.com/xmtp/libxmtp/blob/main/bindings_node/src/conversation.rs#L49).
 
 ## Set disappearing message settings on conversation create
-
-For example:
 
 :::code-group
 
@@ -143,7 +150,10 @@ try await client.conversations.newGroup(
 
 ## Update disappearing message settings for an existing conversation
 
-For example:
+When you update disappearing message settings, the system changes each field separately under the hood. This means you'll receive two separate protocol messages when settings are updated:
+
+1. One message for `message_disappear_from_ns` (the `disappearStartingAtNs` field)
+2. One message for `message_disappear_in_ns` (the `retentionDurationInNs` field)
 
 :::code-group
 
@@ -187,8 +197,6 @@ try await conversation.clearDisappearingMessageSettings()
 :::
 
 ## Get the disappearing message settings for a conversation
-
-For example:
 
 :::code-group
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Document disappearing message permissions, nanosecond fields, and protocol mappings in [disappearing-messages.mdx](https://github.com/xmtp/docs-xmtp-org/pull/539/files#diff-7b20d874ae3412d4df509fce35bb58e18360247b1b1af8822e05fdaf432c5b81)
Update the disappearing messages doc to define group admin vs DM permissions, specify expiration fields in nanoseconds, map SDK fields `disappearStartingAtNs` and `retentionDurationInNs` to protocol fields `message_disappear_from_ns` and `message_disappear_in_ns`, note per-field update messages, and fix capitalization to XMTP Mainnet.

#### 📍Where to Start
Start with the new permissions and settings sections in [disappearing-messages.mdx](https://github.com/xmtp/docs-xmtp-org/pull/539/files#diff-7b20d874ae3412d4df509fce35bb58e18360247b1b1af8822e05fdaf432c5b81).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized d2b7c60.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->