### PR TITLE
Fix command formatting in fund-your-app.mdx

### DIFF
--- a/docs/pages/fund-agents-apps/fund-your-app.mdx
+++ b/docs/pages/fund-agents-apps/fund-your-app.mdx
@@ -206,7 +206,7 @@ To get mxUSD, you must self-mint it.
 
    ```bash
     docker run --rm ghcr.io/xmtp/xmtpd-cli:main \
-      funds mint --amount <1000> --to <receiving-address>
+      funds mint --amount <1000> --to <receiving-address> \
       --private-key <private-key> \
       --app-rpc-url https://xmtp-ropsten.g.alchemy.com/v2/<your-alchemy-api-key> \
       --settlement-rpc-url https://base-sepolia.g.alchemy.com/v2/<your-alchemy-api-key> \


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix docker command snippet in docs by adding a line-continuation backslash after `--to <receiving-address>` in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/547/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb)
Add a trailing `\` to the docker command so flags after `--to <receiving-address>` remain part of the same command in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/547/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb).

#### 📍Where to Start
Start with the docker command block in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/547/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 277a631.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->