### PR TITLE
Update mxUSD references to mUSD in documentation

### DIFF
--- a/docs/pages/fund-agents-apps/fund-your-app.mdx
+++ b/docs/pages/fund-agents-apps/fund-your-app.mdx
@@ -25,11 +25,11 @@ For example, you might self-fund your payer wallet if it already has or can easi
 
 At this time, you can access the testnet-staging deployment of the XMTP Funding Portal: [https://funding-portal-testnet-staging.vercel.app/](https://funding-portal-testnet-staging.vercel.app/).
 
-Use this testnet-staging deployment to test fund and withdrawal flows using a mock token called mxUSD (mock XMTP USD fee token).
+Use this testnet-staging deployment to test fund and withdrawal flows using a mock token called mUSD (mock USD fee token).
 
-To learn how to get mxUSD, see [Self-mint mxUSD](#for-use-with-testnet-staging-only-self-mint-mxusd).
+To learn how to get mUSD, see [Self-mint mUSD](#for-use-with-testnet-staging-only-self-mint-mUSD).
 
-Currently, mxUSD balances on testnet-staging are unaffected by usage.
+Currently, mUSD balances on testnet-staging are unaffected by usage.
 
 <Tabs.Root defaultValue="self-fund">
   <Tabs.List>
@@ -70,7 +70,7 @@ Your payer wallet is now a payer in the Payer Registry smart contract.
 
 :::tip[Using testnet-staging?]
 
-If you are using the testnet-staging deployment of the XMTP Funding Portal, you must use mxUSD, not USDC. To get mxUSD, you must self-mint it. To learn how, see [Self-mint mxUSD](#for-use-with-testnet-staging-only-self-mint-mxusd).
+If you are using the testnet-staging deployment of the XMTP Funding Portal, you must use mUSD, not USDC. To get mUSD, you must self-mint it. To learn how, see [Self-mint mUSD](#for-use-with-testnet-staging-only-self-mint-mUSD).
 
 :::
 
@@ -156,7 +156,7 @@ Your wallet can now fund the payer wallet.
 
 :::tip[Using testnet-staging?]
 
-If you are using the testnet-staging deployment of the XMTP Funding Portal, you must use mxUSD, not USDC. To get mxUSD, you must self-mint it. To learn how, see [Self-mint mxUSD](#for-use-with-testnet-staging-only-self-mint-mxusd).
+If you are using the testnet-staging deployment of the XMTP Funding Portal, you must use mUSD, not USDC. To get mUSD, you must self-mint it. To learn how, see [Self-mint mUSD](#for-use-with-testnet-staging-only-self-mint-mUSD).
 
 :::
 
@@ -192,17 +192,17 @@ The payer wallet now has:
 </Tabs.Content>
 </Tabs.Root>
 
-## For use with testnet-staging only: Self-mint mxUSD
+## For use with testnet-staging only: Self-mint mUSD
 
-To fund your app on the testnet-staging deployment of the [XMTP Funding Portal](#access-the-xmtp-funding-portal), you must use mxUSD (mock XMTP USD fee token) instead of USDC.
+To fund your app on the testnet-staging deployment of the [XMTP Funding Portal](#access-the-xmtp-funding-portal), you must use mUSD (mock XMTP USD fee token) instead of USDC.
 
-To get mxUSD, you must self-mint it.
+To get mUSD, you must self-mint it.
 
-### Self-mint mxUSD
+### Self-mint mUSD
 
 1. Start [Docker Desktop](https://docs.docker.com/desktop/).
 
-2. Use the `xmtpd-cli` Docker image with your relevant parameter values to self-mint mxUSD:
+2. Use the `xmtpd-cli` Docker image with your relevant parameter values to self-mint mUSD:
 
    ```bash
     docker run --rm ghcr.io/xmtp/xmtpd-cli:main \
@@ -215,9 +215,9 @@ To get mxUSD, you must self-mint it.
 
 Available parameters:
 
-- `--amount`: Amount of mxUSD to mint, in whole units. For example, `1000`.
+- `--amount`: Amount of mUSD to mint, in whole units. For example, `1000`.
 - `--to`: Receiving address (typically your payer wallet address)
-- `--private-key`: Private key of the address you want to use to pay the gas fee to mint the mxUSD
+- `--private-key`: Private key of the address you want to use to pay the gas fee to mint the mUSD
 - `--app-rpc-url`: Your Alchemy API endpoint for XMTP Ropsten
 - `--settlement-rpc-url`: Your Alchemy API endpoint for the Base Sepolia
 
@@ -230,22 +230,22 @@ INFO    funds-admin     tokens minted   {"settlement_chain_id": 84532, "app_chai
 INFO    successfully minted mock underlying fee token   {"to": "0x132455a4306D362d7D051B7c2f2c96d9021D6a1c", "amount": "1000000000"}
 ```
 
-Note that the amount in the output is shown in the smallest unit with 6 decimal places, so `1000000000` equals 1000 mxUSD.
+Note that the amount in the output is shown in the smallest unit with 6 decimal places, so `1000000000` equals 1000 mUSD.
 
-### Add mxUSD to MetaMask
+### Add mUSD to MetaMask
 
-After self-minting mxUSD, you'll need to add the token to MetaMask to view your balance:
+After self-minting mUSD, you'll need to add the token to MetaMask to view your balance:
 
 1. Open MetaMask and select the **Tokens** tab.
 2. Open the kebab menu and click **Import tokens**.
 3. Select the **Base Sepolia** network and enter these token details:
    - **Token contract address**: `0x2d7e0534183dAD09008C97f230d9F4f6425eE859`
-   - **Token symbol**: `mxUSD`
+   - **Token symbol**: `mUSD`
    - **Token decimal**: `6`
 4. Click **Next**.
 5. Click **Import** to confirm.
 
-Your mxUSD balance should now be visible in MetaMask.
+Your mUSD balance should now be visible in MetaMask.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Rename mxUSD to mUSD across the Fund Your App documentation page in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/556/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb)
Update headings, instructional text, anchor links, and MetaMask token symbol to use `mUSD` instead of `mxUSD` in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/556/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb).

#### 📍Where to Start
Start with the content changes in [fund-your-app.mdx](https://github.com/xmtp/docs-xmtp-org/pull/556/files#diff-972247ba429d45245eb4caa001ab657c464eaf9672b89901186d1d62e9a68ccb), focusing on the renamed anchors and link texts for `Self-mint mUSD`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a53e3fb.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->