### PR TITLE
Add another potential cause of error

### DIFF
--- a/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
@@ -292,3 +292,5 @@ This error occurs when there's a mismatch between the chain ID used when initial
 > inbox id for address {0} not found
 
 This typically happens when trying to create a DM with an address that hasn't been registered or associated with an XMTP inbox ID yet. You can only message wallet addresses that have been registered on the XMTP network. Registration occurs when a wallet is used with an XMTP-based chat app or one of our Client SDKs.
+
+This error may also occur if your client is connected to a different XMTP network environment than the target address. For example, your client might be using the dev network while the target address was registered on production.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add an explanatory note to the Create a signer docs page about the 'inbox id for address {0} not found' error cause when client and target run on different XMTP environments
Update [create-a-signer.mdx](https://github.com/xmtp/docs-xmtp-org/pull/581/files#diff-9f9193651a2a29d71a4e4b6d375fb06fd05e04cd364015510b6413d8a25b99d3) to document that this error can occur when the client is on dev and the target address is on production.

#### 📍Where to Start
Start with the content changes in [create-a-signer.mdx](https://github.com/xmtp/docs-xmtp-org/pull/581/files#diff-9f9193651a2a29d71a4e4b6d375fb06fd05e04cd364015510b6413d8a25b99d3).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e824ce8.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->