### PR TITLE
Remove docs on broadcast signatures

### DIFF
--- a/docs/pages/protocol/signatures.mdx
+++ b/docs/pages/protocol/signatures.mdx
@@ -79,17 +79,3 @@ If you decide to change the recovery address, a **Sign this message?** window di
 ```
 
 Sign with the wallet address you want to set as the recovery address to change the recovery address.
-
-## Sign to consent to receive broadcast messages
-
-When you click a **Subscribe** button built with XMTP's consent standards, you're prompted to sign an **XMTP : Grant inbox consent to sender** message.
-
-For example, here's the MetaMask **Signature request** window that displays when clicking the **Subscribe** button on this [example subscription page](https://subscribe-broadcast.vercel.app/subscribe/button) connected to the XMTP `dev` network. You typically see **Subscribe** buttons like this on a web page or in a dapp.
-
-![MetaMask wallet browser extension Signature request window showing an "XMTP: Grant inbox consent to sender" message](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/docs/pages/img/consent-proof-sign.png)
-
-When you click **Sign**, you're consenting to receive broadcast messages from the publisher at your connected wallet address. You can see the publisher's sending address in the **Signature request** window.
-
-When you provide consent, you're adding the publisher's address to your personal XMTP allowed contacts list. This enables messages from the publisher to be displayed in your main inbox instead of being treated as a message from an unknown sender and placed in a secondary view.
-
-To learn about XMTP's consent standards, see [Understand how user consent preferences support spam-free inboxes](/chat-apps/user-consent/user-consent).


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove the broadcast consent signature section from `docs/pages/protocol/signatures.mdx` to align documentation with current guidance
Delete the “Sign to consent to receive broadcast messages” section, including its heading, explanatory text, image, and external link in [signatures.mdx](https://github.com/xmtp/docs-xmtp-org/pull/603/files#diff-01cfaa4939aa908fd071f01f604cd4e0a46576faf63a38a58c0882332f58865e).

#### 📍Where to Start
Start with the removed section in [signatures.mdx](https://github.com/xmtp/docs-xmtp-org/pull/603/files#diff-01cfaa4939aa908fd071f01f604cd4e0a46576faf63a38a58c0882332f58865e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6d2843c.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->