### PR TITLE
Move inbox ID diagram

### DIFF
--- a/docs/pages/chat-apps/core-messaging/extend-id-model.md
+++ b/docs/pages/chat-apps/core-messaging/extend-id-model.md
@@ -4,8 +4,6 @@ XMTP is designed with a flexible identity model that can be extended over time w
 
 This document provides a general blueprint for how to extend XMTP to non-EVM platforms where identities are controlled by public keys, such as Solana, Bitcoin, Zcash, and others.
 
-![Many IDs to one XMTP inbox](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/many-ids-to-one-inbox.png)
-
 ### Why is extension needed for non-EVM chains?
 
 XMTP is designed to support EVM chains by default. EVMs all share the same address format and signature scheme.
@@ -25,7 +23,11 @@ For example, see the different address formats, signature schemes, signature sta
 
 ## XMTP inboxes and identity updates
 
-An XMTP inbox groups together many identities into a single address (XMTP inbox ID) that can be reached on the network. Those identities might be wallets, passkeys, app installations, or any other identifier. This identity model is what allows you to sign in to multiple XMTP apps across different devices and platforms and see the same conversations and messages. XMTP enables portability at its core.
+An XMTP inbox groups together many identities into a single address (XMTP inbox ID) that can be reached on the network. Those identities might be wallets, passkeys, app installations, or any other identifier. 
+
+![Many IDs to one XMTP inbox](https://raw.githubusercontent.com/xmtp/docs-xmtp-org/refs/heads/main/docs/pages/img/many-ids-to-one-inbox.png)
+
+This identity model is what allows you to sign in to multiple XMTP apps across different devices and platforms and see the same conversations and messages. XMTP enables portability at its core.
 
 Each XMTP inbox is constructed through a series of identity updates. Identity updates are special messages on the network that can add or remove identities from a given inbox. Anyone who wants to know "who is in this group chat with me?" or "how do I reach vitalik.eth?" will download all the *identity updates* for a given inbox, verify that each update has been correctly signed, and construct the state of that inbox by applying each valid update in order.
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Move the 'Many IDs to one XMTP inbox' diagram within [extend-id-model.md](https://github.com/xmtp/docs-xmtp-org/pull/607/files#diff-f620cb2a509712cb19ec85a4eb9679b95d4c7b356d2c7f3b6e760eaa348bfd82) to the 'XMTP inboxes and identity updates' section to improve inbox ID diagram placement
Repositions the diagram in [extend-id-model.md](https://github.com/xmtp/docs-xmtp-org/pull/607/files#diff-f620cb2a509712cb19ec85a4eb9679b95d4c7b356d2c7f3b6e760eaa348bfd82) and splits a paragraph to insert the image under the 'XMTP inboxes and identity updates' section.

#### 📍Where to Start
Start with the content changes in [extend-id-model.md](https://github.com/xmtp/docs-xmtp-org/pull/607/files#diff-f620cb2a509712cb19ec85a4eb9679b95d4c7b356d2c7f3b6e760eaa348bfd82), focusing on the 'XMTP inboxes and identity updates' section.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 1cf3ce8.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->