### PR TITLE
Update links in extend identity

### DIFF
--- a/docs/pages/chat-apps/core-messaging/extend-id-model.md
+++ b/docs/pages/chat-apps/core-messaging/extend-id-model.md
@@ -60,27 +60,6 @@ You'll need to:
 
 1. Define the new identifier kind in the [Rust identity module](https://github.com/xmtp/libxmtp/blob/main/crates/xmtp_id/src/associations/ident.rs) in the libxmtp repo.
 2. Add a new variant to the `MemberIdentifier` protobuf message. You can do this in [association.proto](https://github.com/xmtp/proto/blob/main/proto/identity/associations/association.proto). in the proto repo.
-3. Add a new entry to the `IdentifierKind` enum
-
-   ```proto
-   // The identifier for a member of an XID
-   message MemberIdentifier {
-     oneof kind {
-       string ethereum_address = 1;
-       bytes installation_public_key = 2;
-       Passkey passkey = 3;
-       // Add your new identifier type here
-     }
-   }
-
-   // List of identity kinds
-   enum IdentifierKind {
-     IDENTIFIER_KIND_UNSPECIFIED = 0;
-     IDENTIFIER_KIND_ETHEREUM = 1;
-     IDENTIFIER_KIND_PASSKEY = 2;
-     // Add your new identifier kind here
-   }
-   ```
 
 ### Implement signature verification
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update documentation links and instructions in [extend-id-model.md](https://github.com/xmtp/docs-xmtp-org/pull/610/files#diff-f620cb2a509712cb19ec85a4eb9679b95d4c7b356d2c7f3b6e760eaa348bfd82) to reflect new `crates/xmtp_id` paths and proto guidance
Update repository paths to `crates/xmtp_id`, revise guidance to reference `association.proto` in the proto repo, remove the step for adding `IdentifierKind`, and correct the `verified_signature.rs` path.

#### 📍Where to Start
Start with [extend-id-model.md](https://github.com/xmtp/docs-xmtp-org/pull/610/files#diff-f620cb2a509712cb19ec85a4eb9679b95d4c7b356d2c7f3b6e760eaa348bfd82) to review the updated links and instructions.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a83d45c.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->