### PR TITLE
clarify when to use opt group creation

### DIFF
--- a/docs/pages/chat-apps/core-messaging/create-conversations.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-conversations.mdx
@@ -147,9 +147,11 @@ let group = try await alix.conversations.newGroup([bo.inboxId, caro.inboxId],
 
 ## Optimistically create a new group chat
 
-Optimistic group creation enables instant group chat creation and message preparation before adding members and even when offline. This approach prioritizes user experience by allowing immediate interaction with the group chat, while handling the network synchronization in the background when members are added.
+Optimistic group creation enables instant group chat creation and message preparation before adding members and even when offline. 
 
-Use this method to optimistically create a group chat, which enables a user to create a group chat now and add members later.
+For example, use optimistic group creation when your user creates a new group without any members listed.
+
+This approach prioritizes user experience by allowing immediate interaction with the group chat, while handling the network synchronization in the background when members are added.
 
 The group chat can be created with any number of [standard options](#create-a-new-group-chat), or no options. The group chat is stored only in the local storage of the app installation used to create it. In other words, the group chat is visible only to the creator and in the app installation they used to create it.
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Clarify usage of optimistic group creation in chat app docs by revising the 'Optimistically create a new group chat' section in [create-conversations.mdx](https://github.com/xmtp/docs-xmtp-org/pull/615/files#diff-e50cdfffd5dab5bcebffe9b889f106de8d44f67d75dec62cdec00b7f41a58c49)
Updates the section introduction, adds an example for creating a group without members, and moves the user experience/synchronization note to a new paragraph in [create-conversations.mdx](https://github.com/xmtp/docs-xmtp-org/pull/615/files#diff-e50cdfffd5dab5bcebffe9b889f106de8d44f67d75dec62cdec00b7f41a58c49).

#### 📍Where to Start
Start with the 'Optimistically create a new group chat' section in [create-conversations.mdx](https://github.com/xmtp/docs-xmtp-org/pull/615/files#diff-e50cdfffd5dab5bcebffe9b889f106de8d44f67d75dec62cdec00b7f41a58c49).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 23c97d5.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->