### PR TITLE
Fixes

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -24,6 +24,7 @@
     "autoplay",
     "autorestart",
     "Bankr",
+    "Bech",
     "blobdecoded",
     "buildscript",
     "bufs",
@@ -88,6 +89,7 @@
     "reconnections",
     "retryable",
     "scammy",
+    "Solana",
     "spammy",
     "sqlcipher",
     "sqlitecipher",
@@ -100,6 +102,7 @@
     "typealias",
     "usernotifications",
     "viem",
+    "vitalik",
     "vocs",
     "wagmi",
     "xcaro",
@@ -115,6 +118,7 @@
     "yourdomain",
     "YOURFCMJSON",
     "YOURFCMPROJECTID",
+    "Zcash",
     "Zora"
   ]
 } 

--- a/docs/pages/chat-apps/core-messaging/delete-messages.mdx
+++ b/docs/pages/chat-apps/core-messaging/delete-messages.mdx
@@ -90,7 +90,7 @@ do {
 
 ## Stream message deletions
 
-Use `streamMessageDeletions` to listen for message deletion events in real-time across all conversations. This method is available on the `conversations` object.
+Listen for message deletion events in real-time across all conversations. This method is available on the `conversations` object.
 
 :::code-group
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix cspell dictionary in [cspell.config.json](https://github.com/xmtp/docs-xmtp-org/pull/633/files#diff-8c08d31ca450eac0c902634bbee0fd18630466fb1edaaffa6a489287b237f7d6) and revise deletion event wording in [docs/pages/chat-apps/core-messaging/delete-messages.mdx](https://github.com/xmtp/docs-xmtp-org/pull/633/files#diff-7372e63cc1abc7510e53ea65429f7be9624f15e15b9a391254cc34163241cd19)
Add "Bech", "Solana", "vitalik", and "Zcash" to the cspell dictionary and reword the delete messages doc to refer generically to listening for deletion events.

#### 📍Where to Start
Start with the dictionary updates in [cspell.config.json](https://github.com/xmtp/docs-xmtp-org/pull/633/files#diff-8c08d31ca450eac0c902634bbee0fd18630466fb1edaaffa6a489287b237f7d6), then review the wording change in [docs/pages/chat-apps/core-messaging/delete-messages.mdx](https://github.com/xmtp/docs-xmtp-org/pull/633/files#diff-7372e63cc1abc7510e53ea65429f7be9624f15e15b9a391254cc34163241cd19).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 82b5ef6.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->