### PR TITLE
Describe SignatureError.Invalid

### DIFF
--- a/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
+++ b/docs/pages/chat-apps/core-messaging/create-a-signer.mdx
@@ -309,6 +309,6 @@ This error may also occur if your client is connected to a different XMTP networ
 
 ### SignatureError.Invalid
 
-> Signature error Signature validation failed
+> Signature validation failed
 
 This error occurs when attempting to connect a Smart Contract Wallet (SCW) using an incorrect chain. For example, selecting "Ethereum" as the chain for an SCW that is deployed on "Base".


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Document `SignatureError.Invalid` in chat-apps core messaging signer guide to explain validation failure when connecting a Smart Contract Wallet on the wrong chain in [create-a-signer.mdx](https://github.com/xmtp/docs-xmtp-org/pull/647/files#diff-9f9193651a2a29d71a4e4b6d375fb06fd05e04cd364015510b6413d8a25b99d3)
Add a `SignatureError.Invalid` error section and fix an admonition fence formatting issue in [create-a-signer.mdx](https://github.com/xmtp/docs-xmtp-org/pull/647/files#diff-9f9193651a2a29d71a4e4b6d375fb06fd05e04cd364015510b6413d8a25b99d3).

#### 📍Where to Start
Start with the new `SignatureError.Invalid` section in [create-a-signer.mdx](https://github.com/xmtp/docs-xmtp-org/pull/647/files#diff-9f9193651a2a29d71a4e4b6d375fb06fd05e04cd364015510b6413d8a25b99d3).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized bd8f963.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->