### PR TITLE
Remove blog post reference from XMTP tutorial

### DIFF
--- a/docs/pages/agents/get-started/connect-to-xmtp.mdx
+++ b/docs/pages/agents/get-started/connect-to-xmtp.mdx
@@ -6,8 +6,6 @@ This tutorial walks you through connecting an agent to the XMTP network, step by
 
 The XMTP Agent SDK is not an agent framework. It doesn't make decisions, call APIs, or manage state. It provides the messaging rails: The ability to send and receive encrypted messages over XMTP. Your agent provides the brain. The SDK provides the rails.
 
-For more on the conceptual architecture behind this pattern, see [Building a Magic 8 Ball Bot with XMTP](TBD BLOG-POST).
-
 ## Prerequisites
 
 - **Node.js 22+** (required by the XMTP Agent SDK)


### PR DESCRIPTION
Removed reference to the blog post on building a Magic 8 Ball Bot with XMTP.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove placeholder blog post reference from XMTP tutorial introduction
> Removes a sentence linking to 'Building a Magic 8 Ball Bot with XMTP' (marked as TBD) from [connect-to-xmtp.mdx](https://github.com/xmtp/docs-xmtp-org/pull/734/files#diff-0819ef8103e28b1b3a8afb2e5b22b422e36c8d335b64b0bbd8ea5b80311b4171). The blog post was never published, so the reference was a dead placeholder.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfc427c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->